### PR TITLE
Integrate realtime analysis with 5min TDX data

### DIFF
--- a/app/api/realtime_analysis.py
+++ b/app/api/realtime_analysis.py
@@ -29,7 +29,7 @@ def sync_minute_data():
         ts_code = data.get('ts_code')
         start_date = data.get('start_date')
         end_date = data.get('end_date')
-        period_type = data.get('period_type', '1min')
+        period_type = data.get('period_type', '5min')
         use_baostock = data.get('use_baostock', True)
         data_source = data.get('data_source', 'tongdaxin')
         
@@ -65,7 +65,7 @@ def sync_multiple_stocks():
     try:
         data = request.get_json()
         stock_list = data.get('stock_list', [])
-        period_type = data.get('period_type', '1min')
+        period_type = data.get('period_type', '5min')
         start_date = data.get('start_date')
         end_date = data.get('end_date')
         batch_size = data.get('batch_size', 10)

--- a/app/api/realtime_indicators.py
+++ b/app/api/realtime_indicators.py
@@ -30,7 +30,7 @@ def calculate_indicators():
     try:
         data = request.get_json()
         ts_code = data.get('ts_code')
-        period_type = data.get('period_type', '1min')
+        period_type = data.get('period_type', '5min')
         indicators = data.get('indicators')  # 可选，None表示计算所有指标
         lookback_days = data.get('lookback_days', 30)
         
@@ -151,7 +151,7 @@ def get_latest_indicators():
     """获取最新指标数据"""
     try:
         ts_code = request.args.get('ts_code')
-        period_type = request.args.get('period_type', '1min')
+        period_type = request.args.get('period_type', '5min')
         indicator_names = request.args.getlist('indicators')
         limit = int(request.args.get('limit', 100))
         
@@ -187,7 +187,7 @@ def get_indicator_history():
     """获取指标历史数据"""
     try:
         ts_code = request.args.get('ts_code')
-        period_type = request.args.get('period_type', '1min')
+        period_type = request.args.get('period_type', '5min')
         indicator_name = request.args.get('indicator_name')
         start_time = request.args.get('start_time')
         end_time = request.args.get('end_time')
@@ -269,7 +269,7 @@ def batch_calculate_indicators():
     try:
         data = request.get_json()
         stock_codes = data.get('stock_codes', [])
-        period_type = data.get('period_type', '1min')
+        period_type = data.get('period_type', '5min')
         indicators = data.get('indicators')
         lookback_days = data.get('lookback_days', 7)
         
@@ -321,7 +321,7 @@ def compare_indicators():
     try:
         data = request.get_json()
         stock_codes = data.get('stock_codes', [])
-        period_type = data.get('period_type', '1min')
+        period_type = data.get('period_type', '5min')
         indicator_name = data.get('indicator_name')
         limit = data.get('limit', 50)
         

--- a/app/api/realtime_monitor.py
+++ b/app/api/realtime_monitor.py
@@ -35,7 +35,7 @@ def get_realtime_quotes():
     try:
         # 获取请求参数
         stock_codes_param = request.args.get('stock_codes')
-        period_type = request.args.get('period_type', '1min')
+        period_type = request.args.get('period_type', '5min')
         limit = int(request.args.get('limit', 50))
         
         # 解析股票代码列表
@@ -120,7 +120,7 @@ def add_to_watchlist():
         # 获取这些股票的实时行情
         result = monitor_service.get_realtime_quotes(
             stock_codes=stock_codes,
-            period_type='1min',
+            period_type='5min',
             limit=len(stock_codes)
         )
         
@@ -233,7 +233,7 @@ def get_top_movers():
     """获取涨跌幅排行"""
     try:
         limit = int(request.args.get('limit', 20))
-        period_type = request.args.get('period_type', '1min')
+        period_type = request.args.get('period_type', '5min')
         
         # 获取实时行情数据
         quotes_result = monitor_service.get_realtime_quotes(

--- a/app/api/realtime_signals.py
+++ b/app/api/realtime_signals.py
@@ -25,7 +25,7 @@ def generate_signals():
     try:
         data = request.get_json()
         ts_code = data.get('ts_code')
-        period_type = data.get('period_type', '1min')
+        period_type = data.get('period_type', '5min')
         strategies = data.get('strategies')  # 可选，None表示使用所有策略
         lookback_days = data.get('lookback_days', 5)
         
@@ -53,7 +53,7 @@ def fuse_signals():
     try:
         data = request.get_json()
         ts_code = data.get('ts_code')
-        period_type = data.get('period_type', '1min')
+        period_type = data.get('period_type', '5min')
         time_window_hours = data.get('time_window_hours', 1)
         
         if not ts_code:
@@ -204,7 +204,7 @@ def backtest_strategy():
         ts_code = data.get('ts_code')
         start_date = data.get('start_date')
         end_date = data.get('end_date')
-        period_type = data.get('period_type', '1min')
+        period_type = data.get('period_type', '5min')
         
         if not all([strategy_name, ts_code, start_date, end_date]):
             return jsonify({
@@ -234,7 +234,7 @@ def batch_generate_signals():
     try:
         data = request.get_json()
         stock_codes = data.get('stock_codes', [])
-        period_type = data.get('period_type', '1min')
+        period_type = data.get('period_type', '5min')
         strategies = data.get('strategies')
         lookback_days = data.get('lookback_days', 5)
         
@@ -356,7 +356,7 @@ def multi_stock_fusion():
     try:
         data = request.get_json()
         stock_codes = data.get('stock_codes', [])
-        period_type = data.get('period_type', '1min')
+        period_type = data.get('period_type', '5min')
         time_window_hours = data.get('time_window_hours', 1)
         
         if not stock_codes:

--- a/app/services/realtime_data_manager.py
+++ b/app/services/realtime_data_manager.py
@@ -60,7 +60,7 @@ class RealtimeDataManager:
         self.minute_store = MinuteParquetStore()
     
     def sync_minute_data(self, ts_code: str, start_date: str = None, end_date: str = None, 
-                        period_type: str = '1min', use_baostock: bool = True, data_source: str = 'tongdaxin') -> Dict:
+                        period_type: str = '5min', use_baostock: bool = True, data_source: str = 'tongdaxin') -> Dict:
         """
         同步分钟级数据
         
@@ -111,7 +111,7 @@ class RealtimeDataManager:
                 'data_count': 0
             }
     
-    def sync_multiple_stocks_data(self, stock_list: List[str], period_type: str = '1min',
+    def sync_multiple_stocks_data(self, stock_list: List[str], period_type: str = '5min',
                                  start_date: str = None, end_date: str = None,
                                  batch_size: int = 10, use_baostock: bool = True, data_source: str = 'tongdaxin') -> Dict:
         """

--- a/app/services/realtime_monitor_service.py
+++ b/app/services/realtime_monitor_service.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 class RealtimeMonitorService:
     """实时监控服务"""
+    DEFAULT_PERIOD_TYPE = "5min"
     
     def __init__(self):
         self.sector_mapping = self._initialize_sector_mapping()
@@ -58,7 +59,7 @@ class RealtimeMonitorService:
 
     def _minute_frame(
         self,
-        period_type: str = '1min',
+        period_type: str = DEFAULT_PERIOD_TYPE,
         start_time: Optional[datetime] = None,
         end_time: Optional[datetime] = None,
         ts_codes: Optional[List[str]] = None,
@@ -87,7 +88,7 @@ class RealtimeMonitorService:
         )
     
     def get_realtime_quotes(self, stock_codes: List[str] = None, 
-                           period_type: str = '1min', limit: int = 50) -> Dict:
+                           period_type: str = DEFAULT_PERIOD_TYPE, limit: int = 50) -> Dict:
         """获取实时行情数据"""
         try:
             # 如果没有指定股票代码，获取活跃股票
@@ -149,7 +150,7 @@ class RealtimeMonitorService:
         try:
             end_time = datetime.now()
             start_time = end_time - timedelta(hours=period_hours)
-            minute_df = self._minute_frame(period_type='1min', start_time=start_time, end_time=end_time)
+            minute_df = self._minute_frame(period_type=self.DEFAULT_PERIOD_TYPE, start_time=start_time, end_time=end_time)
             latest_rows = self._latest_rows(minute_df)
             
             sector_performance = []
@@ -166,7 +167,7 @@ class RealtimeMonitorService:
 
                     for _, latest_data in sector_rows.iterrows():
                         current_time = pd.to_datetime(latest_data["datetime"]).to_pydatetime()
-                        prev_close = self._get_previous_close(latest_data["ts_code"], current_time, '1min')
+                        prev_close = self._get_previous_close(latest_data["ts_code"], current_time, self.DEFAULT_PERIOD_TYPE)
                         if prev_close and prev_close > 0:
                             change_pct = (latest_data["close"] - prev_close) / prev_close * 100
                             sector_changes.append(change_pct)
@@ -224,7 +225,7 @@ class RealtimeMonitorService:
             end_time = datetime.now()
             start_time = end_time - timedelta(hours=period_hours)
             active_stocks = self._get_active_stocks(200)
-            minute_df = self._minute_frame(period_type='1min', start_time=start_time, end_time=end_time, ts_codes=active_stocks)
+            minute_df = self._minute_frame(period_type=self.DEFAULT_PERIOD_TYPE, start_time=start_time, end_time=end_time, ts_codes=active_stocks)
             latest_rows = self._latest_rows(minute_df)
             
             anomalies = []
@@ -233,12 +234,12 @@ class RealtimeMonitorService:
                 ts_code = latest_data["ts_code"]
                 try:
                     current_time = pd.to_datetime(latest_data["datetime"]).to_pydatetime()
-                    prev_close = self._get_previous_close(ts_code, current_time, '1min')
+                    prev_close = self._get_previous_close(ts_code, current_time, self.DEFAULT_PERIOD_TYPE)
                     if not prev_close or prev_close <= 0:
                         continue
 
                     change_pct = (latest_data["close"] - prev_close) / prev_close * 100
-                    volume_ratio = self._calculate_volume_ratio(ts_code, current_time, '1min')
+                    volume_ratio = self._calculate_volume_ratio(ts_code, current_time, self.DEFAULT_PERIOD_TYPE)
 
                     anomaly_types = []
                     if abs(change_pct) >= change_threshold:
@@ -289,7 +290,7 @@ class RealtimeMonitorService:
             end_time = datetime.now()
             start_time = end_time - timedelta(hours=period_hours)
             active_stocks = self._get_active_stocks(500)
-            minute_df = self._minute_frame(period_type='1min', start_time=start_time, end_time=end_time, ts_codes=active_stocks)
+            minute_df = self._minute_frame(period_type=self.DEFAULT_PERIOD_TYPE, start_time=start_time, end_time=end_time, ts_codes=active_stocks)
             latest_rows = self._latest_rows(minute_df)
             
             rising_stocks = 0
@@ -302,7 +303,7 @@ class RealtimeMonitorService:
             for _, latest_data in latest_rows.iterrows():
                 try:
                     current_time = pd.to_datetime(latest_data["datetime"]).to_pydatetime()
-                    prev_close = self._get_previous_close(latest_data["ts_code"], current_time, '1min')
+                    prev_close = self._get_previous_close(latest_data["ts_code"], current_time, self.DEFAULT_PERIOD_TYPE)
                     if not prev_close or prev_close <= 0:
                         continue
 
@@ -387,7 +388,7 @@ class RealtimeMonitorService:
     def get_monitor_overview(self) -> Dict:
         """获取监控概览"""
         try:
-            minute_df = self._minute_frame(period_type='1min')
+            minute_df = self._minute_frame(period_type=self.DEFAULT_PERIOD_TYPE)
             if minute_df.empty:
                 return {
                     'success': True,
@@ -431,7 +432,7 @@ class RealtimeMonitorService:
         """获取活跃股票列表"""
         try:
             recent_time = datetime.now() - timedelta(hours=1)
-            minute_df = self._minute_frame(period_type='1min', start_time=recent_time, end_time=datetime.now())
+            minute_df = self._minute_frame(period_type=self.DEFAULT_PERIOD_TYPE, start_time=recent_time, end_time=datetime.now())
             if minute_df.empty or "ts_code" not in minute_df.columns:
                 return ['000001.SZ', '000002.SZ', '600000.SH', '600036.SH', '000858.SZ']
             return minute_df["ts_code"].dropna().astype(str).drop_duplicates().head(limit).tolist()
@@ -511,7 +512,7 @@ class RealtimeMonitorService:
         try:
             latest_time = pd.to_datetime(latest_data["datetime"]).to_pydatetime()
             start_time = latest_time - timedelta(hours=20)
-            price_df = self._minute_frame(period_type='1min', start_time=start_time, end_time=latest_time, ts_codes=[ts_code])
+            price_df = self._minute_frame(period_type=self.DEFAULT_PERIOD_TYPE, start_time=start_time, end_time=latest_time, ts_codes=[ts_code])
 
             if price_df.empty:
                 return False

--- a/app/services/realtime_report_generator.py
+++ b/app/services/realtime_report_generator.py
@@ -212,11 +212,19 @@ class RealtimeReportGenerator:
         minute_data_count = int(len(minute_df))
         active_stocks = int(minute_df["ts_code"].dropna().astype(str).nunique()) if not minute_df.empty and "ts_code" in minute_df.columns else 0
         
-        # 获取技术指标数量与信号数量
-        indicator_stats = RealtimeIndicator.get_indicator_stats()
-        signal_stats = TradingSignal.get_signal_stats()
-        indicator_count = indicator_stats.get('total_records', 0)
-        signal_count = signal_stats.get('total_signals', 0)
+        # 获取当天 5min 技术指标数量与信号数量
+        day_start = datetime.combine(today, datetime.min.time())
+        day_end = datetime.combine(today, datetime.max.time())
+        indicator_count = RealtimeIndicator.query.filter(
+            RealtimeIndicator.datetime >= day_start,
+            RealtimeIndicator.datetime <= day_end,
+            RealtimeIndicator.period_type == '5min'
+        ).count()
+        signal_count = TradingSignal.query.filter(
+            TradingSignal.created_at >= day_start,
+            TradingSignal.created_at <= day_end,
+            TradingSignal.period_type == '5min'
+        ).count()
         
         return {
             'date': today.isoformat(),
@@ -383,8 +391,18 @@ class RealtimeReportGenerator:
         total_volume = sum(stock["total_volume"] or 0 for stock in active_stocks)
         avg_data_points = np.mean([stock["data_points"] for stock in active_stocks]) if active_stocks else 0
         
-        # 获取技术指标统计
-        indicator_stats = RealtimeIndicator.get_indicator_stats().get('indicator_stats', {})
+        # 获取当天 5min 技术指标统计
+        day_start = datetime.combine(today, datetime.min.time())
+        day_end = datetime.combine(today, datetime.max.time())
+        indicator_stats_query = db.session.query(
+            RealtimeIndicator.indicator_name,
+            db.func.count(RealtimeIndicator.id).label('count')
+        ).filter(
+            RealtimeIndicator.datetime >= day_start,
+            RealtimeIndicator.datetime <= day_end,
+            RealtimeIndicator.period_type == '5min'
+        ).group_by(RealtimeIndicator.indicator_name).all()
+        indicator_stats = {stat.indicator_name: stat.count for stat in indicator_stats_query}
         
         return {
             'market_overview': {

--- a/app/services/realtime_report_generator.py
+++ b/app/services/realtime_report_generator.py
@@ -17,6 +17,7 @@ from app.models.trading_signal import TradingSignal
 from app.models.portfolio_position import PortfolioPosition
 from app.models.risk_alert import RiskAlert
 from app.extensions import db
+from app.services.data_reader import ParquetDataReader
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +27,8 @@ class RealtimeReportGenerator:
     
     def __init__(self):
         """初始化报告生成器"""
+        self.data_reader = ParquetDataReader()
+        self.minute_reader = self.data_reader.get_minute_reader()
         self.report_types = {
             'daily_summary': '每日市场总结',
             'portfolio_analysis': '投资组合分析',
@@ -203,26 +206,17 @@ class RealtimeReportGenerator:
     def _collect_daily_summary_data(self) -> Dict[str, Any]:
         """收集每日总结数据"""
         today = datetime.now().date()
+
+        minute_df = self._load_minute_frame("5min", today, today)
+
+        minute_data_count = int(len(minute_df))
+        active_stocks = int(minute_df["ts_code"].dropna().astype(str).nunique()) if not minute_df.empty and "ts_code" in minute_df.columns else 0
         
-        # 获取今日分钟数据统计
-        minute_data_count = StockMinuteData.query.filter(
-            db.func.date(StockMinuteData.datetime) == today
-        ).count()
-        
-        # 获取活跃股票数量
-        active_stocks = db.session.query(StockMinuteData.ts_code).filter(
-            db.func.date(StockMinuteData.datetime) == today
-        ).distinct().count()
-        
-        # 获取技术指标数量
-        indicator_count = RealtimeIndicator.query.filter(
-            db.func.date(RealtimeIndicator.datetime) == today
-        ).count()
-        
-        # 获取交易信号数量
-        signal_count = TradingSignal.query.filter(
-            db.func.date(TradingSignal.created_at) == today
-        ).count()
+        # 获取技术指标数量与信号数量
+        indicator_stats = RealtimeIndicator.get_indicator_stats()
+        signal_stats = TradingSignal.get_signal_stats()
+        indicator_count = indicator_stats.get('total_records', 0)
+        signal_count = signal_stats.get('total_signals', 0)
         
         return {
             'date': today.isoformat(),
@@ -318,8 +312,11 @@ class RealtimeReportGenerator:
         """收集交易信号数据"""
         # 获取最近的交易信号
         recent_signals = TradingSignal.query.filter(
-            TradingSignal.created_at >= datetime.utcnow() - timedelta(days=7)
-        ).order_by(TradingSignal.created_at.desc()).limit(100).all()
+            TradingSignal.created_at >= datetime.utcnow() - timedelta(days=7),
+            TradingSignal.period_type == '5min'
+        ).all()
+        recent_signals.sort(key=lambda signal: signal.created_at or datetime.min, reverse=True)
+        recent_signals = recent_signals[:100]
         
         # 统计信号类型分布
         signal_types = {}
@@ -354,7 +351,8 @@ class RealtimeReportGenerator:
                 'total_signals': len(recent_signals),
                 'signal_types': signal_types,
                 'strategy_performance': strategy_performance,
-                'analysis_period': '最近7天'
+                'analysis_period': '最近7天',
+                'period_type': '5min'
             },
             'recent_signals': [signal.to_dict() for signal in recent_signals[:20]],  # 最近20个信号
             'analysis_date': datetime.utcnow().isoformat()
@@ -363,29 +361,30 @@ class RealtimeReportGenerator:
     def _collect_market_data(self) -> Dict[str, Any]:
         """收集市场数据"""
         today = datetime.now().date()
-        
-        # 获取今日活跃股票
-        active_stocks = db.session.query(
-            StockMinuteData.ts_code,
-            db.func.count(StockMinuteData.id).label('data_points'),
-            db.func.max(StockMinuteData.close).label('high'),
-            db.func.min(StockMinuteData.close).label('low'),
-            db.func.sum(StockMinuteData.volume).label('total_volume')
-        ).filter(
-            db.func.date(StockMinuteData.datetime) == today
-        ).group_by(StockMinuteData.ts_code).all()
-        
-        # 计算市场统计
-        total_volume = sum(stock.total_volume or 0 for stock in active_stocks)
-        avg_data_points = np.mean([stock.data_points for stock in active_stocks]) if active_stocks else 0
+        minute_df = self._load_minute_frame("5min", today, today)
+
+        if minute_df.empty:
+            active_stocks = []
+        else:
+            minute_df = minute_df.copy()
+            minute_df["datetime"] = pd.to_datetime(minute_df["datetime"], errors="coerce")
+            active_stocks = []
+            for ts_code, group in minute_df.groupby("ts_code"):
+                active_stocks.append(
+                    {
+                        "ts_code": ts_code,
+                        "data_points": int(len(group)),
+                        "high": float(group["close"].max()) if "close" in group.columns and not group["close"].empty else None,
+                        "low": float(group["close"].min()) if "close" in group.columns and not group["close"].empty else None,
+                        "total_volume": float(group["volume"].sum()) if "volume" in group.columns and not group["volume"].empty else 0,
+                    }
+                )
+
+        total_volume = sum(stock["total_volume"] or 0 for stock in active_stocks)
+        avg_data_points = np.mean([stock["data_points"] for stock in active_stocks]) if active_stocks else 0
         
         # 获取技术指标统计
-        indicator_stats = db.session.query(
-            RealtimeIndicator.indicator_type,
-            db.func.count(RealtimeIndicator.id).label('count')
-        ).filter(
-            db.func.date(RealtimeIndicator.datetime) == today
-        ).group_by(RealtimeIndicator.indicator_type).all()
+        indicator_stats = RealtimeIndicator.get_indicator_stats().get('indicator_stats', {})
         
         return {
             'market_overview': {
@@ -394,20 +393,15 @@ class RealtimeReportGenerator:
                 'avg_data_points': avg_data_points,
                 'analysis_date': today.isoformat()
             },
-            'stock_activity': [
-                {
-                    'ts_code': stock.ts_code,
-                    'data_points': stock.data_points,
-                    'high': stock.high,
-                    'low': stock.low,
-                    'total_volume': stock.total_volume
-                }
-                for stock in active_stocks[:20]  # 前20只活跃股票
-            ],
-            'indicator_distribution': {
-                stat.indicator_type: stat.count for stat in indicator_stats
-            }
+            'stock_activity': active_stocks[:20],
+            'indicator_distribution': indicator_stats
         }
+
+    def _load_minute_frame(self, period_type: str, start_date, end_date) -> pd.DataFrame:
+        """Load minute parquet data for a date range."""
+        start_dt = datetime.combine(start_date, datetime.min.time()) if hasattr(start_date, "year") else start_date
+        end_dt = datetime.combine(end_date, datetime.max.time()) if hasattr(end_date, "year") else end_date
+        return self.minute_reader.get_data(period_type=period_type, start_time=start_dt, end_time=end_dt)
     
     def _generate_report_content(self, report_type: str, template: Optional[ReportTemplate], 
                                report_data: Dict[str, Any]) -> Dict[str, Any]:

--- a/app/services/realtime_risk_manager.py
+++ b/app/services/realtime_risk_manager.py
@@ -338,7 +338,7 @@ class RealtimeRiskManager:
             for ts_code in stock_codes:
                 data = self.minute_reader.get_data(
                     ts_code=ts_code,
-                    period_type='60min',
+                    period_type='5min',
                     start_time=start_date,
                     end_time=end_date,
                 )
@@ -533,7 +533,7 @@ class RealtimeRiskManager:
     def _get_current_price(self, ts_code: str) -> Optional[float]:
         """获取当前价格"""
         try:
-            latest_data = self.minute_reader.get_latest_data(ts_code, '1min', 1)
+            latest_data = self.minute_reader.get_latest_data(ts_code, '5min', 1)
             if latest_data.empty:
                 return None
             return float(latest_data.iloc[0]['close'])

--- a/app/templates/realtime_analysis/monitor.html
+++ b/app/templates/realtime_analysis/monitor.html
@@ -276,7 +276,7 @@
         // 加载所有数据
         function loadAllData() {
             loadOverview();
-            loadQuotes('1min');
+            loadQuotes('5min');
             loadSectors(1);
             loadAnomalies(5.0, 3.0);
             loadSentiment(1);
@@ -340,7 +340,7 @@
         }
 
         // 加载实时行情
-        function loadQuotes(periodType = '1min') {
+        function loadQuotes(periodType = '5min') {
             const loading = document.getElementById('quotesLoading');
             loading.classList.remove('d-none');
 

--- a/tests/api/test_realtime_analysis_tongdaxin_contract.py
+++ b/tests/api/test_realtime_analysis_tongdaxin_contract.py
@@ -30,3 +30,21 @@ def test_sync_endpoint_passes_tongdaxin_data_source():
 
     assert response.status_code == 200
     assert manager.sync_minute_data.call_args.kwargs["data_source"] == "tongdaxin"
+
+
+def test_sync_endpoint_defaults_to_five_minute_period():
+    app = _build_app()
+    client = app.test_client()
+
+    with patch("app.api.realtime_analysis.data_manager") as manager:
+        manager.sync_minute_data.return_value = {"success": True, "message": "ok", "data_count": 1}
+        response = client.post(
+            "/api/realtime-analysis/data/sync",
+            json={
+                "ts_code": "sh.600000",
+                "data_source": "tongdaxin",
+            },
+        )
+
+    assert response.status_code == 200
+    assert manager.sync_minute_data.call_args.kwargs["period_type"] == "5min"

--- a/tests/api/test_realtime_report_contract.py
+++ b/tests/api/test_realtime_report_contract.py
@@ -1,0 +1,156 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from flask import Flask
+
+from app.api.realtime_report import realtime_report_bp
+from app.extensions import db
+
+
+def _build_app() -> Flask:
+    app = Flask(__name__)
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI="sqlite://",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        TESTING=True,
+    )
+    db.init_app(app)
+    app.register_blueprint(realtime_report_bp, url_prefix="/api/realtime-analysis/reports")
+    return app
+
+
+class _CountQuery:
+    def __init__(self, total, filtered_counts=None, filters=None):
+        self.total = total
+        self.filtered_counts = filtered_counts or {}
+        self.filters = filters or {}
+
+    def filter_by(self, **kwargs):
+        next_filters = dict(self.filters)
+        next_filters.update(kwargs)
+        return _CountQuery(self.total, self.filtered_counts, next_filters)
+
+    def count(self):
+        key = tuple(sorted(self.filters.items()))
+        return self.filtered_counts.get(key, self.total)
+
+
+class _ReportTypeGroupQuery:
+    def group_by(self, *args, **kwargs):
+        return self
+
+    def all(self):
+        return [
+            SimpleNamespace(report_type="daily_summary", count=2),
+            SimpleNamespace(report_type="market_overview", count=1),
+        ]
+
+
+class _FakeSession:
+    def query(self, *args, **kwargs):
+        return _ReportTypeGroupQuery()
+
+
+def test_reports_blueprint_is_registered_under_expected_prefix():
+    app = _build_app()
+    client = app.test_client()
+
+    response = client.get("/api/realtime-analysis/reports/report-types")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"] is True
+    assert "daily_summary" in data["data"]
+    assert "market_overview" in data["data"]
+
+
+def test_generate_report_forwards_payload_and_accepts_valid_types():
+    app = _build_app()
+    client = app.test_client()
+
+    payload = {
+        "report_type": "signal_analysis",
+        "template_id": 7,
+        "report_name": "Tongdaxin 5min Snapshot",
+        "parameters": {"period_type": "5min", "scope": "market"},
+        "generated_by": "ui",
+    }
+
+    with patch("app.api.realtime_report.report_generator.generate_report", return_value={"success": True, "data": {"report_id": 88}}) as generate_report:
+        response = client.post("/api/realtime-analysis/reports/generate-report", json=payload)
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"] is True
+    assert data["data"]["report_id"] == 88
+    assert generate_report.call_args.kwargs == payload
+
+
+def test_generate_report_rejects_invalid_report_type():
+    app = _build_app()
+    client = app.test_client()
+
+    response = client.post(
+        "/api/realtime-analysis/reports/generate-report",
+        json={"report_type": "not_supported"},
+    )
+
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data["success"] is False
+    assert "无效的报告类型" in data["message"]
+
+
+def test_report_metadata_endpoints_expose_stable_response_shape():
+    app = _build_app()
+    client = app.test_client()
+
+    report_query = _CountQuery(
+        total=5,
+        filtered_counts={
+            (("report_status", "completed"),): 4,
+            (("report_status", "failed"),): 1,
+        },
+    )
+    template_query = _CountQuery(
+        total=3,
+        filtered_counts={
+            (("is_active", True),): 2,
+        },
+    )
+    subscription_query = _CountQuery(
+        total=4,
+        filtered_counts={
+            (("is_active", True),): 3,
+        },
+    )
+
+    with app.app_context():
+        with (
+            patch("app.api.realtime_report.RealtimeReport.query", report_query),
+            patch("app.api.realtime_report.ReportTemplate.query", template_query),
+            patch("app.api.realtime_report.ReportSubscription.query", subscription_query),
+            patch("app.api.realtime_report.db.session", _FakeSession()),
+        ):
+            report_types = client.get("/api/realtime-analysis/reports/report-types")
+            schedule_types = client.get("/api/realtime-analysis/reports/schedule-types")
+            statistics = client.get("/api/realtime-analysis/reports/statistics")
+
+    assert report_types.status_code == 200
+    assert schedule_types.status_code == 200
+    assert statistics.status_code == 200
+
+    report_types_data = report_types.get_json()
+    schedule_types_data = schedule_types.get_json()
+    statistics_data = statistics.get_json()
+
+    assert report_types_data["success"] is True
+    assert "daily_summary" in report_types_data["data"]
+    assert schedule_types_data["success"] is True
+    assert "daily" in schedule_types_data["data"]
+    assert statistics_data["success"] is True
+    assert set(statistics_data["data"].keys()) == {"reports", "templates", "subscriptions", "report_type_stats"}
+    assert statistics_data["data"]["reports"]["total"] == 5
+    assert statistics_data["data"]["templates"]["active"] == 2
+    assert statistics_data["data"]["subscriptions"]["active"] == 3
+    assert statistics_data["data"]["report_type_stats"]["daily_summary"] == 2

--- a/tests/services/test_realtime_monitor_contract.py
+++ b/tests/services/test_realtime_monitor_contract.py
@@ -22,13 +22,13 @@ def _write_parquet_assets(tmp_path: Path):
         ]
     ).to_parquet(tmp_path / "stock_basic.parquet", index=False)
 
-    minute_dir = tmp_path / "stock_minute" / "1min" / "year=2026" / "month=06" / "day=04"
+    minute_dir = tmp_path / "stock_minute" / "5min" / "year=2026" / "month=06" / "day=04"
     minute_dir.mkdir(parents=True)
     pd.DataFrame(
         [
             {
                 "ts_code": "000001.SZ",
-                "period_type": "1min",
+                "period_type": "5min",
                 "datetime": FixedDateTime(2026, 6, 4, 9, 31),
                 "open": 10.0,
                 "high": 10.2,
@@ -39,7 +39,7 @@ def _write_parquet_assets(tmp_path: Path):
             },
             {
                 "ts_code": "000001.SZ",
-                "period_type": "1min",
+                "period_type": "5min",
                 "datetime": FixedDateTime(2026, 6, 4, 9, 59),
                 "open": 10.1,
                 "high": 10.4,
@@ -50,7 +50,7 @@ def _write_parquet_assets(tmp_path: Path):
             },
             {
                 "ts_code": "000002.SZ",
-                "period_type": "1min",
+                "period_type": "5min",
                 "datetime": FixedDateTime(2026, 6, 4, 9, 58),
                 "open": 20.0,
                 "high": 20.1,
@@ -80,3 +80,43 @@ def test_monitor_service_reads_quotes_and_overview_from_parquet(tmp_path, monkey
     assert overview["success"] is True
     assert overview["data"]["total_stocks"] == 2
     assert overview["data"]["active_stocks"] == 2
+
+
+def test_monitor_service_defaults_to_5min_for_quotes_and_overview(tmp_path, monkeypatch):
+    _write_parquet_assets(tmp_path)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    ParquetDataReader._stock_basic_cache = None
+
+    service = RealtimeMonitorService()
+    minute_frame_calls = []
+
+    def fake_minute_frame(*args, **kwargs):
+        minute_frame_calls.append(kwargs.get("period_type"))
+        return pd.DataFrame(
+            [
+                {
+                    "ts_code": "000001.SZ",
+                    "period_type": kwargs.get("period_type", "5min"),
+                    "datetime": FixedDateTime(2026, 6, 4, 9, 59),
+                    "open": 10.1,
+                    "high": 10.4,
+                    "low": 10.0,
+                    "close": 10.3,
+                    "volume": 1500,
+                    "amount": 15450.0,
+                }
+            ]
+        )
+
+    with patch.object(service, "_minute_frame", side_effect=fake_minute_frame), patch.object(
+        service, "_get_previous_close", return_value=10.0
+    ), patch.object(service, "_calculate_volume_ratio", return_value=1.0), patch.object(
+        service, "_calculate_turnover_rate", return_value=1.5
+    ), patch.object(service, "_get_stock_name", return_value="平安银行"):
+        quotes = service.get_realtime_quotes(stock_codes=["000001.SZ"], limit=10)
+        overview = service.get_monitor_overview()
+
+    assert quotes["success"] is True
+    assert overview["success"] is True
+    assert minute_frame_calls[0] == "5min"
+    assert "1min" not in minute_frame_calls

--- a/tests/services/test_realtime_report_generator.py
+++ b/tests/services/test_realtime_report_generator.py
@@ -1,0 +1,281 @@
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+
+from app.services.realtime_report_generator import RealtimeReportGenerator
+
+
+class FixedDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2026, 6, 5, 10, 0, 0)
+
+
+class _ComparableField:
+    def __init__(self, name):
+        self.name = name
+
+    def __ge__(self, other):
+        return ("ge", self.name, other)
+
+    def __eq__(self, other):
+        return ("eq", self.name, other)
+
+    def __le__(self, other):
+        return ("le", self.name, other)
+
+    def __lt__(self, other):
+        return ("lt", self.name, other)
+
+    def __gt__(self, other):
+        return ("gt", self.name, other)
+
+
+class _ReportQuery:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+        self.filters = []
+
+    def filter(self, *args, **kwargs):
+        self.filters.extend(args)
+        return self
+
+    def all(self):
+        return self.rows
+
+    def count(self):
+        return len(self.rows)
+
+
+class _FakeIndicatorModel:
+    id = _ComparableField("id")
+    datetime = _ComparableField("datetime")
+    period_type = _ComparableField("period_type")
+    indicator_name = _ComparableField("indicator_name")
+    query = _ReportQuery(rows=[object(), object()])
+
+
+class _FakeSignal:
+    created_at = _ComparableField("created_at")
+    period_type = _ComparableField("period_type")
+    signal_type = _ComparableField("signal_type")
+    strategy_name = _ComparableField("strategy_name")
+
+    def __init__(self, signal_type="BUY", strategy_name="trend_following", signal_strength=0.6):
+        self.signal_type = signal_type
+        self.strategy_name = strategy_name
+        self.signal_strength = signal_strength
+        self.created_at = FixedDateTime(2026, 6, 5, 9, 35)
+
+    def to_dict(self):
+        return {
+            "signal_type": self.signal_type,
+            "strategy_name": self.strategy_name,
+            "signal_strength": self.signal_strength,
+        }
+
+
+class _FakeSignalModel:
+    created_at = _ComparableField("created_at")
+    period_type = _ComparableField("period_type")
+    signal_type = _ComparableField("signal_type")
+    strategy_name = _ComparableField("strategy_name")
+    query = _ReportQuery(rows=[_FakeSignal(signal_type="BUY", strategy_name="trend_following", signal_strength=0.7)])
+
+    @staticmethod
+    def get_signal_stats():
+        return {"total_signals": 1}
+
+
+class _FakeStatsQuery:
+    def __init__(self, rows):
+        self.rows = rows
+        self.filters = []
+
+    def filter(self, *args, **kwargs):
+        self.filters.extend(args)
+        return self
+
+    def group_by(self, *args, **kwargs):
+        return self
+
+    def all(self):
+        return self.rows
+
+    def count(self):
+        return len(self.rows)
+
+
+class _FakeDBSession:
+    def __init__(self, indicator_rows):
+        self.indicator_rows = indicator_rows
+
+    def query(self, *args, **kwargs):
+        return _FakeStatsQuery(self.indicator_rows)
+
+
+def _write_minute_assets(tmp_path: Path):
+    minute_dir = tmp_path / "stock_minute" / "5min" / "year=2026" / "month=06" / "day=05"
+    minute_dir.mkdir(parents=True)
+    pd.DataFrame(
+        [
+            {
+                "ts_code": "000001.SZ",
+                "period_type": "5min",
+                "datetime": FixedDateTime(2026, 6, 5, 9, 35),
+                "open": 10.0,
+                "high": 10.2,
+                "low": 9.9,
+                "close": 10.1,
+                "volume": 1000,
+                "amount": 10100.0,
+            },
+            {
+                "ts_code": "000002.SZ",
+                "period_type": "5min",
+                "datetime": FixedDateTime(2026, 6, 5, 9, 35),
+                "open": 20.0,
+                "high": 20.2,
+                "low": 19.9,
+                "close": 20.1,
+                "volume": 2000,
+                "amount": 40200.0,
+            },
+        ]
+    ).to_parquet(minute_dir / "data.parquet", index=False)
+
+
+def test_daily_summary_and_market_overview_use_5min_parquet(tmp_path, monkeypatch):
+    _write_minute_assets(tmp_path)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+    generator = RealtimeReportGenerator()
+
+    indicator_rows = [type("Row", (), {"indicator_name": "RSI", "count": 3})(), type("Row", (), {"indicator_name": "MACD", "count": 2})()]
+    fake_indicator_model = type(
+        "FakeIndicatorModel",
+        (),
+        {
+            "id": _ComparableField("id"),
+            "datetime": _ComparableField("datetime"),
+            "period_type": _ComparableField("period_type"),
+            "indicator_name": _ComparableField("indicator_name"),
+            "query": _ReportQuery(rows=[object(), object()]),
+        },
+    )
+
+    with patch("app.services.realtime_report_generator.RealtimeIndicator", fake_indicator_model), patch(
+        "app.services.realtime_report_generator.TradingSignal", _FakeSignalModel
+    ), patch("app.services.realtime_report_generator.db.session", _FakeDBSession(indicator_rows)), patch(
+        "app.services.realtime_report_generator.datetime", FixedDateTime
+    ):
+        daily = generator._collect_daily_summary_data()
+        market = generator._collect_market_data()
+
+    assert daily["market_data"]["minute_data_points"] == 2
+    assert daily["market_data"]["active_stocks"] == 2
+    assert daily["market_data"]["technical_indicators"] == 2
+    assert daily["market_data"]["trading_signals"] == 1
+    assert market["market_overview"]["active_stocks"] == 2
+    assert market["market_overview"]["total_volume"] == 3000
+    assert market["indicator_distribution"] == {"RSI": 3, "MACD": 2}
+
+
+def test_signal_analysis_filters_by_five_minute_period(tmp_path, monkeypatch):
+    _write_minute_assets(tmp_path)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+    generator = RealtimeReportGenerator()
+    query = _ReportQuery(rows=[_FakeSignal(signal_type="BUY", strategy_name="trend_following", signal_strength=0.7)])
+
+    fake_signal_model = type(
+        "FakeSignalModel",
+        (),
+        {
+            "created_at": _ComparableField("created_at"),
+            "period_type": _ComparableField("period_type"),
+            "signal_type": _ComparableField("signal_type"),
+            "strategy_name": _ComparableField("strategy_name"),
+            "query": query,
+        },
+    )
+
+    with patch("app.services.realtime_report_generator.TradingSignal", fake_signal_model), patch(
+        "app.services.realtime_report_generator.datetime", FixedDateTime
+    ):
+        signal_data = generator._collect_signal_data()
+
+    assert query.filters, "expected report generator to query trading signals"
+    assert any(
+        isinstance(item, tuple) and item[:3] == ("eq", "period_type", "5min") for item in query.filters
+    ), query.filters
+    assert signal_data["signal_summary"]["total_signals"] == 1
+
+
+def test_generate_report_keeps_market_overview_payload_shape(tmp_path, monkeypatch):
+    _write_minute_assets(tmp_path)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+    generator = RealtimeReportGenerator()
+
+    with patch.object(generator, "_get_or_create_template", return_value=None), patch.object(
+        generator,
+        "_collect_report_data",
+        return_value={"market_overview": {"active_stocks": 2, "total_volume": 3000, "avg_data_points": 1.0}},
+    ), patch.object(generator, "_generate_report_content", return_value={"sections": []}), patch(
+        "app.services.realtime_report_generator.RealtimeReport.create_report"
+    ) as create_report:
+        report = create_report.return_value
+        report.id = 1
+        report.report_name = "mock"
+        report.report_type = "market_overview"
+        report.update_status.return_value = None
+
+        result = generator.generate_report("market_overview", parameters={})
+
+    assert result["success"] is True
+    assert "content" in result["data"]
+    assert "data" in result["data"]
+
+
+def test_daily_summary_and_market_overview_count_today_five_minute_data_only(tmp_path, monkeypatch):
+    _write_minute_assets(tmp_path)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+    generator = RealtimeReportGenerator()
+    indicator_rows = [type("Row", (), {"indicator_name": "RSI", "count": 2})()]
+
+    fake_indicator_model = type(
+        "FakeIndicatorModel",
+        (),
+        {
+            "id": _ComparableField("id"),
+            "datetime": _ComparableField("datetime"),
+            "period_type": _ComparableField("period_type"),
+            "indicator_name": _ComparableField("indicator_name"),
+            "query": _ReportQuery(rows=[object(), object()]),
+        },
+    )
+    fake_signal_model = type(
+        "FakeSignalModel",
+        (),
+        {
+            "created_at": _ComparableField("created_at"),
+            "period_type": _ComparableField("period_type"),
+            "query": _ReportQuery(rows=[_FakeSignal(signal_type="BUY", strategy_name="trend_following", signal_strength=0.7)]),
+        },
+    )
+
+    with patch("app.services.realtime_report_generator.RealtimeIndicator", fake_indicator_model), patch(
+        "app.services.realtime_report_generator.TradingSignal", fake_signal_model
+    ), patch("app.services.realtime_report_generator.db.session", _FakeDBSession(indicator_rows)), patch(
+        "app.services.realtime_report_generator.datetime", FixedDateTime
+    ):
+        daily = generator._collect_daily_summary_data()
+        market = generator._collect_market_data()
+
+    assert daily["market_data"]["technical_indicators"] == 2
+    assert daily["market_data"]["trading_signals"] == 1
+    assert market["indicator_distribution"] == {"RSI": 2}

--- a/tests/services/test_realtime_risk_contract.py
+++ b/tests/services/test_realtime_risk_contract.py
@@ -6,13 +6,13 @@ from app.services.realtime_risk_manager import RealtimeRiskManager
 
 
 def _write_minute_assets(tmp_path: Path):
-    minute_dir = tmp_path / "stock_minute" / "60min" / "year=2026" / "month=06" / "day=04"
+    minute_dir = tmp_path / "stock_minute" / "5min" / "year=2026" / "month=06" / "day=04"
     minute_dir.mkdir(parents=True)
     pd.DataFrame(
         [
             {
                 "ts_code": "000001.SZ",
-                "period_type": "60min",
+                "period_type": "5min",
                 "datetime": "2026-06-04T10:00:00",
                 "open": 10.0,
                 "high": 10.2,
@@ -23,7 +23,7 @@ def _write_minute_assets(tmp_path: Path):
             },
             {
                 "ts_code": "000001.SZ",
-                "period_type": "60min",
+                "period_type": "5min",
                 "datetime": "2026-06-04T11:00:00",
                 "open": 10.1,
                 "high": 10.4,
@@ -32,16 +32,9 @@ def _write_minute_assets(tmp_path: Path):
                 "volume": 1500,
                 "amount": 15450.0,
             },
-        ]
-    ).to_parquet(minute_dir / "data.parquet", index=False)
-
-    current_dir = tmp_path / "stock_minute" / "1min" / "year=2026" / "month=06" / "day=04"
-    current_dir.mkdir(parents=True)
-    pd.DataFrame(
-        [
             {
                 "ts_code": "000001.SZ",
-                "period_type": "1min",
+                "period_type": "5min",
                 "datetime": "2026-06-04T11:30:00",
                 "open": 10.3,
                 "high": 10.5,
@@ -49,9 +42,9 @@ def _write_minute_assets(tmp_path: Path):
                 "close": 10.4,
                 "volume": 1800,
                 "amount": 18720.0,
-            }
+            },
         ]
-    ).to_parquet(current_dir / "data.parquet", index=False)
+    ).to_parquet(minute_dir / "data.parquet", index=False)
 
 
 def test_risk_manager_reads_current_and_history_prices_from_parquet(tmp_path, monkeypatch):
@@ -66,3 +59,23 @@ def test_risk_manager_reads_current_and_history_prices_from_parquet(tmp_path, mo
     assert not price_data.empty
     assert "000001.SZ" in price_data.columns
     assert current_price == 10.4
+
+
+def test_risk_manager_defaults_current_price_lookup_to_5min(tmp_path, monkeypatch):
+    _write_minute_assets(tmp_path)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+    manager = RealtimeRiskManager()
+
+    with monkeypatch.context() as m:
+        calls = []
+
+        def fake_get_latest_data(ts_code, period_type="1min", limit=1):
+            calls.append(period_type)
+            return pd.DataFrame([{"close": 10.4}])
+
+        m.setattr(manager.minute_reader, "get_latest_data", fake_get_latest_data)
+        current_price = manager._get_current_price("000001.SZ")
+
+    assert current_price == 10.4
+    assert calls == ["5min"]


### PR DESCRIPTION
## Summary
- Switch realtime analysis indicator, signal, monitor, risk, and report flows to the Tongdaxin 5min data path
- Align report generation with parquet-backed 5min minute data and lock the public report API contract
- Update monitor defaults and add/adjust regression coverage for the 5min workflow

## Test Plan
- [x] pytest tests/api/test_realtime_report_contract.py tests/api/test_realtime_analysis_5min_contract.py tests/services/test_realtime_report_generator.py tests/services/test_realtime_monitor_contract.py tests/services/test_realtime_risk_contract.py -q
