### PR TITLE
feat: SQLite + Parquet migration — remove MySQL runtime dependency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,15 +5,6 @@ SECRET_KEY=change-this-secret
 # SQLite ORM default
 SQLITE_DATABASE_PATH=./instance/stock_cursor.sqlite3
 
-# Legacy MySQL compatibility (optional)
-# Set MYSQL_COMPAT_ENABLED=true only if you intentionally need the legacy connector
-DB_HOST=localhost
-DB_USER=root
-DB_PASSWORD=root
-DB_NAME=stock_cursor
-DB_CHARSET=utf8mb4
-MYSQL_COMPAT_ENABLED=false
-
 # Redis / Celery
 REDIS_HOST=localhost
 REDIS_PORT=6379
@@ -29,4 +20,7 @@ TUSHARE_TOKEN=your_tushare_token
 DATA_JOB_EXECUTION_MODE=inline
 
 # OpenAI / LLM optional
-OPENAI_API_KEY=
+LLM_PROVIDER=openai
+LLM_API_KEY=
+LLM_BASE_URL=https://api.deepseek.com
+LLM_MODEL=deepseek-v4-flash

--- a/.env.example
+++ b/.env.example
@@ -2,13 +2,17 @@
 DEBUG=True
 SECRET_KEY=change-this-secret
 
+# SQLite ORM default
+SQLITE_DATABASE_PATH=./instance/stock_cursor.sqlite3
+
 # Legacy MySQL compatibility (optional)
+# Set MYSQL_COMPAT_ENABLED=true only if you intentionally need the legacy connector
 DB_HOST=localhost
 DB_USER=root
 DB_PASSWORD=root
 DB_NAME=stock_cursor
 DB_CHARSET=utf8mb4
-MYSQL_COMPAT_ENABLED=true
+MYSQL_COMPAT_ENABLED=false
 
 # Redis / Celery
 REDIS_HOST=localhost

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,11 @@ This is a **Flask + SQLAlchemy + SocketIO** quantitative stock analysis system (
 ### Request Flow
 
 ```
-HTTP → Blueprint (app/api/*.py) → Service (app/services/*.py) → ParquetDataReader / SQLAlchemy models (MySQL-compatible app state)
+HTTP → Blueprint (app/api/*.py) → Service (app/services/*.py) → ParquetDataReader / SQLAlchemy models (SQLite app state)
 WebSocket → app/websocket/websocket_events.py → app/services/websocket_push_service.py
 ```
+
+Do not treat MySQL as a normal runtime dependency. SQLite is the default ORM store and Parquet is the default market-data store.
 
 HTML page routes live in `app/routes/` (separate from API blueprints).
 
@@ -74,7 +76,7 @@ Controlled by `DATA_JOB_EXECUTION_MODE` env var:
 
 All config in `config.py` via env vars (`.env` file). Key vars:
 - `DATA_SOURCE` — defaults to `parquet`
-- `DB_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_NAME` — MySQL-compatible application state settings (default db: `stock_cursor`)
+- `SQLALCHEMY_DATABASE_URI` — defaults to SQLite (`stock_cursor.sqlite3`)
 - `REDIS_HOST`, `REDIS_PORT` — Redis for Celery and caching
 - `FLASK_ENV` — `development` or `production`
 - `DATA_JOB_EXECUTION_MODE` — `inline` or `celery`

--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@
 - **前端**: Bootstrap 5 / JavaScript
 - **市场数据源**: Parquet 文件为主，市场数据统一落在 `data/`
 - **ML 因子状态层**: Parquet 文件，状态数据统一落在 `data/ml_factor_state/`
-- **应用状态层**: 部分遗留模块仍使用 MySQL-compatible 数据库
+- **应用状态层**: 低并发状态与元数据统一使用 SQLite
 
 ## 🚀 快速开始
 
 ### 1. 环境要求
 - Python 3.8+
-- 如需使用遗留模块或 ORM 状态层，仍需 MySQL 5.7 或 8.x；纯 parquet 主链路可不依赖 MySQL
+- 运行系统不需要 MySQL；默认使用 SQLite + Parquet
 
 ### 2. 安装依赖
 ```bash
@@ -97,7 +97,7 @@ cp .env.example .env
 docker compose up --build
 ```
 
-默认会同时启动 Web、MySQL 和 Redis；其中市场数据和 ml-factor 状态仍以本地 parquet 文件为准。
+默认会同时启动 Web、SQLite 和 Redis；其中市场数据和 ml-factor 状态仍以本地 parquet 文件为准。
 
 ### 3. 启动系统
 ```bash

--- a/app/api/realtime_indicators.py
+++ b/app/api/realtime_indicators.py
@@ -5,6 +5,7 @@
 
 from flask import Blueprint, request, jsonify
 from datetime import datetime, timedelta
+import os
 import logging
 import json
 import numpy as np
@@ -20,8 +21,23 @@ logger = logging.getLogger(__name__)
 # 创建蓝图
 realtime_indicators_bp = Blueprint('realtime_indicators', __name__)
 
-# 初始化指标引擎
-indicator_engine = RealtimeIndicatorEngine()
+indicator_engine = None
+_indicator_engine_data_dir = None
+
+
+def get_indicator_engine():
+    global indicator_engine, _indicator_engine_data_dir
+    current_data_dir = os.getenv("DATA_DIR")
+
+    if indicator_engine is None:
+        indicator_engine = RealtimeIndicatorEngine()
+        _indicator_engine_data_dir = current_data_dir
+        return indicator_engine
+
+    if _indicator_engine_data_dir != current_data_dir:
+        indicator_engine = RealtimeIndicatorEngine()
+        _indicator_engine_data_dir = current_data_dir
+    return indicator_engine
 
 
 @realtime_indicators_bp.route('/calculate', methods=['POST'])
@@ -38,7 +54,7 @@ def calculate_indicators():
             return jsonify({'success': False, 'message': '股票代码不能为空'})
         
         # 计算指标
-        result = indicator_engine.calculate_indicators(
+        result = get_indicator_engine().calculate_indicators(
             ts_code=ts_code,
             period_type=period_type,
             indicators=indicators,
@@ -133,7 +149,7 @@ def calculate_multi_period():
             return jsonify({'success': False, 'message': '股票代码不能为空'})
         
         # 计算多周期指标
-        result = indicator_engine.calculate_multi_period_indicators(
+        result = get_indicator_engine().calculate_multi_period_indicators(
             ts_code=ts_code,
             indicators=indicators,
             periods=periods

--- a/app/api/realtime_indicators.py
+++ b/app/api/realtime_indicators.py
@@ -327,8 +327,9 @@ def compare_indicators():
         
         if not stock_codes or not indicator_name:
             return jsonify({'success': False, 'message': '股票代码列表和指标名称不能为空'})
-        
+
         results = {}
+        empty_stock_codes = []
         
         for ts_code in stock_codes:
             try:
@@ -339,18 +340,36 @@ def compare_indicators():
                     limit=limit
                 )
                 
-                results[ts_code] = [indicator.to_dict() for indicator in indicators]
+                serialized = sorted(
+                    [indicator.to_dict() for indicator in indicators],
+                    key=lambda item: item.get('datetime') or ''
+                )
+                results[ts_code] = serialized
+                if not serialized:
+                    empty_stock_codes.append(ts_code)
                 
             except Exception as e:
                 logger.error(f"获取 {ts_code} 指标数据失败: {str(e)}")
                 results[ts_code] = []
-        
+                empty_stock_codes.append(ts_code)
+
+        empty_state = None
+        if empty_stock_codes:
+            empty_state = {
+                'has_data': False,
+                'message': '未找到可用于对比的指标数据',
+                'empty_stock_codes': empty_stock_codes,
+                'indicator_name': indicator_name,
+                'period_type': period_type,
+            }
+
         return jsonify({
             'success': True,
             'data': results,
             'indicator_name': indicator_name,
             'period_type': period_type,
-            'stock_codes': stock_codes
+            'stock_codes': stock_codes,
+            'empty_state': empty_state
         })
         
     except Exception as e:

--- a/app/api/realtime_report.py
+++ b/app/api/realtime_report.py
@@ -4,13 +4,11 @@
 """
 
 from flask import Blueprint, request, jsonify
-from datetime import datetime
 import logging
 
 from app.services.realtime_report_generator import RealtimeReportGenerator
 from app.services.report_dispatch_service import ReportDispatchService
 from app.models.realtime_report import ReportTemplate, RealtimeReport, ReportSubscription
-from app.extensions import db
 
 logger = logging.getLogger(__name__)
 
@@ -90,13 +88,12 @@ def get_report_by_id(report_id):
 def delete_report(report_id):
     """删除报告"""
     try:
-        report = RealtimeReport.query.get(report_id)
+        report = RealtimeReport.get_by_id(report_id)
         
         if not report:
             return jsonify({'success': False, 'message': '报告不存在'}), 404
         
-        db.session.delete(report)
-        db.session.commit()
+        RealtimeReport.delete_report_by_id(report_id)
         
         return jsonify({
             'success': True,
@@ -159,7 +156,7 @@ def create_report_template():
 def get_template_by_id(template_id):
     """根据ID获取模板"""
     try:
-        template = ReportTemplate.query.get(template_id)
+        template = ReportTemplate.get_by_id(template_id)
         
         if not template:
             return jsonify({'success': False, 'message': '模板不存在'}), 404
@@ -179,32 +176,25 @@ def get_template_by_id(template_id):
 def update_report_template(template_id):
     """更新报告模板"""
     try:
-        template = ReportTemplate.query.get(template_id)
+        template = ReportTemplate.get_by_id(template_id)
         
         if not template:
             return jsonify({'success': False, 'message': '模板不存在'}), 404
         
         data = request.get_json()
-        
-        # 更新模板字段
-        if 'template_name' in data:
-            template.template_name = data['template_name']
-        if 'description' in data:
-            template.description = data['description']
-        if 'components' in data:
-            import json
-            template.components = json.dumps(data['components'])
-        if 'is_active' in data:
-            template.is_active = data['is_active']
-        if 'is_default' in data:
-            template.is_default = data['is_default']
-        
-        template.updated_at = datetime.utcnow()
-        db.session.commit()
+        updated_template = ReportTemplate.update_template_by_id(
+            template_id,
+            template_name=data.get('template_name', template.template_name),
+            template_type=data.get('template_type', template.template_type),
+            description=data.get('description', template.description),
+            components=data.get('components', template.to_dict().get('components', [])),
+            is_active=data.get('is_active', template.is_active),
+            is_default=data.get('is_default', template.is_default),
+        )
         
         return jsonify({
             'success': True,
-            'data': template.to_dict(),
+            'data': updated_template.to_dict(),
             'message': '模板更新成功'
         })
         
@@ -217,21 +207,20 @@ def update_report_template(template_id):
 def delete_report_template(template_id):
     """删除报告模板"""
     try:
-        template = ReportTemplate.query.get(template_id)
+        template = ReportTemplate.get_by_id(template_id)
         
         if not template:
             return jsonify({'success': False, 'message': '模板不存在'}), 404
         
         # 检查是否有关联的报告
-        report_count = RealtimeReport.query.filter_by(template_id=template_id).count()
+        report_count = RealtimeReport.count_reports_by_template(template_id)
         if report_count > 0:
             return jsonify({
                 'success': False,
                 'message': f'模板被 {report_count} 个报告使用，无法删除'
             }), 400
         
-        db.session.delete(template)
-        db.session.commit()
+        ReportTemplate.delete_template_by_id(template_id)
         
         return jsonify({
             'success': True,
@@ -247,9 +236,7 @@ def delete_report_template(template_id):
 def get_subscriptions():
     """获取订阅列表"""
     try:
-        subscriptions = ReportSubscription.query.order_by(
-            ReportSubscription.created_at.desc()
-        ).all()
+        subscriptions = ReportSubscription.list_subscriptions()
         
         return jsonify({
             'success': True,
@@ -284,7 +271,7 @@ def create_subscription():
             }), 400
         
         # 验证模板是否存在
-        template = ReportTemplate.query.get(template_id)
+        template = ReportTemplate.get_by_id(template_id)
         if not template:
             return jsonify({
                 'success': False,
@@ -318,7 +305,7 @@ def create_subscription():
 def get_subscription_by_id(subscription_id):
     """根据ID获取订阅"""
     try:
-        subscription = ReportSubscription.query.get(subscription_id)
+        subscription = ReportSubscription.get_by_id(subscription_id)
         
         if not subscription:
             return jsonify({'success': False, 'message': '订阅不存在'}), 404
@@ -338,37 +325,26 @@ def get_subscription_by_id(subscription_id):
 def update_subscription(subscription_id):
     """更新订阅"""
     try:
-        subscription = ReportSubscription.query.get(subscription_id)
+        subscription = ReportSubscription.get_by_id(subscription_id)
         
         if not subscription:
             return jsonify({'success': False, 'message': '订阅不存在'}), 404
         
         data = request.get_json()
-        
-        # 更新订阅字段
-        if 'subscription_name' in data:
-            subscription.subscription_name = data['subscription_name']
-        if 'subscriber_email' in data:
-            subscription.subscriber_email = data['subscriber_email']
-        if 'subscriber_phone' in data:
-            subscription.subscriber_phone = data['subscriber_phone']
-        if 'schedule_type' in data:
-            subscription.schedule_type = data['schedule_type']
-        if 'schedule_config' in data:
-            import json
-            subscription.schedule_config = json.dumps(data['schedule_config'])
-        if 'notification_channels' in data:
-            import json
-            subscription.notification_channels = json.dumps(data['notification_channels'])
-        if 'is_active' in data:
-            subscription.is_active = data['is_active']
-        
-        subscription.updated_at = datetime.utcnow()
-        db.session.commit()
+        updated_subscription = ReportSubscription.update_subscription_by_id(
+            subscription_id,
+            subscription_name=data.get('subscription_name', subscription.subscription_name),
+            subscriber_email=data.get('subscriber_email', subscription.subscriber_email),
+            subscriber_phone=data.get('subscriber_phone', subscription.subscriber_phone),
+            schedule_type=data.get('schedule_type', subscription.schedule_type),
+            schedule_config=data.get('schedule_config', subscription.schedule_config),
+            notification_channels=data.get('notification_channels', subscription.notification_channels),
+            is_active=data.get('is_active', subscription.is_active),
+        )
         
         return jsonify({
             'success': True,
-            'data': subscription.to_dict(),
+            'data': updated_subscription.to_dict(),
             'message': '订阅更新成功'
         })
         
@@ -381,13 +357,12 @@ def update_subscription(subscription_id):
 def delete_subscription(subscription_id):
     """删除订阅"""
     try:
-        subscription = ReportSubscription.query.get(subscription_id)
+        subscription = ReportSubscription.get_by_id(subscription_id)
         
         if not subscription:
             return jsonify({'success': False, 'message': '订阅不存在'}), 404
         
-        db.session.delete(subscription)
-        db.session.commit()
+        ReportSubscription.delete_subscription_by_id(subscription_id)
         
         return jsonify({
             'success': True,
@@ -461,24 +436,20 @@ def get_report_statistics():
     """获取报告统计信息"""
     try:
         # 统计报告数量
-        total_reports = RealtimeReport.query.count()
-        completed_reports = RealtimeReport.query.filter_by(report_status='completed').count()
-        failed_reports = RealtimeReport.query.filter_by(report_status='failed').count()
+        total_reports = RealtimeReport.count_reports()
+        completed_reports = RealtimeReport.count_reports(status='completed')
+        failed_reports = RealtimeReport.count_reports(status='failed')
         
         # 统计模板数量
-        total_templates = ReportTemplate.query.count()
-        active_templates = ReportTemplate.query.filter_by(is_active=True).count()
+        total_templates = ReportTemplate.count_templates()
+        active_templates = ReportTemplate.count_templates(active_only=True)
         
         # 统计订阅数量
-        total_subscriptions = ReportSubscription.query.count()
-        active_subscriptions = ReportSubscription.query.filter_by(is_active=True).count()
+        total_subscriptions = ReportSubscription.count_subscriptions()
+        active_subscriptions = ReportSubscription.count_subscriptions(active_only=True)
         
         # 按类型统计报告
-        from sqlalchemy import func
-        report_type_stats = db.session.query(
-            RealtimeReport.report_type,
-            func.count(RealtimeReport.id).label('count')
-        ).group_by(RealtimeReport.report_type).all()
+        report_type_stats = RealtimeReport.get_report_type_stats()
         
         return jsonify({
             'success': True,
@@ -497,9 +468,7 @@ def get_report_statistics():
                     'total': total_subscriptions,
                     'active': active_subscriptions
                 },
-                'report_type_stats': {
-                    stat.report_type: stat.count for stat in report_type_stats
-                }
+                'report_type_stats': report_type_stats
             },
             'message': '统计信息获取成功'
         })

--- a/app/api/realtime_risk.py
+++ b/app/api/realtime_risk.py
@@ -10,7 +10,6 @@ import logging
 from app.services.realtime_risk_manager import RealtimeRiskManager
 from app.models.portfolio_position import PortfolioPosition
 from app.models.risk_alert import RiskAlert
-from app.extensions import db
 
 logger = logging.getLogger(__name__)
 
@@ -142,12 +141,10 @@ def create_risk_alert():
 def resolve_risk_alert(alert_id):
     """解决风险预警"""
     try:
-        alert = RiskAlert.query.get(alert_id)
+        alert = RiskAlert.resolve_by_id(alert_id)
         
         if not alert:
             return jsonify({'success': False, 'message': '预警记录不存在'})
-        
-        alert.resolve_alert()
         
         return jsonify({
             'success': True,
@@ -180,7 +177,7 @@ def create_portfolio_position():
             return jsonify({'success': False, 'message': '该股票持仓已存在'})
         
         # 创建持仓
-        position = PortfolioPosition(
+        position = PortfolioPosition.create_position(
             portfolio_id=portfolio_id,
             ts_code=ts_code,
             position_size=position_size,
@@ -189,10 +186,7 @@ def create_portfolio_position():
             market_value=position_size * avg_cost,
             sector=sector
         )
-        
-        db.session.add(position)
-        db.session.commit()
-        
+
         return jsonify({
             'success': True,
             'data': position.to_dict(),
@@ -253,34 +247,19 @@ def update_portfolio_position(portfolio_id, position_id):
     try:
         data = request.get_json()
         
-        position = PortfolioPosition.query.filter_by(
-            id=position_id,
-            portfolio_id=portfolio_id
-        ).first()
+        position = PortfolioPosition.update_position_by_id(
+            portfolio_id,
+            position_id,
+            position_size=float(data['position_size']) if 'position_size' in data else None,
+            avg_cost=float(data['avg_cost']) if 'avg_cost' in data else None,
+            current_price=float(data['current_price']) if 'current_price' in data else None,
+            sector=data.get('sector'),
+            stop_loss_price=float(data['stop_loss_price']) if 'stop_loss_price' in data else None,
+            take_profit_price=float(data['take_profit_price']) if 'take_profit_price' in data else None,
+        )
         
         if not position:
             return jsonify({'success': False, 'message': '持仓记录不存在'})
-        
-        # 更新字段
-        if 'position_size' in data:
-            position.position_size = float(data['position_size'])
-        if 'avg_cost' in data:
-            position.avg_cost = float(data['avg_cost'])
-        if 'current_price' in data:
-            position.current_price = float(data['current_price'])
-        if 'sector' in data:
-            position.sector = data['sector']
-        if 'stop_loss_price' in data:
-            position.stop_loss_price = float(data['stop_loss_price'])
-        if 'take_profit_price' in data:
-            position.take_profit_price = float(data['take_profit_price'])
-        
-        # 重新计算市值和盈亏
-        if position.current_price:
-            position.market_value = position.position_size * position.current_price
-            position.unrealized_pnl = (position.current_price - position.avg_cost) * position.position_size
-        
-        db.session.commit()
         
         return jsonify({
             'success': True,
@@ -297,17 +276,8 @@ def update_portfolio_position(portfolio_id, position_id):
 def delete_portfolio_position(portfolio_id, position_id):
     """删除投资组合持仓"""
     try:
-        position = PortfolioPosition.query.filter_by(
-            id=position_id,
-            portfolio_id=portfolio_id
-        ).first()
-        
-        if not position:
+        if not PortfolioPosition.delete_position_by_id(portfolio_id, position_id):
             return jsonify({'success': False, 'message': '持仓记录不存在'})
-        
-        # 软删除
-        position.is_active = False
-        db.session.commit()
         
         return jsonify({
             'success': True,

--- a/app/api/realtime_signals.py
+++ b/app/api/realtime_signals.py
@@ -15,8 +15,19 @@ logger = logging.getLogger(__name__)
 # 创建蓝图
 realtime_signals_bp = Blueprint('realtime_signals', __name__)
 
-# 初始化信号引擎
-signal_engine = RealtimeTradingSignalEngine()
+signal_engine = None
+_signal_engine_data_dir = None
+
+
+def get_signal_engine():
+    global signal_engine, _signal_engine_data_dir
+    current_data_dir = __import__("os").getenv("DATA_DIR")
+    if signal_engine is not None:
+        return signal_engine
+    if _signal_engine_data_dir != current_data_dir:
+        signal_engine = RealtimeTradingSignalEngine()
+        _signal_engine_data_dir = current_data_dir
+    return signal_engine
 
 
 @realtime_signals_bp.route('/generate', methods=['POST'])
@@ -33,7 +44,7 @@ def generate_signals():
             return jsonify({'success': False, 'message': '股票代码不能为空'})
         
         # 生成信号
-        result = signal_engine.generate_signals(
+        result = get_signal_engine().generate_signals(
             ts_code=ts_code,
             period_type=period_type,
             strategies=strategies,
@@ -60,7 +71,7 @@ def fuse_signals():
             return jsonify({'success': False, 'message': '股票代码不能为空'})
         
         # 融合信号
-        result = signal_engine.fuse_signals(
+        result = get_signal_engine().fuse_signals(
             ts_code=ts_code,
             period_type=period_type,
             time_window_hours=time_window_hours
@@ -182,7 +193,7 @@ def get_signal_performance():
 def get_supported_strategies():
     """获取支持的策略列表"""
     try:
-        strategies = signal_engine.get_supported_strategies()
+        strategies = get_signal_engine().get_supported_strategies()
         
         return jsonify({
             'success': True,
@@ -248,7 +259,7 @@ def batch_generate_signals():
         
         for ts_code in stock_codes:
             try:
-                result = signal_engine.generate_signals(
+                result = get_signal_engine().generate_signals(
                     ts_code=ts_code,
                     period_type=period_type,
                     strategies=strategies,
@@ -366,7 +377,7 @@ def multi_stock_fusion():
         
         for ts_code in stock_codes:
             try:
-                result = signal_engine.fuse_signals(
+                result = get_signal_engine().fuse_signals(
                     ts_code=ts_code,
                     period_type=period_type,
                     time_window_hours=time_window_hours

--- a/app/api/text2sql_api.py
+++ b/app/api/text2sql_api.py
@@ -7,7 +7,6 @@ import logging
 from flask import Blueprint, request, jsonify, render_template
 from app.services.text2sql_engine import get_text2sql_engine
 from app.models.text2sql_metadata import QueryHistory, QueryTemplate, BusinessDictionary
-from app.extensions import db
 
 # 创建蓝图
 text2sql_bp = Blueprint('text2sql', __name__, url_prefix='/api/text2sql')
@@ -115,7 +114,7 @@ def get_query_history():
 def get_query_templates():
     """获取查询模板"""
     try:
-        templates = QueryTemplate.query.filter_by(is_active=True).all()
+        templates = QueryTemplate.list_active()
         
         template_list = []
         for template in templates:
@@ -154,12 +153,11 @@ def create_query_template():
                 return jsonify({'error': f'缺少必要字段: {field}'}), 400
         
         # 检查模板ID是否已存在
-        existing_template = QueryTemplate.query.get(data['template_id'])
+        existing_template = QueryTemplate.get_by_id(data['template_id'])
         if existing_template:
             return jsonify({'error': '模板ID已存在'}), 400
         
-        # 创建新模板
-        template = QueryTemplate(
+        template = QueryTemplate.create_template(
             template_id=data['template_id'],
             template_name=data['template_name'],
             intent_pattern=data.get('intent_pattern'),
@@ -168,9 +166,6 @@ def create_query_template():
             is_active=data.get('is_active', True)
         )
         
-        db.session.add(template)
-        db.session.commit()
-        
         return jsonify({
             'success': True,
             'message': '模板创建成功',
@@ -178,7 +173,6 @@ def create_query_template():
         })
         
     except Exception as e:
-        db.session.rollback()
         logger.error(f"创建查询模板失败: {e}")
         return jsonify({'error': str(e)}), 500
 
@@ -187,7 +181,7 @@ def create_query_template():
 def update_query_template(template_id):
     """更新查询模板"""
     try:
-        template = QueryTemplate.query.get(template_id)
+        template = QueryTemplate.get_by_id(template_id)
         if not template:
             return jsonify({'error': '模板不存在'}), 404
         
@@ -195,19 +189,14 @@ def update_query_template(template_id):
         if not data:
             return jsonify({'error': '请求数据为空'}), 400
         
-        # 更新模板字段
-        if 'template_name' in data:
-            template.template_name = data['template_name']
-        if 'intent_pattern' in data:
-            template.intent_pattern = data['intent_pattern']
-        if 'sql_template' in data:
-            template.sql_template = data['sql_template']
-        if 'parameters' in data:
-            template.parameters = data['parameters']
-        if 'is_active' in data:
-            template.is_active = data['is_active']
-        
-        db.session.commit()
+        template = QueryTemplate.update_template_by_id(
+            template_id,
+            template_name=data.get('template_name', template.template_name),
+            intent_pattern=data.get('intent_pattern', template.intent_pattern),
+            sql_template=data.get('sql_template', template.sql_template),
+            parameters=data.get('parameters', template.parameters),
+            is_active=data.get('is_active', template.is_active),
+        )
         
         return jsonify({
             'success': True,
@@ -216,7 +205,6 @@ def update_query_template(template_id):
         })
         
     except Exception as e:
-        db.session.rollback()
         logger.error(f"更新查询模板失败: {e}")
         return jsonify({'error': str(e)}), 500
 
@@ -225,13 +213,10 @@ def update_query_template(template_id):
 def delete_query_template(template_id):
     """删除查询模板"""
     try:
-        template = QueryTemplate.query.get(template_id)
-        if not template:
+        if not QueryTemplate.get_by_id(template_id):
             return jsonify({'error': '模板不存在'}), 404
-        
-        # 软删除：设置为非激活状态
-        template.is_active = False
-        db.session.commit()
+
+        QueryTemplate.delete_template_by_id(template_id)
         
         return jsonify({
             'success': True,
@@ -239,7 +224,6 @@ def delete_query_template(template_id):
         })
         
     except Exception as e:
-        db.session.rollback()
         logger.error(f"删除查询模板失败: {e}")
         return jsonify({'error': str(e)}), 500
 
@@ -250,11 +234,7 @@ def get_business_dictionary():
     try:
         category = request.args.get('category')
         
-        query = BusinessDictionary.query.filter_by(is_active=True)
-        if category:
-            query = query.filter_by(category=category)
-        
-        dictionaries = query.all()
+        dictionaries = BusinessDictionary.list_active(category=category)
         
         dict_list = []
         for dictionary in dictionaries:
@@ -285,8 +265,7 @@ def create_business_dictionary():
             if not data.get(field):
                 return jsonify({'error': f'缺少必要字段: {field}'}), 400
         
-        # 创建新词典条目
-        dictionary = BusinessDictionary(
+        dictionary = BusinessDictionary.create_dictionary(
             category=data['category'],
             standard_term=data['standard_term'],
             synonyms=data.get('synonyms', []),
@@ -296,9 +275,6 @@ def create_business_dictionary():
             is_active=data.get('is_active', True)
         )
         
-        db.session.add(dictionary)
-        db.session.commit()
-        
         return jsonify({
             'success': True,
             'message': '词典条目创建成功',
@@ -306,7 +282,6 @@ def create_business_dictionary():
         })
         
     except Exception as e:
-        db.session.rollback()
         logger.error(f"创建业务词典失败: {e}")
         return jsonify({'error': str(e)}), 500
 
@@ -316,38 +291,22 @@ def get_query_statistics():
     """获取查询统计信息"""
     try:
         # 总查询次数
-        total_queries = QueryHistory.query.count()
+        total_queries = QueryHistory.count_total()
         
         # 成功查询次数
-        successful_queries = QueryHistory.query.filter_by(is_successful=True).count()
+        successful_queries = QueryHistory.count_successful()
         
         # 成功率
         success_rate = (successful_queries / total_queries * 100) if total_queries > 0 else 0
         
         # 平均执行时间
-        avg_execution_time = db.session.query(
-            db.func.avg(QueryHistory.execution_time)
-        ).filter_by(is_successful=True).scalar() or 0
+        avg_execution_time = QueryHistory.get_average_execution_time()
         
         # 最常用的意图
-        intent_stats = db.session.query(
-            QueryHistory.intent,
-            db.func.count(QueryHistory.intent).label('count')
-        ).filter(
-            QueryHistory.intent.isnot(None)
-        ).group_by(QueryHistory.intent).order_by(
-            db.func.count(QueryHistory.intent).desc()
-        ).limit(5).all()
+        intent_stats = QueryHistory.get_top_intents()
         
         # 最常用的模板
-        template_stats = db.session.query(
-            QueryHistory.template_used,
-            db.func.count(QueryHistory.template_used).label('count')
-        ).filter(
-            QueryHistory.template_used.isnot(None)
-        ).group_by(QueryHistory.template_used).order_by(
-            db.func.count(QueryHistory.template_used).desc()
-        ).limit(5).all()
+        template_stats = QueryHistory.get_top_templates()
         
         return jsonify({
             'success': True,

--- a/app/models/data_job_cursor.py
+++ b/app/models/data_job_cursor.py
@@ -8,7 +8,7 @@ class DataJobCursor(db.Model):
 
     __tablename__ = "data_job_cursor"
 
-    id = db.Column(db.BigInteger, primary_key=True, autoincrement=True)
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     job_type = db.Column(db.String(64), nullable=False, index=True)
     cursor_key = db.Column(db.String(128), nullable=False)
     cursor_value = db.Column(db.String(255), nullable=False)

--- a/app/models/data_job_run.py
+++ b/app/models/data_job_run.py
@@ -8,7 +8,7 @@ class DataJobRun(db.Model):
 
     __tablename__ = "data_job_run"
 
-    id = db.Column(db.BigInteger, primary_key=True, autoincrement=True)
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     job_type = db.Column(db.String(64), nullable=False, index=True)
     status = db.Column(db.String(32), nullable=False, default="pending", index=True)
     progress = db.Column(db.Float, nullable=False, default=0.0)

--- a/app/models/ml_predictions.py
+++ b/app/models/ml_predictions.py
@@ -18,7 +18,7 @@ class MLPredictions(db.Model):
     __table_args__ = (
         Index('idx_model_date', 'model_id', 'trade_date'),
         Index('idx_date_rank', 'trade_date', 'rank_score'),
-        Index('idx_ts_code_date', 'ts_code', 'trade_date'),
+        Index('idx_ml_ts_code_date', 'ts_code', 'trade_date'),
     )
     
     def to_dict(self):

--- a/app/models/portfolio_position.py
+++ b/app/models/portfolio_position.py
@@ -6,6 +6,7 @@
 from app.extensions import db
 from datetime import datetime
 from sqlalchemy import Index
+from app.services.persistence import persist_changes, persist_new
 
 
 class PortfolioPosition(db.Model):
@@ -72,7 +73,21 @@ class PortfolioPosition(db.Model):
         self.market_value = self.position_size * current_price
         self.unrealized_pnl = (current_price - self.avg_cost) * self.position_size
         self.updated_at = datetime.utcnow()
-        db.session.commit()
+        persist_changes(self)
+
+    def update_risk_limits(self, stop_loss_price=None, take_profit_price=None):
+        """更新止损止盈价格并持久化。"""
+        if stop_loss_price is not None:
+            self.stop_loss_price = stop_loss_price
+        if take_profit_price is not None:
+            self.take_profit_price = take_profit_price
+        self.updated_at = datetime.utcnow()
+        persist_changes(self)
+
+    @classmethod
+    def create_position(cls, **fields):
+        position = cls(**fields)
+        return persist_new(position)
     
     def calculate_pnl_percentage(self):
         """计算盈亏百分比"""
@@ -108,6 +123,59 @@ class PortfolioPosition(db.Model):
             ts_code=ts_code,
             is_active=True
         ).first()
+
+    @classmethod
+    def get_by_id(cls, position_id):
+        return cls.query.get(position_id)
+
+    @classmethod
+    def list_positions(cls, portfolio_id=None, active_only=True):
+        query = cls.query
+        if portfolio_id:
+            query = query.filter_by(portfolio_id=portfolio_id)
+        if active_only:
+            query = query.filter_by(is_active=True)
+        return query.all()
+
+    @classmethod
+    def get_by_portfolio_and_id(cls, portfolio_id, position_id):
+        return cls.query.filter_by(
+            id=position_id,
+            portfolio_id=portfolio_id,
+        ).first()
+
+    @classmethod
+    def update_position_by_id(cls, portfolio_id, position_id, **fields):
+        position = cls.get_by_portfolio_and_id(portfolio_id, position_id)
+        if not position:
+            return None
+
+        for key in ['position_size', 'avg_cost', 'current_price', 'sector', 'stop_loss_price', 'take_profit_price', 'is_active']:
+            if key in fields:
+                setattr(position, key, fields[key])
+
+        if position.current_price:
+            position.market_value = position.position_size * position.current_price
+            position.unrealized_pnl = (position.current_price - position.avg_cost) * position.position_size
+
+        position.updated_at = datetime.utcnow()
+        persist_changes(position)
+        return position
+
+    @classmethod
+    def delete_position_by_id(cls, portfolio_id, position_id):
+        position = cls.get_by_portfolio_and_id(portfolio_id, position_id)
+        if not position:
+            return False
+        position.is_active = False
+        position.updated_at = datetime.utcnow()
+        persist_changes(position)
+        return True
+
+    @classmethod
+    def list_active_portfolio_ids(cls):
+        rows = cls.query.filter_by(is_active=True).with_entities(cls.portfolio_id).distinct().all()
+        return [row[0] for row in rows if row and row[0]]
     
     @classmethod
     def calculate_portfolio_metrics(cls, portfolio_id):

--- a/app/models/realtime_indicator.py
+++ b/app/models/realtime_indicator.py
@@ -6,6 +6,20 @@
 from datetime import datetime, timedelta
 from sqlalchemy import Column, String, Float, DateTime, Integer, Index, func
 from app import db
+from app.services.parquet_event_store import ParquetEventStore
+
+
+class _RealtimeIndicatorEvent:
+    def __init__(self, data):
+        self.__dict__.update(data)
+
+    def to_dict(self):
+        result = dict(self.__dict__)
+        for key in ['datetime', 'created_at', 'updated_at']:
+            value = result.get(key)
+            if hasattr(value, 'isoformat'):
+                result[key] = value.isoformat()
+        return result
 
 
 class RealtimeIndicator(db.Model):
@@ -37,6 +51,10 @@ class RealtimeIndicator(db.Model):
         Index('idx_indicator_name_period', 'indicator_name', 'period_type'),
         Index('idx_indicator_datetime', 'datetime'),
     )
+
+    @staticmethod
+    def _store() -> ParquetEventStore:
+        return ParquetEventStore()
     
     def __repr__(self):
         return f'<RealtimeIndicator {self.ts_code} {self.indicator_name} {self.datetime}>'
@@ -60,76 +78,35 @@ class RealtimeIndicator(db.Model):
     @classmethod
     def get_latest_indicators(cls, ts_code, period_type, indicator_names=None, limit=100):
         """获取最新的技术指标数据"""
-        query = cls.query.filter_by(ts_code=ts_code, period_type=period_type)
-        
-        if indicator_names:
-            query = query.filter(cls.indicator_name.in_(indicator_names))
-        
-        return query.order_by(cls.datetime.desc()).limit(limit).all()
+        frame = cls._store().get_latest_indicators(ts_code, period_type, indicator_names=indicator_names, limit=limit)
+        return [cls._row_to_event(row) for _, row in frame.iterrows()]
     
     @classmethod
     def get_indicator_history(cls, ts_code, period_type, indicator_name, start_time=None, end_time=None):
         """获取指标历史数据"""
-        query = cls.query.filter_by(
-            ts_code=ts_code, 
+        frame = cls._store().get_indicator_history(
+            ts_code=ts_code,
             period_type=period_type,
-            indicator_name=indicator_name
+            indicator_name=indicator_name,
+            start_time=start_time,
+            end_time=end_time,
         )
-        
-        if start_time:
-            query = query.filter(cls.datetime >= start_time)
-        if end_time:
-            query = query.filter(cls.datetime <= end_time)
-        
-        return query.order_by(cls.datetime.asc()).all()
+        return [cls._row_to_event(row) for _, row in frame.iterrows()]
     
     @classmethod
     def batch_insert(cls, indicators_data):
         """批量插入指标数据"""
         try:
-            db.session.bulk_insert_mappings(cls, indicators_data)
-            db.session.commit()
+            cls._store().append_indicators(indicators_data)
             return True, f"成功插入 {len(indicators_data)} 条指标数据"
         except Exception as e:
-            db.session.rollback()
             return False, f"批量插入失败: {str(e)}"
     
     @classmethod
     def get_indicator_stats(cls):
         """获取指标统计信息"""
         try:
-            # 总记录数
-            total_records = cls.query.count()
-            
-            # 指标类型统计
-            indicator_stats = db.session.query(
-                cls.indicator_name,
-                func.count(cls.id).label('count')
-            ).group_by(cls.indicator_name).all()
-            
-            # 周期统计
-            period_stats = db.session.query(
-                cls.period_type,
-                func.count(cls.id).label('count')
-            ).group_by(cls.period_type).all()
-            
-            # 股票统计
-            stock_count = db.session.query(func.count(func.distinct(cls.ts_code))).scalar()
-            
-            # 时间范围
-            time_range = db.session.query(
-                func.min(cls.datetime).label('earliest'),
-                func.max(cls.datetime).label('latest')
-            ).first()
-            
-            return {
-                'total_records': total_records,
-                'total_stocks': stock_count,
-                'indicator_stats': {stat.indicator_name: stat.count for stat in indicator_stats},
-                'period_stats': {stat.period_type: stat.count for stat in period_stats},
-                'earliest_time': time_range.earliest.isoformat() if time_range.earliest else None,
-                'latest_time': time_range.latest.isoformat() if time_range.latest else None
-            }
+            return cls._store().get_indicator_stats()
         except Exception as e:
             return {'error': str(e)}
     
@@ -137,10 +114,12 @@ class RealtimeIndicator(db.Model):
     def cleanup_old_data(cls, days_to_keep=30):
         """清理旧数据"""
         try:
-            cutoff_date = datetime.now() - timedelta(days=days_to_keep)
-            deleted_count = cls.query.filter(cls.datetime < cutoff_date).delete()
-            db.session.commit()
+            deleted_count = cls._store().cleanup_old_indicators(days_to_keep=days_to_keep)
             return True, f"清理了 {deleted_count} 条旧数据"
         except Exception as e:
-            db.session.rollback()
-            return False, f"清理失败: {str(e)}" 
+            return False, f"清理失败: {str(e)}"
+
+    @staticmethod
+    def _row_to_event(row):
+        data = row.to_dict()
+        return _RealtimeIndicatorEvent(data)

--- a/app/models/realtime_report.py
+++ b/app/models/realtime_report.py
@@ -7,6 +7,7 @@ from app.extensions import db
 from datetime import datetime
 from sqlalchemy import Index, Text
 import json
+from app.services.persistence import persist_changes, persist_new, remove_instance
 
 
 class ReportTemplate(db.Model):
@@ -60,9 +61,66 @@ class ReportTemplate(db.Model):
             components=json.dumps(components) if components else None,
             created_by=created_by
         )
-        db.session.add(template)
-        db.session.commit()
-        return template
+        return persist_new(template)
+
+    @classmethod
+    def create_or_update_default_template(cls, template_name, template_type, description=None,
+                                          template_config=None, components=None, created_by=None):
+        template = cls.get_default_template(template_type)
+        if template:
+            return cls.update_template_by_id(
+                template.id,
+                template_name=template_name,
+                template_type=template_type,
+                description=description,
+                template_config=template_config,
+                components=components,
+                created_by=created_by,
+                is_default=True,
+            )
+        template = cls.create_template(
+            template_name=template_name,
+            template_type=template_type,
+            description=description,
+            template_config=template_config,
+            components=components,
+            created_by=created_by,
+        )
+        template.is_default = True
+        return persist_changes(template)
+
+    @classmethod
+    def update_template_by_id(cls, template_id, **fields):
+        template = cls.get_by_id(template_id)
+        if not template:
+            return None
+
+        if 'template_name' in fields:
+            template.template_name = fields['template_name']
+        if 'template_type' in fields:
+            template.template_type = fields['template_type']
+        if 'description' in fields:
+            template.description = fields['description']
+        if 'template_config' in fields:
+            template.template_config = json.dumps(fields['template_config']) if fields['template_config'] else None
+        if 'components' in fields:
+            template.components = json.dumps(fields['components']) if fields['components'] else None
+        if 'is_active' in fields:
+            template.is_active = fields['is_active']
+        if 'is_default' in fields:
+            template.is_default = fields['is_default']
+        if 'created_by' in fields:
+            template.created_by = fields['created_by']
+
+        template.updated_at = datetime.utcnow()
+        return persist_changes(template)
+
+    @classmethod
+    def delete_template_by_id(cls, template_id):
+        template = cls.get_by_id(template_id)
+        if not template:
+            return False
+        return remove_instance(template)
     
     @classmethod
     def get_templates_by_type(cls, template_type, active_only=True):
@@ -71,7 +129,7 @@ class ReportTemplate(db.Model):
         if active_only:
             query = query.filter_by(is_active=True)
         return query.order_by(cls.created_at.desc()).all()
-    
+
     @classmethod
     def get_default_template(cls, template_type):
         """获取默认模板"""
@@ -80,6 +138,33 @@ class ReportTemplate(db.Model):
             is_default=True,
             is_active=True
         ).first()
+
+    @classmethod
+    def get_by_id(cls, template_id):
+        return cls.query.get(template_id)
+
+    @classmethod
+    def count_templates(cls, active_only=None):
+        query = cls.query
+        if active_only is True:
+            query = query.filter_by(is_active=True)
+        elif active_only is False:
+            query = query.filter_by(is_active=False)
+        return query.count()
+
+    @classmethod
+    def list_templates(cls, active_only=None, template_type=None, limit=None):
+        query = cls.query
+        if active_only is True:
+            query = query.filter_by(is_active=True)
+        elif active_only is False:
+            query = query.filter_by(is_active=False)
+        if template_type:
+            query = query.filter_by(template_type=template_type)
+        query = query.order_by(cls.created_at.desc())
+        if limit is not None:
+            query = query.limit(limit)
+        return query.all()
 
 
 class RealtimeReport(db.Model):
@@ -146,10 +231,45 @@ class RealtimeReport(db.Model):
             report_data=json.dumps(report_data) if report_data else None,
             generated_by=generated_by
         )
-        db.session.add(report)
-        db.session.commit()
+        return persist_new(report)
+
+    @classmethod
+    def create_generated_report(
+        cls,
+        report_name,
+        report_type,
+        template_id=None,
+        report_content=None,
+        report_data=None,
+        generated_by=None,
+        status="generating",
+        generation_time=None,
+        error_message=None,
+    ):
+        report = cls.create_report(
+            report_name=report_name,
+            report_type=report_type,
+            template_id=template_id,
+            report_content=report_content,
+            report_data=report_data,
+            generated_by=generated_by,
+        )
+        report.update_generation_result(
+            report_content=report_content,
+            report_data=report_data,
+            status=status,
+            error_message=error_message,
+            generation_time=generation_time,
+        )
         return report
-    
+
+    @classmethod
+    def delete_report_by_id(cls, report_id):
+        report = cls.get_by_id(report_id)
+        if not report:
+            return False
+        return remove_instance(report)
+
     def update_status(self, status, error_message=None, file_path=None, 
                      file_format=None, file_size=None, generation_time=None):
         """更新报告状态"""
@@ -164,7 +284,68 @@ class RealtimeReport(db.Model):
             self.file_size = file_size
         if generation_time:
             self.generation_time = generation_time
-        db.session.commit()
+        persist_changes(self)
+
+    def update_generation_result(self, report_content=None, report_data=None, status=None,
+                                 error_message=None, generation_time=None):
+        """一次性更新生成结果，避免服务层反复拆字段写入。"""
+        if report_content is not None:
+            self.report_content = json.dumps(report_content) if not isinstance(report_content, str) else report_content
+        if report_data is not None:
+            self.report_data = json.dumps(report_data) if not isinstance(report_data, str) else report_data
+        if status is not None:
+            self.report_status = status
+        if error_message is not None:
+            self.error_message = error_message
+        if generation_time is not None:
+            self.generation_time = generation_time
+        persist_changes(self)
+
+    def attach_dispatch_metadata(self, subscription_id, channels=None, subscriber_email=None, subscriber_phone=None):
+        """附加分发元数据到报告数据。"""
+        payload = json.loads(self.report_data) if self.report_data else {}
+        payload["dispatch"] = {
+            "subscription_id": subscription_id,
+            "channels": channels or ["log"],
+            "subscriber_email": subscriber_email,
+            "subscriber_phone": subscriber_phone,
+        }
+        self.report_data = json.dumps(payload)
+        persist_changes(self)
+
+    @classmethod
+    def update_report_by_id(cls, report_id, **fields):
+        report = cls.get_by_id(report_id)
+        if not report:
+            return None
+
+        for key in [
+            'report_name', 'report_type', 'template_id', 'report_content', 'report_data',
+            'report_status', 'file_path', 'file_format', 'file_size', 'generation_time',
+            'error_message', 'generated_by', 'expires_at'
+        ]:
+            if key in fields:
+                value = fields[key]
+                if key in {'report_content', 'report_data'} and value is not None and not isinstance(value, str):
+                    value = json.dumps(value)
+                setattr(report, key, value)
+
+        return persist_changes(report)
+
+    @classmethod
+    def create_or_update_report(cls, report_id=None, **fields):
+        if report_id is None:
+            report = cls(**{
+                key: json.dumps(value) if key in {'report_content', 'report_data'} and value is not None and not isinstance(value, str) else value
+                for key, value in fields.items()
+                if key in {
+                    'report_name', 'report_type', 'template_id', 'report_content', 'report_data',
+                    'report_status', 'file_path', 'file_format', 'file_size', 'generation_time',
+                    'error_message', 'generated_by', 'expires_at'
+                }
+            })
+            return persist_new(report)
+        return cls.update_report_by_id(report_id, **fields)
     
     @classmethod
     def get_reports_by_type(cls, report_type, limit=50):
@@ -172,7 +353,7 @@ class RealtimeReport(db.Model):
         return cls.query.filter_by(report_type=report_type)\
                        .order_by(cls.generated_at.desc())\
                        .limit(limit).all()
-    
+
     @classmethod
     def get_recent_reports(cls, days=7, limit=20):
         """获取最近的报告"""
@@ -181,6 +362,41 @@ class RealtimeReport(db.Model):
         return cls.query.filter(cls.generated_at >= cutoff_date)\
                        .order_by(cls.generated_at.desc())\
                        .limit(limit).all()
+
+    @classmethod
+    def get_by_id(cls, report_id):
+        return cls.query.get(report_id)
+
+    @classmethod
+    def count_reports(cls, status=None):
+        query = cls.query
+        if status:
+            query = query.filter_by(report_status=status)
+        return query.count()
+
+    @classmethod
+    def count_reports_by_template(cls, template_id):
+        return cls.query.filter_by(template_id=template_id).count()
+
+    @classmethod
+    def get_report_type_stats(cls):
+        from sqlalchemy import func
+
+        stats = db.session.query(
+            cls.report_type,
+            func.count(cls.id).label('count')
+        ).group_by(cls.report_type).all()
+        return {stat.report_type: stat.count for stat in stats}
+
+    @classmethod
+    def list_reports(cls, report_type=None, limit=None):
+        query = cls.query
+        if report_type:
+            query = query.filter_by(report_type=report_type)
+        query = query.order_by(cls.generated_at.desc())
+        if limit is not None:
+            query = query.limit(limit)
+        return query.all()
 
 
 class ReportSubscription(db.Model):
@@ -247,9 +463,53 @@ class ReportSubscription(db.Model):
             notification_channels=json.dumps(notification_channels) if notification_channels else None,
             created_by=created_by
         )
-        db.session.add(subscription)
-        db.session.commit()
-        return subscription
+        return persist_new(subscription)
+
+    @classmethod
+    def create_or_replace_subscription(cls, **fields):
+        subscription_id = fields.pop("subscription_id", None)
+        if subscription_id is None:
+            return cls.create_subscription(**fields)
+        return cls.update_subscription_by_id(subscription_id, **fields)
+
+    @classmethod
+    def update_subscription_by_id(cls, subscription_id, **fields):
+        subscription = cls.get_by_id(subscription_id)
+        if not subscription:
+            return None
+
+        if 'subscription_name' in fields:
+            subscription.subscription_name = fields['subscription_name']
+        if 'template_id' in fields:
+            subscription.template_id = fields['template_id']
+        if 'subscriber_email' in fields:
+            subscription.subscriber_email = fields['subscriber_email']
+        if 'subscriber_phone' in fields:
+            subscription.subscriber_phone = fields['subscriber_phone']
+        if 'schedule_type' in fields:
+            subscription.schedule_type = fields['schedule_type']
+        if 'schedule_config' in fields:
+            subscription.schedule_config = json.dumps(fields['schedule_config']) if fields['schedule_config'] else None
+        if 'notification_channels' in fields:
+            subscription.notification_channels = json.dumps(fields['notification_channels']) if fields['notification_channels'] else None
+        if 'is_active' in fields:
+            subscription.is_active = fields['is_active']
+        if 'created_by' in fields:
+            subscription.created_by = fields['created_by']
+        if 'last_sent_at' in fields:
+            subscription.last_sent_at = fields['last_sent_at']
+        if 'next_send_at' in fields:
+            subscription.next_send_at = fields['next_send_at']
+
+        subscription.updated_at = datetime.utcnow()
+        return persist_changes(subscription)
+
+    @classmethod
+    def delete_subscription_by_id(cls, subscription_id):
+        subscription = cls.get_by_id(subscription_id)
+        if not subscription:
+            return False
+        return remove_instance(subscription)
     
     @classmethod
     def get_pending_subscriptions(cls):
@@ -259,7 +519,43 @@ class ReportSubscription(db.Model):
             cls.is_active == True,
             cls.next_send_at <= now
         ).all()
-    
+
+    @classmethod
+    def get_by_id(cls, subscription_id):
+        return cls.query.get(subscription_id)
+
+    @classmethod
+    def list_subscriptions(cls, active_only=False):
+        query = cls.query
+        if active_only:
+            query = query.filter_by(is_active=True)
+        return query.order_by(cls.created_at.desc()).all()
+
+    @classmethod
+    def count_subscriptions(cls, active_only=None):
+        query = cls.query
+        if active_only is True:
+            query = query.filter_by(is_active=True)
+        elif active_only is False:
+            query = query.filter_by(is_active=False)
+        return query.count()
+
+    @classmethod
+    def list_pending(cls):
+        return cls.get_pending_subscriptions()
+
+    @classmethod
+    def list_subscriptions(cls, active_only=None, limit=None):
+        query = cls.query
+        if active_only is True:
+            query = query.filter_by(is_active=True)
+        elif active_only is False:
+            query = query.filter_by(is_active=False)
+        query = query.order_by(cls.created_at.desc())
+        if limit is not None:
+            query = query.limit(limit)
+        return query.all()
+
     def update_send_time(self):
         """更新发送时间"""
         self.last_sent_at = datetime.utcnow()
@@ -274,4 +570,7 @@ class ReportSubscription(db.Model):
             from datetime import timedelta
             self.next_send_at = self.last_sent_at + timedelta(days=30)
         
-        db.session.commit() 
+        persist_changes(self)
+
+    def mark_sent(self):
+        self.update_send_time()

--- a/app/models/risk_alert.py
+++ b/app/models/risk_alert.py
@@ -6,6 +6,7 @@
 from app.extensions import db
 from datetime import datetime
 from sqlalchemy import Index
+from app.services.persistence import persist_changes, persist_new, remove_instance
 
 
 class RiskAlert(db.Model):
@@ -69,16 +70,33 @@ class RiskAlert(db.Model):
             position_size=position_size,
             portfolio_weight=portfolio_weight
         )
-        db.session.add(alert)
-        db.session.commit()
-        return alert
+        return persist_new(alert)
     
     def resolve_alert(self):
         """解决预警"""
         self.is_resolved = True
         self.is_active = False
         self.resolved_at = datetime.utcnow()
-        db.session.commit()
+        persist_changes(self)
+
+    def update_alert(self, **fields):
+        """更新预警字段并持久化。"""
+        for key in [
+            'ts_code', 'alert_type', 'alert_level', 'alert_message', 'risk_value',
+            'threshold_value', 'current_price', 'position_size', 'portfolio_weight',
+            'is_active', 'is_resolved', 'resolved_at'
+        ]:
+            if key in fields:
+                setattr(self, key, fields[key])
+        persist_changes(self)
+
+    @classmethod
+    def resolve_by_id(cls, alert_id):
+        alert = cls.get_by_id(alert_id)
+        if not alert:
+            return None
+        alert.update_alert(is_active=False, is_resolved=True, resolved_at=datetime.utcnow())
+        return alert
     
     @classmethod
     def get_active_alerts(cls, ts_code=None, alert_type=None, alert_level=None):
@@ -104,4 +122,40 @@ class RiskAlert(db.Model):
             func.count(cls.id).label('count')
         ).filter_by(is_active=True, is_resolved=False).group_by(cls.alert_level).all()
         
-        return {level: count for level, count in stats} 
+        return {level: count for level, count in stats}
+
+    @classmethod
+    def get_by_id(cls, alert_id):
+        return cls.query.get(alert_id)
+
+    @classmethod
+    def list_all(cls):
+        return cls.query.order_by(cls.created_at.desc()).all()
+
+    @classmethod
+    def get_active_alerts_for_portfolio(cls, portfolio_codes=None, alert_level=None):
+        query = cls.query.filter_by(is_active=True, is_resolved=False)
+        if portfolio_codes:
+            query = query.filter(cls.ts_code.in_(portfolio_codes))
+        if alert_level:
+            query = query.filter_by(alert_level=alert_level)
+        return query.order_by(cls.created_at.desc()).all()
+
+    @classmethod
+    def get_existing_active_alert(cls, ts_code, alert_type):
+        return cls.query.filter_by(
+            ts_code=ts_code,
+            alert_type=alert_type,
+            is_active=True,
+            is_resolved=False,
+        ).first()
+
+    @classmethod
+    def get_recent_alerts(cls, minutes=10, active_only=True, limit=10):
+        from datetime import timedelta
+
+        cutoff = datetime.utcnow() - timedelta(minutes=minutes)
+        query = cls.query.filter(cls.created_at >= cutoff)
+        if active_only:
+            query = query.filter_by(is_active=True)
+        return query.order_by(cls.created_at.desc()).limit(limit).all()

--- a/app/models/stock_minute_data.py
+++ b/app/models/stock_minute_data.py
@@ -3,9 +3,14 @@
 支持1分钟、5分钟、15分钟、30分钟、60分钟等多种周期的K线数据
 """
 
-from app.extensions import db
 from datetime import datetime
+
+import pandas as pd
 from sqlalchemy import Index, func
+
+from app.extensions import db
+from app.services.minute_parquet_reader import MinuteParquetReader
+from app.services.minute_parquet_store import MinuteParquetStore
 
 
 class StockMinuteData(db.Model):
@@ -67,20 +72,19 @@ class StockMinuteData(db.Model):
     @classmethod
     def get_latest_data(cls, ts_code, period_type='1min', limit=100):
         """获取最新的K线数据"""
-        return cls.query.filter_by(
-            ts_code=ts_code,
-            period_type=period_type
-        ).order_by(cls.datetime.desc()).limit(limit).all()
+        frame = cls._reader().get_latest_data(ts_code, period_type=period_type, limit=limit)
+        return [cls._row_to_event(row) for _, row in frame.iterrows()]
     
     @classmethod
     def get_data_by_time_range(cls, ts_code, start_time, end_time, period_type='1min'):
         """根据时间范围获取K线数据"""
-        return cls.query.filter(
-            cls.ts_code == ts_code,
-            cls.period_type == period_type,
-            cls.datetime >= start_time,
-            cls.datetime <= end_time
-        ).order_by(cls.datetime.asc()).all()
+        frame = cls._reader().get_data(
+            ts_code=ts_code,
+            period_type=period_type,
+            start_time=start_time,
+            end_time=end_time,
+        )
+        return [cls._row_to_event(row) for _, row in frame.iterrows()]
     
     @classmethod
     def get_data_range(cls, ts_code, period_type, start_time, end_time):
@@ -90,21 +94,28 @@ class StockMinuteData(db.Model):
     @classmethod
     def get_latest_price(cls, ts_code):
         """获取最新价格"""
-        latest = cls.query.filter_by(
-            ts_code=ts_code,
-            period_type='1min'
-        ).order_by(cls.datetime.desc()).first()
-        return latest.close if latest else None
+        latest = cls._reader().get_latest_data(ts_code, period_type='1min', limit=1)
+        if latest.empty:
+            return None
+        return latest.iloc[0].get("close")
     
     @classmethod
     def bulk_insert(cls, data_list):
         """批量插入数据"""
         try:
-            db.session.bulk_insert_mappings(cls, data_list)
-            db.session.commit()
+            frame = pd.DataFrame(data_list)
+            if frame.empty:
+                return True
+
+            store = cls._store()
+            if "period_type" not in frame.columns:
+                store.write_frame(frame, period_type='1min')
+                return True
+
+            for period_type, period_frame in frame.groupby("period_type"):
+                store.write_frame(period_frame, period_type=str(period_type))
             return True
         except Exception as e:
-            db.session.rollback()
             raise e
     
     @classmethod
@@ -158,4 +169,20 @@ class StockMinuteData(db.Model):
             'completeness': completeness,
             'latest_time': data[-1].datetime.isoformat() if data else None,
             'earliest_time': data[0].datetime.isoformat() if data else None
-        } 
+        }
+
+    @staticmethod
+    def _reader() -> MinuteParquetReader:
+        return MinuteParquetReader()
+
+    @staticmethod
+    def _store() -> MinuteParquetStore:
+        return MinuteParquetStore()
+
+    @staticmethod
+    def _row_to_event(row):
+        data = row.to_dict()
+        event = StockMinuteData()
+        for key, value in data.items():
+            setattr(event, key, value)
+        return event

--- a/app/models/text2sql_metadata.py
+++ b/app/models/text2sql_metadata.py
@@ -6,6 +6,7 @@ Text2SQL元数据模型
 from app.extensions import db
 from datetime import datetime
 import json
+from app.services.persistence import persist_changes, persist_new, remove_instance
 
 
 class TableMetadata(db.Model):
@@ -98,14 +99,53 @@ class QueryTemplate(db.Model):
     def increment_usage(self):
         """增加使用次数"""
         self.usage_count += 1
-        db.session.commit()
+        persist_changes(self)
+
+    @classmethod
+    def create_template(cls, template_id, template_name, intent_pattern=None, sql_template=None, parameters=None, is_active=True):
+        template = cls(
+            template_id=template_id,
+            template_name=template_name,
+            intent_pattern=intent_pattern,
+            sql_template=sql_template,
+            parameters=parameters,
+            is_active=is_active,
+        )
+        return persist_new(template)
+
+    @classmethod
+    def update_template_by_id(cls, template_id, **fields):
+        template = cls.get_by_id(template_id)
+        if not template:
+            return None
+
+        for key in ['template_name', 'intent_pattern', 'sql_template', 'parameters', 'is_active']:
+            if key in fields:
+                setattr(template, key, fields[key])
+
+        return persist_changes(template)
+
+    @classmethod
+    def delete_template_by_id(cls, template_id):
+        template = cls.get_by_id(template_id)
+        if not template:
+            return False
+        return remove_instance(template)
+
+    @classmethod
+    def get_by_id(cls, template_id):
+        return cls.query.get(template_id)
+
+    @classmethod
+    def list_active(cls):
+        return cls.query.filter_by(is_active=True).all()
 
 
 class QueryHistory(db.Model):
     """查询历史"""
     __tablename__ = 'query_history'
     
-    id = db.Column(db.BigInteger, primary_key=True, autoincrement=True, comment='主键ID')
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True, comment='主键ID')
     user_query = db.Column(db.Text, nullable=False, comment='用户查询')
     intent = db.Column(db.String(50), comment='识别意图')
     entities = db.Column(db.JSON, comment='提取的实体')
@@ -137,6 +177,49 @@ class QueryHistory(db.Model):
             'created_at': self.created_at.isoformat() if self.created_at else None
         }
 
+    @classmethod
+    def list_recent(cls, limit=10):
+        return cls.query.order_by(cls.created_at.desc()).limit(limit).all()
+
+    @classmethod
+    def create_history(cls, **fields):
+        history = cls(**fields)
+        return persist_new(history)
+
+    @classmethod
+    def count_total(cls):
+        return cls.query.count()
+
+    @classmethod
+    def count_successful(cls):
+        return cls.query.filter_by(is_successful=True).count()
+
+    @classmethod
+    def get_average_execution_time(cls):
+        return db.session.query(db.func.avg(cls.execution_time)).filter_by(is_successful=True).scalar() or 0
+
+    @classmethod
+    def get_top_intents(cls, limit=5):
+        return db.session.query(
+            cls.intent,
+            db.func.count(cls.intent).label('count')
+        ).filter(
+            cls.intent.isnot(None)
+        ).group_by(cls.intent).order_by(
+            db.func.count(cls.intent).desc()
+        ).limit(limit).all()
+
+    @classmethod
+    def get_top_templates(cls, limit=5):
+        return db.session.query(
+            cls.template_used,
+            db.func.count(cls.template_used).label('count')
+        ).filter(
+            cls.template_used.isnot(None)
+        ).group_by(cls.template_used).order_by(
+            db.func.count(cls.template_used).desc()
+        ).limit(limit).all()
+
 
 class BusinessDictionary(db.Model):
     """业务词典"""
@@ -167,3 +250,46 @@ class BusinessDictionary(db.Model):
             'created_at': self.created_at.isoformat() if self.created_at else None,
             'updated_at': self.updated_at.isoformat() if self.updated_at else None
         } 
+
+    @classmethod
+    def list_active(cls, category=None):
+        query = cls.query.filter_by(is_active=True)
+        if category:
+            query = query.filter_by(category=category)
+        return query.all()
+
+    @classmethod
+    def create_dictionary(cls, category, standard_term, synonyms=None, description=None, mapping_field=None, mapping_table=None, is_active=True):
+        item = cls(
+            category=category,
+            standard_term=standard_term,
+            synonyms=synonyms,
+            description=description,
+            mapping_field=mapping_field,
+            mapping_table=mapping_table,
+            is_active=is_active,
+        )
+        return persist_new(item)
+
+    @classmethod
+    def get_by_id(cls, dictionary_id):
+        return cls.query.get(dictionary_id)
+
+    @classmethod
+    def update_dictionary_by_id(cls, dictionary_id, **fields):
+        dictionary = cls.get_by_id(dictionary_id)
+        if not dictionary:
+            return None
+
+        for key in ['category', 'standard_term', 'synonyms', 'description', 'mapping_field', 'mapping_table', 'is_active']:
+            if key in fields:
+                setattr(dictionary, key, fields[key])
+
+        return persist_changes(dictionary)
+
+    @classmethod
+    def delete_dictionary_by_id(cls, dictionary_id):
+        dictionary = cls.get_by_id(dictionary_id)
+        if not dictionary:
+            return False
+        return remove_instance(dictionary)

--- a/app/models/trading_signal.py
+++ b/app/models/trading_signal.py
@@ -6,6 +6,20 @@
 from datetime import datetime, timedelta
 from sqlalchemy import Column, String, Float, DateTime, Integer, Index, func, Text
 from app import db
+from app.services.parquet_event_store import ParquetEventStore
+
+
+class _TradingSignalEvent:
+    def __init__(self, data):
+        self.__dict__.update(data)
+
+    def to_dict(self):
+        result = dict(self.__dict__)
+        for key in ['datetime', 'created_at', 'updated_at', 'expiry_time', 'executed_time']:
+            value = result.get(key)
+            if hasattr(value, 'isoformat'):
+                result[key] = value.isoformat()
+        return result
 
 
 class TradingSignal(db.Model):
@@ -56,6 +70,10 @@ class TradingSignal(db.Model):
         Index('idx_signal_datetime_status', 'datetime', 'status'),
         Index('idx_signal_strength', 'signal_strength'),
     )
+
+    @staticmethod
+    def _store() -> ParquetEventStore:
+        return ParquetEventStore()
     
     def __repr__(self):
         return f'<TradingSignal {self.ts_code} {self.strategy_name} {self.signal_type} {self.datetime}>'
@@ -89,181 +107,66 @@ class TradingSignal(db.Model):
     @classmethod
     def get_active_signals(cls, ts_code=None, strategy_name=None, limit=100):
         """获取活跃的交易信号"""
-        query = cls.query.filter_by(status='ACTIVE')
-        
-        if ts_code:
-            query = query.filter_by(ts_code=ts_code)
-        if strategy_name:
-            query = query.filter_by(strategy_name=strategy_name)
-        
-        return query.order_by(cls.datetime.desc()).limit(limit).all()
+        frame = cls._store().get_active_signals(ts_code=ts_code, strategy_name=strategy_name, limit=limit)
+        return [cls._row_to_event(row) for _, row in frame.iterrows()]
     
     @classmethod
     def get_signals_by_time_range(cls, start_time, end_time, ts_code=None, strategy_name=None):
         """根据时间范围获取交易信号"""
-        query = cls.query.filter(
-            cls.datetime >= start_time,
-            cls.datetime <= end_time
+        frame = cls._store().get_signals_by_time_range(
+            start_time=start_time,
+            end_time=end_time,
+            ts_code=ts_code,
+            strategy_name=strategy_name,
         )
-        
-        if ts_code:
-            query = query.filter_by(ts_code=ts_code)
-        if strategy_name:
-            query = query.filter_by(strategy_name=strategy_name)
-        
-        return query.order_by(cls.datetime.asc()).all()
+        return [cls._row_to_event(row) for _, row in frame.iterrows()]
     
     @classmethod
     def get_signal_performance(cls, strategy_name=None, days=30):
         """获取信号表现统计"""
-        end_time = datetime.now()
-        start_time = end_time - timedelta(days=days)
-        
-        query = cls.query.filter(
-            cls.datetime >= start_time,
-            cls.status.in_(['EXECUTED', 'EXPIRED'])
-        )
-        
-        if strategy_name:
-            query = query.filter_by(strategy_name=strategy_name)
-        
-        signals = query.all()
-        
-        if not signals:
-            return {
-                'total_signals': 0,
-                'executed_signals': 0,
-                'win_rate': 0.0,
-                'avg_profit_loss': 0.0,
-                'total_profit_loss': 0.0,
-                'max_profit': 0.0,
-                'max_loss': 0.0
-            }
-        
-        executed_signals = [s for s in signals if s.status == 'EXECUTED' and s.profit_loss is not None]
-        
-        total_signals = len(signals)
-        executed_count = len(executed_signals)
-        
-        if executed_count == 0:
-            return {
-                'total_signals': total_signals,
-                'executed_signals': 0,
-                'win_rate': 0.0,
-                'avg_profit_loss': 0.0,
-                'total_profit_loss': 0.0,
-                'max_profit': 0.0,
-                'max_loss': 0.0
-            }
-        
-        profit_losses = [s.profit_loss for s in executed_signals]
-        winning_signals = [s for s in executed_signals if s.profit_loss > 0]
-        
-        return {
-            'total_signals': total_signals,
-            'executed_signals': executed_count,
-            'win_rate': len(winning_signals) / executed_count * 100,
-            'avg_profit_loss': sum(profit_losses) / executed_count,
-            'total_profit_loss': sum(profit_losses),
-            'max_profit': max(profit_losses) if profit_losses else 0.0,
-            'max_loss': min(profit_losses) if profit_losses else 0.0
-        }
+        return cls._store().get_signal_performance(strategy_name=strategy_name, days=days)
     
     @classmethod
     def batch_insert(cls, signals_data):
         """批量插入信号数据"""
         try:
-            db.session.bulk_insert_mappings(cls, signals_data)
-            db.session.commit()
+            cls._store().append_signals(signals_data)
             return True, f"成功插入 {len(signals_data)} 条信号数据"
         except Exception as e:
-            db.session.rollback()
             return False, f"批量插入失败: {str(e)}"
     
     @classmethod
     def update_signal_status(cls, signal_id, status, executed_price=None, profit_loss=None):
         """更新信号状态"""
         try:
-            signal = cls.query.get(signal_id)
-            if not signal:
-                return False, "信号不存在"
-            
-            signal.status = status
-            signal.updated_at = datetime.now()
-            
-            if executed_price:
-                signal.executed_price = executed_price
-                signal.executed_time = datetime.now()
-            
-            if profit_loss is not None:
-                signal.profit_loss = profit_loss
-                if signal.trigger_price:
-                    signal.profit_loss_pct = (profit_loss / signal.trigger_price) * 100
-            
-            db.session.commit()
-            return True, "信号状态更新成功"
+            success = cls._store().update_signal_status(
+                signal_id,
+                status,
+                executed_price=executed_price,
+                profit_loss=profit_loss,
+            )
+            return (True, "信号状态更新成功") if success else (False, "信号不存在")
         except Exception as e:
-            db.session.rollback()
             return False, f"更新失败: {str(e)}"
     
     @classmethod
     def expire_old_signals(cls, hours=24):
         """过期旧信号"""
         try:
-            cutoff_time = datetime.now() - timedelta(hours=hours)
-            expired_count = cls.query.filter(
-                cls.status == 'ACTIVE',
-                cls.datetime < cutoff_time
-            ).update({'status': 'EXPIRED'})
-            
-            db.session.commit()
+            expired_count = cls._store().expire_old_signals(hours=hours)
             return True, f"过期了 {expired_count} 条信号"
         except Exception as e:
-            db.session.rollback()
             return False, f"过期信号失败: {str(e)}"
     
     @classmethod
     def get_signal_stats(cls):
         """获取信号统计信息"""
         try:
-            # 总信号数
-            total_signals = cls.query.count()
-            
-            # 按状态统计
-            status_stats = db.session.query(
-                cls.status,
-                func.count(cls.id).label('count')
-            ).group_by(cls.status).all()
-            
-            # 按策略统计
-            strategy_stats = db.session.query(
-                cls.strategy_name,
-                func.count(cls.id).label('count')
-            ).group_by(cls.strategy_name).all()
-            
-            # 按信号类型统计
-            type_stats = db.session.query(
-                cls.signal_type,
-                func.count(cls.id).label('count')
-            ).group_by(cls.signal_type).all()
-            
-            # 股票数量
-            stock_count = db.session.query(func.count(func.distinct(cls.ts_code))).scalar()
-            
-            # 时间范围
-            time_range = db.session.query(
-                func.min(cls.datetime).label('earliest'),
-                func.max(cls.datetime).label('latest')
-            ).first()
-            
-            return {
-                'total_signals': total_signals,
-                'total_stocks': stock_count,
-                'status_stats': {stat.status: stat.count for stat in status_stats},
-                'strategy_stats': {stat.strategy_name: stat.count for stat in strategy_stats},
-                'type_stats': {stat.signal_type: stat.count for stat in type_stats},
-                'earliest_time': time_range.earliest.isoformat() if time_range.earliest else None,
-                'latest_time': time_range.latest.isoformat() if time_range.latest else None
-            }
+            return cls._store().get_signal_stats()
         except Exception as e:
-            return {'error': str(e)} 
+            return {'error': str(e)}
+
+    @staticmethod
+    def _row_to_event(row):
+        data = row.to_dict()
+        return _TradingSignalEvent(data)

--- a/app/services/data_jobs/parquet_state_store.py
+++ b/app/services/data_jobs/parquet_state_store.py
@@ -114,7 +114,7 @@ class ParquetDataJobStateStore:
             )
             base_dir = os.path.join(data_dir, "data_job_state")
         self.store = ParquetStateStore(base_dir=base_dir)
-        self._migrate_legacy_state_if_needed()
+        self._migrate_previous_state_if_needed()
         self._normalize_state_files()
 
     def create_run(
@@ -280,24 +280,24 @@ class ParquetDataJobStateStore:
             updated_at=_to_python(row.get("updated_at")),
         )
 
-    def _migrate_legacy_state_if_needed(self) -> None:
+    def _migrate_previous_state_if_needed(self) -> None:
         current_runs = self.store.path_for(self.TABLE_RUNS)
         current_cursors = self.store.path_for(self.TABLE_CURSORS)
         current_dir = self.store.base_dir
-        legacy_dir = current_dir.parent / "ml_factor_state"
+        previous_dir = current_dir.parent / "ml_factor_state"
 
-        if legacy_dir == current_dir:
+        if previous_dir == current_dir:
             return
 
         migrations = [
-            (legacy_dir / f"{self.TABLE_RUNS}.parquet", current_runs),
-            (legacy_dir / f"{self.TABLE_CURSORS}.parquet", current_cursors),
+            (previous_dir / f"{self.TABLE_RUNS}.parquet", current_runs),
+            (previous_dir / f"{self.TABLE_CURSORS}.parquet", current_cursors),
         ]
-        for legacy_path, current_path in migrations:
-            if current_path.exists() or not legacy_path.exists():
+        for previous_path, current_path in migrations:
+            if current_path.exists() or not previous_path.exists():
                 continue
             current_path.parent.mkdir(parents=True, exist_ok=True)
-            shutil.move(str(legacy_path), str(current_path))
+            shutil.move(str(previous_path), str(current_path))
 
     def _normalize_state_files(self) -> None:
         self._normalize_runs_file()

--- a/app/services/data_jobs/runner.py
+++ b/app/services/data_jobs/runner.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Tuple
 
 
 class ScriptRunner:
-    """Adapter to execute legacy app/utils scripts in a managed way."""
+    """Adapter to execute app/utils scripts in a managed way."""
 
     def __init__(self, project_root: Optional[Path] = None):
         self.project_root = project_root or Path(__file__).resolve().parents[3]

--- a/app/services/data_jobs/state_store.py
+++ b/app/services/data_jobs/state_store.py
@@ -1,15 +1,13 @@
-from datetime import datetime
 from typing import Any, Dict, Optional
 
-from app.models.data_job_cursor import DataJobCursor
-from app.models.data_job_run import DataJobRun
+from app.services.data_jobs.parquet_state_store import ParquetDataJobStateStore
 
 
 class DataJobStateStore:
-    """Persistence wrapper for data job run state."""
+    """Compatibility wrapper for data job state backed by Parquet."""
 
-    def __init__(self, session):
-        self.session = session
+    def __init__(self, state_store: Optional[Any] = None):
+        self.state_store = state_store or ParquetDataJobStateStore()
 
     def create_run(
         self,
@@ -19,71 +17,43 @@ class DataJobStateStore:
         source_mode: Optional[str] = None,
         snapshot_tag: Optional[str] = None,
         progress_message: Optional[str] = None,
-    ) -> DataJobRun:
-        run = DataJobRun(
+    ):
+        return self.state_store.create_run(
             job_type=job_type,
-            params_json=params or {},
-            status="pending",
+            params=params,
             source_name=source_name,
             source_mode=source_mode,
             snapshot_tag=snapshot_tag,
             progress_message=progress_message,
         )
-        self.session.add(run)
-        self.session.commit()
-        return run
 
-    def find_active_duplicate(self, job_type: str, params: Dict[str, Any]) -> Optional[DataJobRun]:
-        return (
-            self.session.query(DataJobRun)
-            .filter(
-                DataJobRun.job_type == job_type,
-                DataJobRun.status.in_(["pending", "queued", "running"]),
-                DataJobRun.params_json == (params or {}),
-            )
-            .first()
-        )
+    def find_active_duplicate(self, job_type: str, params: Dict[str, Any]):
+        return self.state_store.find_active_duplicate(job_type, params)
 
-    def get_run(self, run_id: int) -> Optional[DataJobRun]:
-        return self.session.query(DataJobRun).filter_by(id=run_id).first()
+    def get_run(self, run_id: int):
+        return self.state_store.get_run(run_id)
 
     def update_run_status(
         self,
-        run: DataJobRun,
+        run,
         status: str,
         progress: Optional[float] = None,
         error_message: Optional[str] = None,
         progress_message: Optional[str] = None,
-    ) -> DataJobRun:
-        run.status = status
-        if progress is not None:
-            run.progress = progress
-        if error_message is not None:
-            run.error_message = error_message
-        if progress_message is not None:
-            run.progress_message = progress_message
-        if status == "running" and run.started_at is None:
-            run.started_at = datetime.utcnow()
-        if status in {"success", "failed", "cancelled"}:
-            run.finished_at = datetime.utcnow()
-        self.session.commit()
-        return run
-
-    def save_run(self, run: DataJobRun) -> DataJobRun:
-        self.session.add(run)
-        self.session.commit()
-        return run
-
-    def upsert_cursor(self, job_type: str, cursor_key: str, cursor_value: str) -> DataJobCursor:
-        cursor = (
-            self.session.query(DataJobCursor)
-            .filter_by(job_type=job_type, cursor_key=cursor_key)
-            .first()
+    ):
+        return self.state_store.update_run_status(
+            run,
+            status,
+            progress=progress,
+            error_message=error_message,
+            progress_message=progress_message,
         )
-        if cursor is None:
-            cursor = DataJobCursor(job_type=job_type, cursor_key=cursor_key, cursor_value=cursor_value)
-            self.session.add(cursor)
-        else:
-            cursor.cursor_value = cursor_value
-        self.session.commit()
-        return cursor
+
+    def save_run(self, run):
+        return self.state_store.save_run(run)
+
+    def upsert_cursor(self, job_type: str, cursor_key: str, cursor_value: str):
+        return self.state_store.upsert_cursor(job_type, cursor_key, cursor_value)
+
+    def list_runs(self, limit: int = 50, status: Optional[str] = None):
+        return self.state_store.list_runs(limit=limit, status=status)

--- a/app/services/data_reader.py
+++ b/app/services/data_reader.py
@@ -1,5 +1,5 @@
 """
-ParquetDataReader — 从本地 Parquet 文件加载日行情数据，替代 MySQL 查询。
+ParquetDataReader — 从本地 Parquet 文件加载日行情数据，替代传统数据库查询。
 
 存储布局（Hive 分区格式）：
     {data_dir}/daily_history/daily/year=YYYY/month=MM/day=DD/data.parquet

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -157,14 +157,23 @@ class LLMService:
         try:
             # 构建提示词
             prompt = self._build_sql_prompt(user_query, context)
-            
+
             messages = [
                 {
                     "role": "system",
-                    "content": "你是一个专业的SQL生成助手，专门为股票分析系统生成准确的SQL查询语句。"
+                    "content": (
+                        "你是一个专业的SQL生成助手，专门为股票分析系统生成准确的SQL查询语句。\n"
+                        "重要：目标数据库是 SQLite，请使用 SQLite 兼容的语法：\n"
+                        "- 用 datetime('now') 代替 NOW() / CURDATE()\n"
+                        "- 用 date('now', '-N days') 代替 DATE_SUB()\n"
+                        "- 不支持 GROUP_CONCAT 的 SEPARATOR 子句\n"
+                        "- 不支持 IF()，用 CASE WHEN 代替\n"
+                        "- 字符串拼接用 || 而非 CONCAT()\n"
+                        "- 只返回 SQL 语句，不要包含注释"
+                    )
                 },
                 {
-                    "role": "user", 
+                    "role": "user",
                     "content": prompt
                 }
             ]
@@ -190,6 +199,7 @@ class LLMService:
         
         prompt = f"""
 请根据用户的自然语言查询生成对应的SQL语句。
+目标数据库：SQLite
 
 用户查询: {user_query}
 
@@ -200,8 +210,8 @@ class LLMService:
 {self._format_tables_info(tables_info)}
 
 要求:
-1. 生成标准的SQL语句，默认兼容 MySQL 语法，便于遗留路径使用
-2. 只返回SQL语句，不要其他解释
+1. 生成 SQLite 兼容的 SQL 语句
+2. 只返回 SQL 语句，不要其他解释
 3. 确保SQL语法正确
 4. 使用适当的WHERE条件和ORDER BY子句
 5. 添加合理的LIMIT限制

--- a/app/services/minute_parquet_reader.py
+++ b/app/services/minute_parquet_reader.py
@@ -171,6 +171,12 @@ def _minute_code_aliases(value: str) -> set[str]:
     lower_text = text.lower()
     aliases = {text, lower_text}
 
+    # 兼容前端直接传入的 6 位纯数字代码（例如 300502）
+    if lower_text.isdigit() and len(lower_text) == 6:
+        market = 'SH' if lower_text.startswith('6') else 'SZ'
+        aliases.add(f"{lower_text}.{market}")
+        aliases.add(f"{market.lower()}.{lower_text}")
+
     if lower_text.startswith(("sh.", "sz.")):
         market, symbol = lower_text.split(".", 1)
         aliases.add(f"{symbol}.{market.upper()}")

--- a/app/services/nlp_processor.py
+++ b/app/services/nlp_processor.py
@@ -528,7 +528,7 @@ class BusinessDictionaryManager:
         """加载同义词词典"""
         try:
             # 从数据库加载业务词典
-            dictionaries = BusinessDictionary.query.filter_by(is_active=True).all()
+            dictionaries = BusinessDictionary.list_active()
             
             for dictionary in dictionaries:
                 category = dictionary.category

--- a/app/services/parquet_event_store.py
+++ b/app/services/parquet_event_store.py
@@ -1,0 +1,459 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+import pandas as pd
+from loguru import logger
+
+
+class ParquetEventStore:
+    """Lightweight Parquet-backed append/query store for realtime events."""
+
+    def __init__(self, base_dir: Optional[str] = None):
+        if base_dir is None:
+            base_dir = os.getenv(
+                "DATA_DIR",
+                os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "data"),
+            )
+        self.base_dir = Path(base_dir) / "realtime_events"
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def _event_dir(self, event_type: str) -> Path:
+        path = self.base_dir / event_type
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def _partition_path(self, event_type: str, day: datetime) -> Path:
+        return (
+            self._event_dir(event_type)
+            / f"year={day.year:04d}"
+            / f"month={day.month:02d}"
+            / f"day={day.day:02d}"
+            / "data.parquet"
+        )
+
+    def _ensure_frame(self, rows: Iterable[Dict[str, Any]] | pd.DataFrame) -> pd.DataFrame:
+        if isinstance(rows, pd.DataFrame):
+            frame = rows.copy()
+        else:
+            frame = pd.DataFrame(list(rows))
+        if frame.empty:
+            return frame
+        if "datetime" in frame.columns:
+            frame["datetime"] = pd.to_datetime(frame["datetime"], errors="coerce")
+        if "created_at" in frame.columns:
+            frame["created_at"] = pd.to_datetime(frame["created_at"], errors="coerce")
+        if "updated_at" in frame.columns:
+            frame["updated_at"] = pd.to_datetime(frame["updated_at"], errors="coerce")
+        if "expiry_time" in frame.columns:
+            frame["expiry_time"] = pd.to_datetime(frame["expiry_time"], errors="coerce")
+        if "resolved_at" in frame.columns:
+            frame["resolved_at"] = pd.to_datetime(frame["resolved_at"], errors="coerce")
+        return frame
+
+    def _read_partition(self, path: Path) -> pd.DataFrame:
+        if not path.is_file():
+            return pd.DataFrame()
+        try:
+            return pd.read_parquet(path)
+        except Exception as exc:
+            logger.warning(f"读取实时事件 parquet 失败 {path}: {exc}")
+            return pd.DataFrame()
+
+    def _read_event_frame(self, event_type: str) -> pd.DataFrame:
+        root = self._event_dir(event_type)
+        paths = sorted(root.glob("year=*/month=*/day=*/data.parquet"))
+        if not paths:
+            return pd.DataFrame()
+
+        frames = [self._read_partition(path) for path in paths]
+        frames = [frame for frame in frames if not frame.empty]
+        if not frames:
+            return pd.DataFrame()
+
+        frame = pd.concat(frames, ignore_index=True)
+        for column in ["datetime", "created_at", "updated_at", "expiry_time", "resolved_at"]:
+            if column in frame.columns:
+                frame[column] = pd.to_datetime(frame[column], errors="coerce")
+        if "id" in frame.columns:
+            frame["id"] = pd.to_numeric(frame["id"], errors="coerce")
+        return frame
+
+    def _write_event_frame(self, event_type: str, frame: pd.DataFrame) -> int:
+        if frame is None or frame.empty:
+            return 0
+
+        frame = frame.copy()
+        frame["datetime"] = pd.to_datetime(frame["datetime"], errors="coerce")
+        frame = frame.dropna(subset=["datetime"])
+        if frame.empty:
+            return 0
+
+        total_rows = 0
+        for date_value, day_frame in frame.groupby(frame["datetime"].dt.date):
+            path = self._partition_path(event_type, datetime.combine(date_value, datetime.min.time()))
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if path.is_file():
+                existing = self._read_partition(path)
+                combined = pd.concat([existing, day_frame], ignore_index=True)
+            else:
+                combined = day_frame.copy()
+
+            if "id" in combined.columns:
+                combined["id"] = pd.to_numeric(combined["id"], errors="coerce")
+                if combined["id"].isna().all():
+                    combined = combined.drop(columns=["id"])
+
+            if "id" not in combined.columns:
+                existing = self._read_event_frame(event_type)
+                next_id = 1
+                if not existing.empty and "id" in existing.columns:
+                    numeric = pd.to_numeric(existing["id"], errors="coerce").dropna()
+                    if not numeric.empty:
+                        next_id = int(numeric.max()) + 1
+                combined = combined.copy()
+                combined["id"] = range(next_id, next_id + len(combined))
+
+            dedupe_cols = [col for col in ["id", "ts_code", "datetime", "period_type", "indicator_name", "strategy_name"] if col in combined.columns]
+            if dedupe_cols:
+                combined = combined.drop_duplicates(subset=dedupe_cols, keep="last")
+
+            sort_cols = [col for col in ["datetime", "ts_code", "indicator_name", "strategy_name", "id"] if col in combined.columns]
+            if sort_cols:
+                combined = combined.sort_values(sort_cols).reset_index(drop=True)
+
+            combined.to_parquet(path, index=False)
+            total_rows += len(day_frame)
+        return total_rows
+
+    def _filter_frame(
+        self,
+        event_type: str,
+        ts_code: Optional[str] = None,
+        period_type: Optional[str] = None,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+    ) -> pd.DataFrame:
+        frame = self._read_event_frame(event_type)
+        if frame.empty:
+            return frame
+
+        if "datetime" in frame.columns:
+            frame["datetime"] = pd.to_datetime(frame["datetime"], errors="coerce")
+            frame = frame.dropna(subset=["datetime"])
+        if ts_code and "ts_code" in frame.columns:
+            frame = frame[frame["ts_code"] == ts_code]
+        if period_type and "period_type" in frame.columns:
+            frame = frame[frame["period_type"] == period_type]
+        if start_time is not None and "datetime" in frame.columns:
+            frame = frame[frame["datetime"] >= start_time]
+        if end_time is not None and "datetime" in frame.columns:
+            frame = frame[frame["datetime"] <= end_time]
+        if frame.empty:
+            return frame
+        sort_cols = [col for col in ["datetime", "ts_code", "indicator_name", "strategy_name", "id"] if col in frame.columns]
+        if sort_cols:
+            frame = frame.sort_values(sort_cols).reset_index(drop=True)
+        return frame
+
+    def append_indicators(self, rows: Iterable[Dict[str, Any]] | pd.DataFrame) -> int:
+        frame = self._ensure_frame(rows)
+        return self._write_event_frame("indicators", frame)
+
+    def append_signals(self, rows: Iterable[Dict[str, Any]] | pd.DataFrame) -> int:
+        frame = self._ensure_frame(rows)
+        return self._write_event_frame("signals", frame)
+
+    def get_latest_indicators(
+        self,
+        ts_code: str,
+        period_type: str,
+        indicator_names: Optional[Sequence[str]] = None,
+        limit: int = 100,
+    ) -> pd.DataFrame:
+        frame = self._filter_frame("indicators", ts_code=ts_code, period_type=period_type)
+        if frame.empty:
+            return frame
+        if indicator_names and "indicator_name" in frame.columns:
+            frame = frame[frame["indicator_name"].isin(set(indicator_names))]
+        if frame.empty:
+            return frame
+        return frame.sort_values("datetime", ascending=False).head(limit).reset_index(drop=True)
+
+    def get_indicator_history(
+        self,
+        ts_code: str,
+        period_type: str,
+        indicator_name: str,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+    ) -> pd.DataFrame:
+        frame = self._filter_frame(
+            "indicators",
+            ts_code=ts_code,
+            period_type=period_type,
+            start_time=start_time,
+            end_time=end_time,
+        )
+        if frame.empty or "indicator_name" not in frame.columns:
+            return frame
+        frame = frame[frame["indicator_name"] == indicator_name]
+        if frame.empty:
+            return frame
+        return frame.sort_values("datetime").reset_index(drop=True)
+
+    def get_indicators_by_time_range(
+        self,
+        ts_code: Optional[str],
+        period_type: Optional[str],
+        start_time: datetime,
+        end_time: datetime,
+    ) -> pd.DataFrame:
+        return self._filter_frame(
+            "indicators",
+            ts_code=ts_code,
+            period_type=period_type,
+            start_time=start_time,
+            end_time=end_time,
+        )
+
+    def get_indicator_stats(self) -> Dict[str, Any]:
+        frame = self._read_event_frame("indicators")
+        if frame.empty:
+            return {
+                "total_records": 0,
+                "total_stocks": 0,
+                "indicator_stats": {},
+                "period_stats": {},
+                "earliest_time": None,
+                "latest_time": None,
+            }
+
+        indicator_stats = {}
+        if "indicator_name" in frame.columns:
+            indicator_stats = frame["indicator_name"].fillna("UNKNOWN").value_counts().to_dict()
+        period_stats = {}
+        if "period_type" in frame.columns:
+            period_stats = frame["period_type"].fillna("UNKNOWN").value_counts().to_dict()
+
+        earliest = pd.to_datetime(frame["datetime"], errors="coerce").min() if "datetime" in frame.columns else None
+        latest = pd.to_datetime(frame["datetime"], errors="coerce").max() if "datetime" in frame.columns else None
+        stock_count = int(frame["ts_code"].dropna().astype(str).nunique()) if "ts_code" in frame.columns else 0
+        return {
+            "total_records": int(len(frame)),
+            "total_stocks": stock_count,
+            "indicator_stats": {str(key): int(value) for key, value in indicator_stats.items()},
+            "period_stats": {str(key): int(value) for key, value in period_stats.items()},
+            "earliest_time": earliest.isoformat() if pd.notna(earliest) else None,
+            "latest_time": latest.isoformat() if pd.notna(latest) else None,
+        }
+
+    def cleanup_old_indicators(self, days_to_keep: int = 30) -> int:
+        cutoff = datetime.utcnow() - pd.Timedelta(days=days_to_keep)
+        frame = self._read_event_frame("indicators")
+        if frame.empty or "datetime" not in frame.columns:
+            return 0
+        keep = frame[pd.to_datetime(frame["datetime"], errors="coerce") >= cutoff]
+        removed = len(frame) - len(keep)
+        self._rewrite_event_frame("indicators", keep)
+        return removed
+
+    def get_active_signals(
+        self,
+        ts_code: Optional[str] = None,
+        strategy_name: Optional[str] = None,
+        limit: int = 100,
+    ) -> pd.DataFrame:
+        frame = self._read_event_frame("signals")
+        if frame.empty:
+            return frame
+        if "status" in frame.columns:
+            frame = frame[frame["status"].fillna("").str.upper() == "ACTIVE"]
+        if ts_code and "ts_code" in frame.columns:
+            frame = frame[frame["ts_code"] == ts_code]
+        if strategy_name and "strategy_name" in frame.columns:
+            frame = frame[frame["strategy_name"] == strategy_name]
+        if frame.empty:
+            return frame
+        return frame.sort_values("datetime", ascending=False).head(limit).reset_index(drop=True)
+
+    def get_signals_by_time_range(
+        self,
+        start_time: datetime,
+        end_time: datetime,
+        ts_code: Optional[str] = None,
+        strategy_name: Optional[str] = None,
+    ) -> pd.DataFrame:
+        frame = self._filter_frame("signals", ts_code=ts_code, start_time=start_time, end_time=end_time)
+        if frame.empty:
+            return frame
+        if strategy_name and "strategy_name" in frame.columns:
+            frame = frame[frame["strategy_name"] == strategy_name]
+        if frame.empty:
+            return frame
+        return frame.sort_values("datetime").reset_index(drop=True)
+
+    def get_recent_signals(
+        self,
+        since: datetime,
+        limit: int = 20,
+        status: Optional[str] = "ACTIVE",
+    ) -> pd.DataFrame:
+        frame = self._filter_frame("signals", start_time=since, end_time=datetime.utcnow())
+        if frame.empty:
+            return frame
+        if status and "status" in frame.columns:
+            frame = frame[frame["status"].fillna("").str.upper() == status.upper()]
+        if frame.empty:
+            return frame
+        return frame.sort_values("datetime", ascending=False).head(limit).reset_index(drop=True)
+
+    def get_signal_performance(self, strategy_name: Optional[str] = None, days: int = 30) -> Dict[str, Any]:
+        end_time = datetime.utcnow()
+        start_time = end_time - pd.Timedelta(days=days)
+        frame = self.get_signals_by_time_range(start_time, end_time, strategy_name=strategy_name)
+        if frame.empty:
+            return {
+                "total_signals": 0,
+                "executed_signals": 0,
+                "win_rate": 0.0,
+                "avg_profit_loss": 0.0,
+                "total_profit_loss": 0.0,
+                "max_profit": 0.0,
+                "max_loss": 0.0,
+            }
+        if "status" in frame.columns:
+            frame = frame[frame["status"].fillna("").isin(["EXECUTED", "EXPIRED"])]
+        if frame.empty:
+            return {
+                "total_signals": 0,
+                "executed_signals": 0,
+                "win_rate": 0.0,
+                "avg_profit_loss": 0.0,
+                "total_profit_loss": 0.0,
+                "max_profit": 0.0,
+                "max_loss": 0.0,
+            }
+
+        executed = frame[(frame["status"].fillna("") == "EXECUTED") & frame["profit_loss"].notna()] if "profit_loss" in frame.columns else pd.DataFrame()
+        if executed.empty:
+            return {
+                "total_signals": int(len(frame)),
+                "executed_signals": 0,
+                "win_rate": 0.0,
+                "avg_profit_loss": 0.0,
+                "total_profit_loss": 0.0,
+                "max_profit": 0.0,
+                "max_loss": 0.0,
+            }
+        profit_losses = pd.to_numeric(executed["profit_loss"], errors="coerce").dropna()
+        if profit_losses.empty:
+            return {
+                "total_signals": int(len(frame)),
+                "executed_signals": int(len(executed)),
+                "win_rate": 0.0,
+                "avg_profit_loss": 0.0,
+                "total_profit_loss": 0.0,
+                "max_profit": 0.0,
+                "max_loss": 0.0,
+            }
+        winning = executed[pd.to_numeric(executed["profit_loss"], errors="coerce") > 0]
+        return {
+            "total_signals": int(len(frame)),
+            "executed_signals": int(len(executed)),
+            "win_rate": len(winning) / len(executed) * 100 if len(executed) else 0.0,
+            "avg_profit_loss": float(profit_losses.mean()),
+            "total_profit_loss": float(profit_losses.sum()),
+            "max_profit": float(profit_losses.max()),
+            "max_loss": float(profit_losses.min()),
+        }
+
+    def get_signal_stats(self) -> Dict[str, Any]:
+        frame = self._read_event_frame("signals")
+        if frame.empty:
+            return {
+                "total_signals": 0,
+                "total_stocks": 0,
+                "status_stats": {},
+                "strategy_stats": {},
+                "type_stats": {},
+                "earliest_time": None,
+                "latest_time": None,
+            }
+
+        status_stats = frame["status"].fillna("UNKNOWN").value_counts().to_dict() if "status" in frame.columns else {}
+        strategy_stats = frame["strategy_name"].fillna("UNKNOWN").value_counts().to_dict() if "strategy_name" in frame.columns else {}
+        type_stats = frame["signal_type"].fillna("UNKNOWN").value_counts().to_dict() if "signal_type" in frame.columns else {}
+        earliest = pd.to_datetime(frame["datetime"], errors="coerce").min() if "datetime" in frame.columns else None
+        latest = pd.to_datetime(frame["datetime"], errors="coerce").max() if "datetime" in frame.columns else None
+        stock_count = int(frame["ts_code"].dropna().astype(str).nunique()) if "ts_code" in frame.columns else 0
+        return {
+            "total_signals": int(len(frame)),
+            "total_stocks": stock_count,
+            "status_stats": {str(key): int(value) for key, value in status_stats.items()},
+            "strategy_stats": {str(key): int(value) for key, value in strategy_stats.items()},
+            "type_stats": {str(key): int(value) for key, value in type_stats.items()},
+            "earliest_time": earliest.isoformat() if pd.notna(earliest) else None,
+            "latest_time": latest.isoformat() if pd.notna(latest) else None,
+        }
+
+    def update_signal_status(
+        self,
+        signal_id: int,
+        status: str,
+        executed_price: Optional[float] = None,
+        profit_loss: Optional[float] = None,
+    ) -> bool:
+        frame = self._read_event_frame("signals")
+        if frame.empty or "id" not in frame.columns:
+            return False
+        mask = frame["id"] == signal_id
+        if not mask.any():
+            return False
+        now = datetime.utcnow()
+        frame.loc[mask, "status"] = status
+        frame.loc[mask, "updated_at"] = now
+        if executed_price is not None:
+            frame.loc[mask, "executed_price"] = executed_price
+            frame.loc[mask, "executed_time"] = now
+        if profit_loss is not None:
+            frame.loc[mask, "profit_loss"] = profit_loss
+            if "trigger_price" in frame.columns:
+                trigger = pd.to_numeric(frame.loc[mask, "trigger_price"], errors="coerce")
+                frame.loc[mask, "profit_loss_pct"] = (profit_loss / trigger) * 100
+        self._rewrite_event_frame("signals", frame)
+        return True
+
+    def expire_old_signals(self, hours: int = 24) -> int:
+        frame = self._read_event_frame("signals")
+        if frame.empty or "datetime" not in frame.columns:
+            return 0
+        cutoff = datetime.utcnow() - pd.Timedelta(hours=hours)
+        mask = pd.to_datetime(frame["datetime"], errors="coerce") < cutoff
+        if "status" in frame.columns:
+            mask = mask & (frame["status"].fillna("") == "ACTIVE")
+        expired_count = int(mask.sum())
+        if expired_count:
+            frame.loc[mask, "status"] = "EXPIRED"
+            frame.loc[mask, "updated_at"] = datetime.utcnow()
+            self._rewrite_event_frame("signals", frame)
+        return expired_count
+
+    def _rewrite_event_frame(self, event_type: str, frame: pd.DataFrame) -> None:
+        root = self._event_dir(event_type)
+        for path in root.glob("year=*/month=*/day=*/data.parquet"):
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+        if frame.empty:
+            return
+        frame = frame.copy()
+        frame["datetime"] = pd.to_datetime(frame["datetime"], errors="coerce")
+        frame = frame.dropna(subset=["datetime"])
+        if frame.empty:
+            return
+        self._write_event_frame(event_type, frame)

--- a/app/services/persistence.py
+++ b/app/services/persistence.py
@@ -1,0 +1,18 @@
+from app.extensions import db
+
+
+def persist_new(instance):
+    db.session.add(instance)
+    db.session.commit()
+    return instance
+
+
+def persist_changes(instance):
+    db.session.commit()
+    return instance
+
+
+def remove_instance(instance):
+    db.session.delete(instance)
+    db.session.commit()
+    return True

--- a/app/services/realtime_data_manager.py
+++ b/app/services/realtime_data_manager.py
@@ -28,7 +28,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-LEGACY_REALTIME_SYNC_DISABLED_MESSAGE = 'legacy分钟数据同步已禁用，请使用真实数据源'
+REALTIME_SYNC_DISABLED_MESSAGE = '分钟数据同步已禁用，请使用真实数据源'
 
 
 class RealtimeDataManager:
@@ -101,7 +101,15 @@ class RealtimeDataManager:
                     )
                 return result
 
-            return self._sync_minute_data_legacy(ts_code, start_date, end_date, period_type)
+            return {
+                'success': False,
+                'message': REALTIME_SYNC_DISABLED_MESSAGE,
+                'data_count': 0,
+                'ts_code': ts_code,
+                'start_date': start_date,
+                'end_date': end_date,
+                'period_type': period_type
+            }
             
         except Exception as e:
             logger.error(f"同步数据失败: {str(e)}")
@@ -132,10 +140,10 @@ class RealtimeDataManager:
             source = self._resolve_minute_data_source(data_source, use_baostock)
 
             if source not in {'baostock', 'tongdaxin'}:
-                logger.warning("批量分钟数据legacy同步已禁用")
+                logger.warning("批量分钟数据同步已禁用")
                 return {
                     'success': False,
-                    'message': LEGACY_REALTIME_SYNC_DISABLED_MESSAGE,
+                    'message': REALTIME_SYNC_DISABLED_MESSAGE,
                     'total_stocks': len(stock_list),
                     'success_stocks': 0,
                     'failed_stocks': len(stock_list),
@@ -186,10 +194,10 @@ class RealtimeDataManager:
             source = self._resolve_minute_data_source(data_source, use_baostock)
 
             if source not in {'baostock', 'tongdaxin'}:
-                logger.warning("全周期分钟数据legacy同步已禁用")
+                logger.warning("全周期分钟数据同步已禁用")
                 return {
                     'success': False,
-                    'message': LEGACY_REALTIME_SYNC_DISABLED_MESSAGE,
+                    'message': REALTIME_SYNC_DISABLED_MESSAGE,
                     'ts_code': ts_code,
                     'period_types': ['1min', '5min', '15min', '30min', '60min']
                 }
@@ -223,21 +231,6 @@ class RealtimeDataManager:
             logger.error(f"获取股票列表异常: {e}")
             return []
     
-    def _sync_minute_data_legacy(self, ts_code: str, start_date: str, end_date: str, period_type: str) -> Dict:
-        """
-        原有的同步方式（保持兼容性）
-        """
-        logger.warning("legacy 分钟数据同步已禁用，避免写入模拟行情数据")
-        return {
-            'success': False,
-            'message': LEGACY_REALTIME_SYNC_DISABLED_MESSAGE,
-            'data_count': 0,
-            'ts_code': ts_code,
-            'start_date': start_date,
-            'end_date': end_date,
-            'period_type': period_type
-        }
-
     def _resolve_minute_data_source(self, data_source: Optional[str], use_baostock: bool) -> str:
         if data_source:
             return str(data_source).strip().lower()

--- a/app/services/realtime_indicator_engine.py
+++ b/app/services/realtime_indicator_engine.py
@@ -11,6 +11,7 @@ from app.extensions import db
 from loguru import logger
 import json
 import math
+from sqlalchemy.exc import SQLAlchemyError
 
 from app.models.realtime_indicator import RealtimeIndicator
 from app.services.data_reader import ParquetDataReader
@@ -82,6 +83,81 @@ class RealtimeIndicatorEngine:
                     cleaned_item[key] = value
             cleaned_data.append(cleaned_item)
         return cleaned_data
+
+    def _normalize_indicator_series(self, values):
+        """将指标序列统一为可存储/可展示的列表。"""
+        if isinstance(values, pd.Series):
+            return values.tolist()
+        if isinstance(values, tuple):
+            return list(values)
+        if isinstance(values, list):
+            return values
+        return [values]
+
+    def _extract_latest_value(self, values):
+        """提取序列中的最新有效值。"""
+        normalized = self._normalize_indicator_series(values)
+        for item in reversed(normalized):
+            if item is None:
+                continue
+            if isinstance(item, (list, tuple)):
+                if any(part is not None for part in item):
+                    return list(item)
+                continue
+            if pd.isna(item):
+                continue
+            return item
+        return None
+
+    def _build_indicator_storage_rows(
+        self,
+        ts_code: str,
+        period_type: str,
+        indicator: str,
+        indicator_result: Dict,
+        df: pd.DataFrame,
+    ) -> tuple[list[Dict], Dict[str, Any]]:
+        """把单个指标的结果展开成存储行和摘要。"""
+        storage_rows: list[Dict] = []
+        latest_values: Dict[str, Any] = {}
+
+        if not isinstance(indicator_result, dict):
+            return storage_rows, latest_values
+
+        for sub_name, values in indicator_result.items():
+            normalized_values = self._normalize_indicator_series(values)
+            latest_values[sub_name] = self._clean_nan_values(self._extract_latest_value(normalized_values))
+
+            for i, row in df.iterrows():
+                if i >= len(normalized_values):
+                    break
+
+                value = normalized_values[i]
+                if value is None or (isinstance(value, float) and pd.isna(value)):
+                    continue
+
+                if isinstance(value, (int, float)):
+                    value1, value2, value3, value4 = value, None, None, None
+                elif isinstance(value, (list, tuple)):
+                    value1 = value[0] if len(value) > 0 else None
+                    value2 = value[1] if len(value) > 1 else None
+                    value3 = value[2] if len(value) > 2 else None
+                    value4 = value[3] if len(value) > 3 else None
+                else:
+                    continue
+
+                storage_rows.append({
+                    'ts_code': ts_code,
+                    'datetime': row['datetime'],
+                    'period_type': period_type,
+                    'indicator_name': indicator,
+                    'value1': value1,
+                    'value2': value2,
+                    'value3': value3,
+                    'value4': value4
+                })
+
+        return storage_rows, latest_values
     
     def _clean_results_for_json(self, results: Dict) -> Dict:
         """清理结果中的NaN值，确保JSON序列化安全"""
@@ -256,57 +332,64 @@ class RealtimeIndicatorEngine:
             # 计算指标
             results = {}
             indicator_data = []
+            latest_values = {}
+            indicator_summary = {}
             
             for indicator in indicators:
                 if indicator in self.supported_indicators:
                     try:
                         indicator_result = self.supported_indicators[indicator](df)
                         results[indicator] = indicator_result
-                        
-                        # 准备存储数据
-                        for i, row in df.iterrows():
-                            if indicator in indicator_result and i < len(indicator_result[indicator]):
-                                values = indicator_result[indicator][i]
-                                if values is not None:
-                                    # 处理单值和多值指标
-                                    if isinstance(values, (int, float)):
-                                        value1, value2, value3, value4 = values, None, None, None
-                                    elif isinstance(values, (list, tuple)):
-                                        value1 = values[0] if len(values) > 0 else None
-                                        value2 = values[1] if len(values) > 1 else None
-                                        value3 = values[2] if len(values) > 2 else None
-                                        value4 = values[3] if len(values) > 3 else None
-                                    else:
-                                        continue
-                                    
-                                    indicator_data.append({
-                                        'ts_code': ts_code,
-                                        'datetime': row['datetime'],
-                                        'period_type': period_type,
-                                        'indicator_name': indicator,
-                                        'value1': value1,
-                                        'value2': value2,
-                                        'value3': value3,
-                                        'value4': value4
-                                    })
+                        rows, summary = self._build_indicator_storage_rows(
+                            ts_code=ts_code,
+                            period_type=period_type,
+                            indicator=indicator,
+                            indicator_result=indicator_result,
+                            df=df,
+                        )
+                        indicator_data.extend(rows)
+                        latest_values[indicator] = summary
+                        indicator_summary[indicator] = {
+                            'sub_indicators': list(indicator_result.keys()) if isinstance(indicator_result, dict) else [],
+                            'latest_values': summary,
+                            'stored_records': len(rows)
+                        }
                     except Exception as e:
                         logger.error(f"计算指标 {indicator} 失败: {str(e)}")
                         results[indicator] = {'error': str(e)}
+                        latest_values[indicator] = {}
+                        indicator_summary[indicator] = {
+                            'sub_indicators': [],
+                            'latest_values': {},
+                            'stored_records': 0,
+                            'error': str(e),
+                        }
             
             # 存储指标数据到数据库
             cleaned_indicator_data = []
+            storage_warning = None
             if indicator_data:
-                # 删除旧数据
-                RealtimeIndicator.query.filter(
-                    RealtimeIndicator.ts_code == ts_code,
-                    RealtimeIndicator.period_type == period_type,
-                    RealtimeIndicator.datetime >= start_time
-                ).delete()
-                
-                cleaned_indicator_data = self._clean_indicator_data(indicator_data)
-                success, message = RealtimeIndicator.batch_insert(cleaned_indicator_data)
-                if not success:
-                    logger.error(f"存储指标数据失败: {message}")
+                try:
+                    # 删除旧数据
+                    RealtimeIndicator.query.filter(
+                        RealtimeIndicator.ts_code == ts_code,
+                        RealtimeIndicator.period_type == period_type,
+                        RealtimeIndicator.datetime >= start_time
+                    ).delete()
+                    
+                    cleaned_indicator_data = self._clean_indicator_data(indicator_data)
+                    success, message = RealtimeIndicator.batch_insert(cleaned_indicator_data)
+                    if not success:
+                        storage_warning = f"存储指标数据失败: {message}"
+                        logger.error(storage_warning)
+                except SQLAlchemyError as e:
+                    db.session.rollback()
+                    storage_warning = f"指标数据落库失败: {str(e)}"
+                    logger.warning(storage_warning)
+                except Exception as e:
+                    db.session.rollback()
+                    storage_warning = f"指标数据落库异常: {str(e)}"
+                    logger.warning(storage_warning)
             
             cleaned_results = self._clean_results_for_json(results)
             
@@ -314,10 +397,15 @@ class RealtimeIndicatorEngine:
             return_dict = {
                 'success': True,
                 'data': cleaned_results,
+                'latest_values': self._clean_results_for_json(latest_values),
+                'indicator_summary': self._clean_results_for_json(indicator_summary),
+                'timeline': df['datetime'].dt.strftime('%Y-%m-%d %H:%M:%S').tolist(),
                 'total_indicators': len(results),
                 'data_points': len(df),
                 'stored_records': len(cleaned_indicator_data)
             }
+            if storage_warning:
+                return_dict['storage_warning'] = storage_warning
             
             # 清理整个返回字典
             final_result = self._clean_results_for_json(return_dict)
@@ -617,6 +705,11 @@ class RealtimeIndicatorEngine:
             indicators = ['MA', 'EMA', 'MACD', 'RSI']
         
         results = {}
+        summary = {
+            'period_count': len(periods),
+            'available_periods': [],
+            'period_summaries': {}
+        }
         
         for period in periods:
             try:
@@ -627,14 +720,33 @@ class RealtimeIndicatorEngine:
                     lookback_days=7  # 多周期计算使用较短的回看期
                 )
                 results[period] = period_result
+                if period_result.get('success'):
+                    summary['available_periods'].append(period)
+                summary['period_summaries'][period] = {
+                    'success': period_result.get('success', False),
+                    'total_indicators': period_result.get('total_indicators', 0),
+                    'data_points': period_result.get('data_points', 0),
+                    'stored_records': period_result.get('stored_records', 0),
+                    'latest_values': period_result.get('latest_values', {}),
+                }
             except Exception as e:
                 logger.error(f"计算 {period} 周期指标失败: {str(e)}")
                 results[period] = {'success': False, 'message': str(e)}
-        
+                summary['period_summaries'][period] = {
+                    'success': False,
+                    'message': str(e)
+                }
+
         return {
             'success': True,
             'data': results,
             'ts_code': ts_code,
             'indicators': indicators,
-            'periods': periods
-        } 
+            'periods': periods,
+            'data_source': {
+                'type': 'parquet',
+                'data_dir': self.data_reader.data_dir,
+                'minute_root': f"{self.data_reader.data_dir}/stock_minute",
+            },
+            'summary': summary
+        }

--- a/app/services/realtime_indicator_engine.py
+++ b/app/services/realtime_indicator_engine.py
@@ -365,29 +365,20 @@ class RealtimeIndicatorEngine:
                             'error': str(e),
                         }
             
-            # 存储指标数据到数据库
+            # 存储指标数据到 Parquet 事件存储
             cleaned_indicator_data = []
             storage_warning = None
             if indicator_data:
                 try:
-                    # 删除旧数据
-                    RealtimeIndicator.query.filter(
-                        RealtimeIndicator.ts_code == ts_code,
-                        RealtimeIndicator.period_type == period_type,
-                        RealtimeIndicator.datetime >= start_time
-                    ).delete()
-                    
                     cleaned_indicator_data = self._clean_indicator_data(indicator_data)
                     success, message = RealtimeIndicator.batch_insert(cleaned_indicator_data)
                     if not success:
                         storage_warning = f"存储指标数据失败: {message}"
                         logger.error(storage_warning)
                 except SQLAlchemyError as e:
-                    db.session.rollback()
                     storage_warning = f"指标数据落库失败: {str(e)}"
                     logger.warning(storage_warning)
                 except Exception as e:
-                    db.session.rollback()
                     storage_warning = f"指标数据落库异常: {str(e)}"
                     logger.warning(storage_warning)
             

--- a/app/services/realtime_report_generator.py
+++ b/app/services/realtime_report_generator.py
@@ -3,7 +3,6 @@
 提供多种类型的分析报告生成功能
 """
 
-import json
 import logging
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Any
@@ -11,13 +10,11 @@ import pandas as pd
 import numpy as np
 
 from app.models.realtime_report import ReportTemplate, RealtimeReport, ReportSubscription
-from app.models.stock_minute_data import StockMinuteData
-from app.models.realtime_indicator import RealtimeIndicator
 from app.models.trading_signal import TradingSignal
 from app.models.portfolio_position import PortfolioPosition
 from app.models.risk_alert import RiskAlert
-from app.extensions import db
 from app.services.data_reader import ParquetDataReader
+from app.services.parquet_event_store import ParquetEventStore
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +26,7 @@ class RealtimeReportGenerator:
         """初始化报告生成器"""
         self.data_reader = ParquetDataReader()
         self.minute_reader = self.data_reader.get_minute_reader()
+        self.event_store = ParquetEventStore()
         self.report_types = {
             'daily_summary': '每日市场总结',
             'portfolio_analysis': '投资组合分析',
@@ -110,16 +108,19 @@ class RealtimeReportGenerator:
             
             # 收集报告数据
             report_data = self._collect_report_data(report_type, parameters or {})
-            
+
             # 生成报告内容
             report_content = self._generate_report_content(report_type, template, report_data)
-            
+
             # 更新报告
             generation_time = (datetime.utcnow() - start_time).total_seconds()
-            report.report_content = json.dumps(report_content)
-            report.report_data = json.dumps(report_data)
-            report.update_status('completed', generation_time=generation_time)
-            
+            report.update_generation_result(
+                report_content=report_content,
+                report_data=report_data,
+                status='completed',
+                generation_time=generation_time,
+            )
+
             return {
                 'success': True,
                 'data': {
@@ -136,7 +137,10 @@ class RealtimeReportGenerator:
         except Exception as e:
             logger.error(f"生成报告失败: {str(e)}")
             if 'report' in locals():
-                report.update_status('failed', error_message=str(e))
+                report.update_generation_result(
+                    status='failed',
+                    error_message=str(e),
+                )
             return {
                 'success': False,
                 'message': f'报告生成失败: {str(e)}'
@@ -145,7 +149,7 @@ class RealtimeReportGenerator:
     def _get_or_create_template(self, report_type: str, template_id: Optional[int]) -> Optional[ReportTemplate]:
         """获取或创建模板"""
         if template_id:
-            template = ReportTemplate.query.get(template_id)
+            template = ReportTemplate.get_by_id(template_id)
             if template and template.template_type == report_type:
                 return template
         
@@ -165,8 +169,7 @@ class RealtimeReportGenerator:
                 components=template_config.get('sections', []),
                 created_by='system'
             )
-            template.is_default = True
-            db.session.commit()
+            ReportTemplate.update_template_by_id(template.id, is_default=True)
             return template
         
         return None
@@ -215,16 +218,8 @@ class RealtimeReportGenerator:
         # 获取当天 5min 技术指标数量与信号数量
         day_start = datetime.combine(today, datetime.min.time())
         day_end = datetime.combine(today, datetime.max.time())
-        indicator_count = RealtimeIndicator.query.filter(
-            RealtimeIndicator.datetime >= day_start,
-            RealtimeIndicator.datetime <= day_end,
-            RealtimeIndicator.period_type == '5min'
-        ).count()
-        signal_count = TradingSignal.query.filter(
-            TradingSignal.created_at >= day_start,
-            TradingSignal.created_at <= day_end,
-            TradingSignal.period_type == '5min'
-        ).count()
+        indicator_count = self._count_indicators_in_range(day_start, day_end, period_type='5min')
+        signal_count = self._count_signals_in_range(day_start, day_end, period_type='5min')
         
         return {
             'date': today.isoformat(),
@@ -286,7 +281,7 @@ class RealtimeReportGenerator:
             }
         
         # 获取风险预警
-        alerts = RiskAlert.query.filter_by(is_resolved=False).all()
+        alerts = RiskAlert.get_active_alerts()
         
         # 计算基础风险指标
         total_value = sum(pos.market_value or 0 for pos in positions)
@@ -319,12 +314,12 @@ class RealtimeReportGenerator:
     def _collect_signal_data(self) -> Dict[str, Any]:
         """收集交易信号数据"""
         # 获取最近的交易信号
-        recent_signals = TradingSignal.query.filter(
-            TradingSignal.created_at >= datetime.utcnow() - timedelta(days=7),
-            TradingSignal.period_type == '5min'
-        ).all()
-        recent_signals.sort(key=lambda signal: signal.created_at or datetime.min, reverse=True)
-        recent_signals = recent_signals[:100]
+        recent_signals = self._load_recent_signals(
+            start_time=datetime.utcnow() - timedelta(days=7),
+            end_time=datetime.utcnow(),
+            period_type='5min',
+            limit=100,
+        )
         
         # 统计信号类型分布
         signal_types = {}
@@ -365,6 +360,41 @@ class RealtimeReportGenerator:
             'recent_signals': [signal.to_dict() for signal in recent_signals[:20]],  # 最近20个信号
             'analysis_date': datetime.utcnow().isoformat()
         }
+
+    def _count_indicators_in_range(self, start_time: datetime, end_time: datetime, period_type: Optional[str] = None) -> int:
+        frame = self.event_store.get_indicators_by_time_range(
+            ts_code=None,
+            period_type=period_type,
+            start_time=start_time,
+            end_time=end_time,
+        )
+        return int(len(frame)) if not frame.empty else 0
+
+    def _count_signals_in_range(self, start_time: datetime, end_time: datetime, period_type: Optional[str] = None) -> int:
+        frame = self.event_store.get_signals_by_time_range(
+            start_time=start_time,
+            end_time=end_time,
+        )
+        if not frame.empty:
+            if period_type and "period_type" in frame.columns:
+                frame = frame[frame["period_type"] == period_type]
+            return int(len(frame))
+        return 0
+
+    def _load_recent_signals(
+        self,
+        start_time: datetime,
+        end_time: datetime,
+        period_type: Optional[str] = None,
+        limit: int = 100,
+    ) -> List[Any]:
+        frame = self.event_store.get_signals_by_time_range(start_time=start_time, end_time=end_time)
+        if not frame.empty:
+            if period_type and "period_type" in frame.columns:
+                frame = frame[frame["period_type"] == period_type]
+            frame = frame.sort_values("datetime", ascending=False).head(limit)
+            return [TradingSignal._row_to_event(row) for _, row in frame.iterrows()]
+        return []
     
     def _collect_market_data(self) -> Dict[str, Any]:
         """收集市场数据"""
@@ -394,15 +424,17 @@ class RealtimeReportGenerator:
         # 获取当天 5min 技术指标统计
         day_start = datetime.combine(today, datetime.min.time())
         day_end = datetime.combine(today, datetime.max.time())
-        indicator_stats_query = db.session.query(
-            RealtimeIndicator.indicator_name,
-            db.func.count(RealtimeIndicator.id).label('count')
-        ).filter(
-            RealtimeIndicator.datetime >= day_start,
-            RealtimeIndicator.datetime <= day_end,
-            RealtimeIndicator.period_type == '5min'
-        ).group_by(RealtimeIndicator.indicator_name).all()
-        indicator_stats = {stat.indicator_name: stat.count for stat in indicator_stats_query}
+        indicator_stats_df = self.event_store.get_indicators_by_time_range(
+            ts_code=None,
+            period_type='5min',
+            start_time=day_start,
+            end_time=day_end,
+        )
+        indicator_stats = {}
+        if not indicator_stats_df.empty and "indicator_name" in indicator_stats_df.columns:
+            indicator_stats = indicator_stats_df["indicator_name"].fillna("UNKNOWN").value_counts().to_dict()
+        else:
+            indicator_stats = {}
         
         return {
             'market_overview': {
@@ -587,9 +619,7 @@ class RealtimeReportGenerator:
             if report_type:
                 reports = RealtimeReport.get_reports_by_type(report_type, limit)
             else:
-                reports = RealtimeReport.query.order_by(
-                    RealtimeReport.generated_at.desc()
-                ).limit(limit).all()
+                reports = RealtimeReport.list_reports(limit=limit)
             
             return {
                 'success': True,
@@ -607,7 +637,7 @@ class RealtimeReportGenerator:
     def get_report_by_id(self, report_id: int) -> Dict[str, Any]:
         """根据ID获取报告"""
         try:
-            report = RealtimeReport.query.get(report_id)
+            report = RealtimeReport.get_by_id(report_id)
             
             if not report:
                 return {
@@ -634,8 +664,7 @@ class RealtimeReportGenerator:
             if template_type:
                 templates = ReportTemplate.get_templates_by_type(template_type)
             else:
-                templates = ReportTemplate.query.filter_by(is_active=True)\
-                                              .order_by(ReportTemplate.created_at.desc()).all()
+                templates = ReportTemplate.list_templates(active_only=True)
             
             return {
                 'success': True,

--- a/app/services/realtime_risk_manager.py
+++ b/app/services/realtime_risk_manager.py
@@ -12,7 +12,6 @@ import logging
 from app.models.stock_basic import StockBasic
 from app.models.portfolio_position import PortfolioPosition
 from app.models.risk_alert import RiskAlert
-from app.extensions import db
 from app.services.data_reader import ParquetDataReader
 
 logger = logging.getLogger(__name__)
@@ -175,10 +174,12 @@ class RealtimeRiskManager:
                 take_profit_price = self._calculate_take_profit_price(
                     position, take_profit_method, take_profit_value
                 )
-                
+
                 # 更新止损止盈价格
-                position.stop_loss_price = stop_loss_price
-                position.take_profit_price = take_profit_price
+                position.update_risk_limits(
+                    stop_loss_price=stop_loss_price,
+                    take_profit_price=take_profit_price,
+                )
                 
                 # 检查是否触发
                 if position.is_stop_loss_triggered():
@@ -211,9 +212,6 @@ class RealtimeRiskManager:
                     'take_profit_distance': (take_profit_price - position.current_price) / position.current_price * 100
                 })
             
-            # 提交数据库更改
-            db.session.commit()
-            
             return {
                 'success': True,
                 'data': {
@@ -242,7 +240,7 @@ class RealtimeRiskManager:
             # 获取预警记录
             alerts = RiskAlert.get_active_alerts(
                 alert_level=alert_level
-            ) if active_only else RiskAlert.query.all()
+            ) if active_only else RiskAlert.list_all()
             
             # 如果指定了组合ID，需要过滤相关股票
             if portfolio_id:
@@ -287,12 +285,7 @@ class RealtimeRiskManager:
         """创建风险预警"""
         try:
             # 检查是否已存在相同的活跃预警
-            existing_alert = RiskAlert.query.filter_by(
-                ts_code=ts_code,
-                alert_type=alert_type,
-                is_active=True,
-                is_resolved=False
-            ).first()
+            existing_alert = RiskAlert.get_existing_active_alert(ts_code, alert_type)
             
             if existing_alert:
                 return {
@@ -302,10 +295,11 @@ class RealtimeRiskManager:
             
             # 获取当前价格和持仓信息
             current_price = self._get_current_price(ts_code)
-            position = PortfolioPosition.query.filter_by(
-                ts_code=ts_code,
-                is_active=True
-            ).first()
+            position = None
+            for candidate in PortfolioPosition.list_positions(active_only=True):
+                if candidate.ts_code == ts_code:
+                    position = candidate
+                    break
             
             # 创建预警
             alert = RiskAlert.create_alert(

--- a/app/services/realtime_trading_signal_engine.py
+++ b/app/services/realtime_trading_signal_engine.py
@@ -14,6 +14,7 @@ from app.models.trading_signal import TradingSignal
 from app.models.realtime_indicator import RealtimeIndicator
 from app.services.realtime_indicator_engine import RealtimeIndicatorEngine
 from app.services.data_reader import ParquetDataReader
+from app.services.parquet_event_store import ParquetEventStore
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,7 @@ class RealtimeTradingSignalEngine:
     def __init__(self):
         self.indicator_engine = RealtimeIndicatorEngine()
         self.minute_reader = ParquetDataReader().get_minute_reader()
+        self.event_store = ParquetEventStore()
         self.strategies = self._initialize_strategies()
     
     def _initialize_strategies(self):
@@ -107,26 +109,29 @@ class RealtimeTradingSignalEngine:
     def _get_indicators_data(self, ts_code: str, period_type: str, 
                            start_time: datetime, end_time: datetime) -> Dict:
         """获取技术指标数据"""
-        indicators = RealtimeIndicator.query.filter(
-            RealtimeIndicator.ts_code == ts_code,
-            RealtimeIndicator.period_type == period_type,
-            RealtimeIndicator.datetime >= start_time,
-            RealtimeIndicator.datetime <= end_time
-        ).order_by(RealtimeIndicator.datetime.asc()).all()
+        indicators = self.event_store.get_indicators_by_time_range(
+            ts_code=ts_code,
+            period_type=period_type,
+            start_time=start_time,
+            end_time=end_time,
+        )
         
         # 按指标名称分组
         indicators_dict = {}
-        for indicator in indicators:
-            if indicator.indicator_name not in indicators_dict:
-                indicators_dict[indicator.indicator_name] = []
-            
-            indicators_dict[indicator.indicator_name].append({
-                'datetime': indicator.datetime,
-                'value1': indicator.value1,
-                'value2': indicator.value2,
-                'value3': indicator.value3,
-                'value4': indicator.value4
-            })
+        if not indicators.empty:
+            indicators = indicators.sort_values("datetime").reset_index(drop=True)
+            for _, indicator in indicators.iterrows():
+                indicator_name = indicator.get("indicator_name")
+                if indicator_name not in indicators_dict:
+                    indicators_dict[indicator_name] = []
+
+                indicators_dict[indicator_name].append({
+                    'datetime': indicator.get('datetime'),
+                    'value1': indicator.get('value1'),
+                    'value2': indicator.get('value2'),
+                    'value3': indicator.get('value3'),
+                    'value4': indicator.get('value4')
+                })
         
         return indicators_dict
     

--- a/app/services/report_dispatch_service.py
+++ b/app/services/report_dispatch_service.py
@@ -1,9 +1,7 @@
-import json
 from typing import Any, Dict, List, Optional
 
 from loguru import logger
 
-from app.extensions import db
 from app.models.realtime_report import ReportSubscription, RealtimeReport
 from app.services.realtime_report_generator import RealtimeReportGenerator
 
@@ -46,7 +44,7 @@ class ReportDispatchService:
             return {"success": False, "subscription_id": subscription.id, "message": "模板不存在"}
 
         parameters = {}
-        schedule_config = json.loads(subscription.schedule_config) if subscription.schedule_config else {}
+        schedule_config = subscription.schedule_config if isinstance(subscription.schedule_config, dict) else {}
         if isinstance(schedule_config, dict):
             parameters.update(schedule_config.get("parameters") or {})
 
@@ -65,20 +63,17 @@ class ReportDispatchService:
             }
 
         report_id = result.get("data", {}).get("report_id")
-        report = RealtimeReport.query.get(report_id) if report_id else None
+        report = RealtimeReport.get_by_id(report_id) if report_id else None
         if report is not None:
-            report.report_data = json.dumps({
-                **(json.loads(report.report_data) if report.report_data else {}),
-                "dispatch": {
-                    "subscription_id": subscription.id,
-                    "channels": json.loads(subscription.notification_channels) if subscription.notification_channels else ["log"],
-                    "subscriber_email": subscription.subscriber_email,
-                    "subscriber_phone": subscription.subscriber_phone,
-                },
-            })
+            channels = subscription.notification_channels if isinstance(subscription.notification_channels, list) else ["log"]
+            report.attach_dispatch_metadata(
+                subscription_id=subscription.id,
+                channels=channels,
+                subscriber_email=subscription.subscriber_email,
+                subscriber_phone=subscription.subscriber_phone,
+            )
 
         subscription.update_send_time()
-        db.session.commit()
 
         logger.info(f"订阅 {subscription.id} 分发完成")
         return {

--- a/app/services/sql_generator.py
+++ b/app/services/sql_generator.py
@@ -307,7 +307,7 @@ class TemplateManager:
         """加载查询模板"""
         try:
             # 从数据库加载模板
-            db_templates = QueryTemplate.query.filter_by(is_active=True).all()
+            db_templates = QueryTemplate.list_active()
             templates = {}
             
             for template in db_templates:
@@ -503,7 +503,7 @@ class TemplateManager:
     def _update_template_usage(self, template_id: str):
         """更新模板使用次数"""
         try:
-            template = QueryTemplate.query.get(template_id)
+            template = QueryTemplate.get_by_id(template_id)
             if template:
                 template.increment_usage()
         except Exception:

--- a/app/services/stock_service.py
+++ b/app/services/stock_service.py
@@ -394,7 +394,7 @@ class StockService:
     
     @staticmethod
     def screen_stocks(criteria: Dict):
-        """基于 Parquet 大宽表的增强筛选（原 MySQL JOIN 已迁移）"""
+        """基于 Parquet 大宽表的增强筛选（原 JOIN 逻辑已迁移）"""
         try:
             def _normalize(value):
                 if value is None:

--- a/app/services/text2sql_engine.py
+++ b/app/services/text2sql_engine.py
@@ -3,9 +3,12 @@ Text2SQL核心引擎
 整合自然语言处理、SQL生成和查询执行功能
 """
 
+import logging
 import time
 import traceback
 from typing import Dict, List, Any, Optional
+
+logger = logging.getLogger(__name__)
 from flask import request
 from sqlalchemy import text
 from app.extensions import db
@@ -160,9 +163,7 @@ class Text2SQLEngine:
     def get_query_history(self, limit: int = 10) -> List[Dict[str, Any]]:
         """获取查询历史"""
         try:
-            histories = QueryHistory.query.order_by(
-                QueryHistory.created_at.desc()
-            ).limit(limit).all()
+            histories = QueryHistory.list_recent(limit=limit)
             
             return [history.to_dict() for history in histories]
             
@@ -197,7 +198,7 @@ class Text2SQLEngine:
             user_ip = request.remote_addr if request else None
             user_agent = request.headers.get('User-Agent') if request else None
             
-            history = QueryHistory(
+            QueryHistory.create_history(
                 user_query=user_query,
                 intent=intent_result.get('intent', {}).get('name'),
                 entities=intent_result.get('entities'),
@@ -210,13 +211,9 @@ class Text2SQLEngine:
                 user_ip=user_ip,
                 user_agent=user_agent
             )
-            
-            db.session.add(history)
-            db.session.commit()
-            
         except Exception as e:
             # 记录历史失败不应该影响主流程
-            db.session.rollback()
+            logger.warning(f"保存查询历史失败: {e}")
     
     def _try_llm_enhancement(self, user_query: str, intent_result: Dict[str, Any]) -> Optional[str]:
         """尝试使用大模型增强SQL生成"""

--- a/app/services/websocket_push_service.py
+++ b/app/services/websocket_push_service.py
@@ -21,6 +21,7 @@ from app.services.realtime_indicator_engine import RealtimeIndicatorEngine
 from app.services.realtime_trading_signal_engine import RealtimeTradingSignalEngine
 from app.services.realtime_monitor_service import RealtimeMonitorService
 from app.services.realtime_risk_manager import RealtimeRiskManager
+from app.services.parquet_event_store import ParquetEventStore
 from app.websocket.websocket_events import (
     broadcast_market_data, broadcast_indicators, broadcast_signals,
     broadcast_monitor_data, broadcast_risk_alert, broadcast_portfolio_update,
@@ -40,6 +41,7 @@ class WebSocketPushService:
         self.signal_engine = RealtimeTradingSignalEngine()
         self.monitor_service = RealtimeMonitorService()
         self.risk_manager = RealtimeRiskManager()
+        self.event_store = ParquetEventStore()
         
         self.is_running = False
         self.push_thread = None
@@ -159,22 +161,28 @@ class WebSocketPushService:
         """推送技术指标数据"""
         try:
             # 获取最新指标数据
-            latest_indicators = RealtimeIndicator.query.filter(
-                RealtimeIndicator.datetime >= datetime.now() - timedelta(minutes=5)
-            ).limit(50).all()
+            latest_indicators = self.event_store.get_latest_indicators(
+                ts_code=None,
+                period_type=None,
+                indicator_names=None,
+                limit=50,
+            )
             
             # 按股票分组
             indicators_by_stock = {}
-            for indicator in latest_indicators:
-                ts_code = indicator.ts_code
+            for _, indicator in latest_indicators.iterrows():
+                ts_code = indicator.get('ts_code')
                 if ts_code not in indicators_by_stock:
                     indicators_by_stock[ts_code] = []
                 
                 indicators_by_stock[ts_code].append({
-                    'indicator_name': indicator.indicator_name,
-                    'period_type': indicator.period_type,
-                    'value': indicator.value,
-                    'datetime': indicator.datetime.isoformat()
+                    'indicator_name': indicator.get('indicator_name'),
+                    'period_type': indicator.get('period_type'),
+                    'value1': indicator.get('value1'),
+                    'value2': indicator.get('value2'),
+                    'value3': indicator.get('value3'),
+                    'value4': indicator.get('value4'),
+                    'datetime': indicator.get('datetime').isoformat() if hasattr(indicator.get('datetime'), 'isoformat') else indicator.get('datetime')
                 })
             
             # 推送指标数据
@@ -194,25 +202,26 @@ class WebSocketPushService:
         """推送交易信号"""
         try:
             # 获取最新信号
-            latest_signals = TradingSignal.query.filter(
-                TradingSignal.created_at >= datetime.now() - timedelta(minutes=10),
-                TradingSignal.status == 'active'
-            ).limit(20).all()
+            latest_signals = self.event_store.get_recent_signals(
+                since=datetime.now() - timedelta(minutes=10),
+                limit=20,
+                status='ACTIVE',
+            )
             
             # 按股票分组
             signals_by_stock = {}
-            for signal in latest_signals:
-                ts_code = signal.ts_code
+            for _, signal in latest_signals.iterrows():
+                ts_code = signal.get('ts_code')
                 if ts_code not in signals_by_stock:
                     signals_by_stock[ts_code] = []
                 
                 signals_by_stock[ts_code].append({
-                    'strategy_name': signal.strategy_name,
-                    'signal_type': signal.signal_type,
-                    'signal_strength': signal.signal_strength,
-                    'confidence': signal.confidence,
-                    'created_at': signal.created_at.isoformat(),
-                    'parameters': signal.parameters
+                    'strategy_name': signal.get('strategy_name'),
+                    'signal_type': signal.get('signal_type'),
+                    'signal_strength': signal.get('signal_strength'),
+                    'confidence': signal.get('confidence'),
+                    'created_at': signal.get('datetime').isoformat() if hasattr(signal.get('datetime'), 'isoformat') else signal.get('datetime'),
+                    'parameters': signal.get('strategy_params')
                 })
             
             # 推送信号数据
@@ -251,10 +260,7 @@ class WebSocketPushService:
         """推送风险预警"""
         try:
             # 获取最新风险预警
-            latest_alerts = RiskAlert.query.filter(
-                RiskAlert.created_at >= datetime.now() - timedelta(minutes=10),
-                RiskAlert.status == 'active'
-            ).limit(10).all()
+            latest_alerts = RiskAlert.get_recent_alerts(minutes=10, active_only=True, limit=10)
             
             for alert in latest_alerts:
                 alert_data = {
@@ -303,10 +309,7 @@ class WebSocketPushService:
     def _get_active_portfolio_ids(self) -> List[str]:
         """获取存在真实持仓的活跃投资组合ID。"""
         try:
-            rows = db.session.query(PortfolioPosition.portfolio_id).filter(
-                PortfolioPosition.is_active.is_(True)
-            ).distinct().all()
-            return [row[0] for row in rows if row and row[0]]
+            return PortfolioPosition.list_active_portfolio_ids()
         except Exception as e:
             logger.error(f"获取活跃投资组合失败: {e}")
             return []

--- a/app/templates/realtime_analysis/indicators.html
+++ b/app/templates/realtime_analysis/indicators.html
@@ -4,40 +4,297 @@
 
 {% block extra_css %}
     <style>
-        .status-indicator {
-            width: 10px;
-            height: 10px;
-            border-radius: 50%;
-            display: inline-block;
-            margin-right: 5px;
+        /* ===== 页面头部 ===== */
+        .page-hero {
+            background: linear-gradient(135deg, rgba(99,102,241,0.06) 0%, rgba(6,182,212,0.04) 100%);
+            border: 1px solid var(--obs-border-light);
+            border-radius: var(--border-radius-lg);
+            padding: 1.25rem 1.5rem;
+            position: relative;
+            overflow: hidden;
         }
-        .status-success { background-color: var(--obs-success); }
-        .status-warning { background-color: var(--obs-warning); }
-        .status-danger { background-color: var(--obs-danger); }
-        .chart-container {
-            height: 400px;
-            margin: 20px 0;
+        .page-hero::before {
+            content: '';
+            position: absolute;
+            top: 0; left: 10%; right: 10%;
+            height: 1px;
+            background: linear-gradient(90deg, transparent, rgba(99,102,241,0.35), transparent);
         }
-        .indicator-card {
-            transition: var(--transition-fast);
-            cursor: pointer;
+        .page-hero h4 {
+            font-weight: 700;
+            font-size: 1.15rem;
+            color: var(--obs-text);
+            margin: 0;
         }
-        .indicator-card:hover {
-            border-color: var(--obs-border-hover);
+        .page-hero p {
+            color: var(--obs-text-muted);
+            font-size: 0.8rem;
+            margin: 0.25rem 0 0;
         }
-        .progress-container {
-            display: none;
-        }
-        .log-container {
-            max-height: 300px;
-            overflow-y: auto;
-            background-color: var(--obs-surface);
+
+        /* ===== Tab 导航增强 ===== */
+        .indicator-tabs {
+            display: flex;
+            gap: 4px;
+            background: var(--obs-surface-alt);
             border: 1px solid var(--obs-border);
-            border-radius: 0.375rem;
-            padding: 10px;
-            font-family: 'Courier New', monospace;
-            font-size: 0.875rem;
+            border-radius: var(--border-radius-lg);
+            padding: 4px;
+        }
+        .indicator-tabs .nav-link {
+            color: var(--obs-text-muted);
+            font-size: 0.8rem;
+            font-weight: 500;
+            padding: 0.5rem 1rem;
+            border-radius: var(--border-radius);
+            border: none;
+            transition: var(--transition-fast);
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .indicator-tabs .nav-link:hover {
             color: var(--obs-text-secondary);
+            background: rgba(99,102,241,0.05);
+        }
+        .indicator-tabs .nav-link.active {
+            background: var(--obs-primary);
+            color: #fff;
+            box-shadow: 0 2px 8px rgba(99,102,241,0.3);
+        }
+        .indicator-tabs .nav-link i {
+            font-size: 0.75rem;
+        }
+
+        /* ===== 图表容器 ===== */
+        .chart-container {
+            height: 420px;
+            margin: 0;
+        }
+
+        /* ===== 指标结果卡片 ===== */
+        .indicator-result-card {
+            background: var(--obs-surface);
+            border: 1px solid var(--obs-border);
+            border-radius: var(--border-radius-lg);
+            overflow: hidden;
+            transition: var(--transition-normal);
+        }
+        .indicator-result-card:hover {
+            border-color: var(--obs-border-hover);
+            box-shadow: 0 0 24px rgba(99,102,241,0.06);
+        }
+        .indicator-result-header {
+            padding: 0.6rem 0.9rem;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            border-bottom: 1px solid var(--obs-border);
+            background: var(--obs-surface-alt);
+        }
+        .indicator-result-header h6 {
+            margin: 0;
+            font-weight: 600;
+            font-size: 0.85rem;
+            color: var(--obs-text);
+        }
+        .indicator-badge {
+            font-size: 0.65rem;
+            padding: 2px 8px;
+            border-radius: 10px;
+            font-weight: 500;
+        }
+        .indicator-badge-success {
+            background: var(--obs-success-bg);
+            color: var(--obs-success-light);
+        }
+        .indicator-badge-error {
+            background: var(--obs-danger-bg);
+            color: var(--obs-danger-light);
+        }
+        .indicator-result-body {
+            padding: 0.75rem 0.9rem;
+        }
+
+        /* ===== 值列表 ===== */
+        .value-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 3px 0;
+            font-size: 0.8rem;
+        }
+        .value-row .label { color: var(--obs-text-muted); }
+        .value-row .value {
+            font-weight: 600;
+            font-variant-numeric: tabular-nums;
+            color: var(--obs-text);
+        }
+
+        /* ===== 图表卡片 ===== */
+        .chart-card {
+            background: var(--obs-surface);
+            border: 1px solid var(--obs-border);
+            border-radius: var(--border-radius-lg);
+            overflow: hidden;
+        }
+        .chart-card-header {
+            padding: 0.6rem 1rem;
+            border-bottom: 1px solid var(--obs-border);
+            background: var(--obs-surface-alt);
+        }
+        .chart-card-header h6 {
+            margin: 0;
+            font-size: 0.82rem;
+            font-weight: 600;
+            color: var(--obs-text-secondary);
+        }
+        .chart-card-body {
+            padding: 0.5rem;
+        }
+
+        /* ===== 统计面板 ===== */
+        .stat-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 12px;
+        }
+        .stat-block {
+            text-align: center;
+            padding: 1rem 0.5rem;
+            background: var(--obs-surface-alt);
+            border-radius: var(--border-radius);
+            border: 1px solid var(--obs-border);
+        }
+        .stat-block .stat-value {
+            font-size: 1.6rem;
+            font-weight: 700;
+            font-variant-numeric: tabular-nums;
+        }
+        .stat-block .stat-label {
+            font-size: 0.72rem;
+            color: var(--obs-text-muted);
+            margin-top: 2px;
+        }
+
+        /* ===== 指标分布条 ===== */
+        .distribution-row {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 4px 0;
+            font-size: 0.8rem;
+        }
+        .distribution-bar {
+            flex: 1;
+            height: 4px;
+            background: var(--obs-border);
+            border-radius: 2px;
+            margin: 0 10px;
+            overflow: hidden;
+        }
+        .distribution-bar-fill {
+            height: 100%;
+            border-radius: 2px;
+            background: var(--obs-primary);
+            transition: width 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+        }
+
+        /* ===== 支持的指标标签 ===== */
+        .indicator-tag {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            background: var(--obs-surface-alt);
+            border: 1px solid var(--obs-border);
+            border-radius: var(--border-radius);
+            padding: 6px 12px;
+            margin: 3px;
+            font-size: 0.78rem;
+            transition: var(--transition-fast);
+        }
+        .indicator-tag:hover {
+            border-color: var(--obs-border-hover);
+            background: var(--obs-primary-bg);
+        }
+        .indicator-tag .tag-code {
+            color: var(--obs-primary-light);
+            font-weight: 600;
+        }
+        .indicator-tag .tag-name {
+            color: var(--obs-text-secondary);
+        }
+
+        /* ===== 空状态 ===== */
+        .empty-state {
+            text-align: center;
+            padding: 3rem 1rem;
+            color: var(--obs-text-muted);
+        }
+        .empty-state i {
+            font-size: 2.5rem;
+            opacity: 0.3;
+            margin-bottom: 1rem;
+        }
+        .empty-state p {
+            font-size: 0.85rem;
+            margin: 0;
+        }
+
+        /* ===== 进度条 ===== */
+        .progress-container { display: none; }
+        .log-container {
+            max-height: 200px;
+            overflow-y: auto;
+            background: var(--obs-surface-alt);
+            border: 1px solid var(--obs-border);
+            border-radius: var(--border-radius);
+            padding: 8px 10px;
+            font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+            font-size: 0.75rem;
+            color: var(--obs-text-muted);
+            line-height: 1.6;
+        }
+        .progress { height: 6px; border-radius: 3px; background: var(--obs-border); }
+        .progress-bar { background: var(--obs-primary); border-radius: 3px; transition: width 0.3s ease; }
+
+        /* ===== 摘要条 ===== */
+        .summary-bar {
+            background: var(--obs-surface-alt);
+            border: 1px solid var(--obs-border);
+            border-radius: var(--border-radius);
+            padding: 0.65rem 1rem;
+            display: flex;
+            gap: 1.5rem;
+            flex-wrap: wrap;
+            align-items: center;
+        }
+        .summary-item {
+            font-size: 0.78rem;
+            color: var(--obs-text-secondary);
+        }
+        .summary-item strong {
+            color: var(--obs-text);
+            font-variant-numeric: tabular-nums;
+        }
+
+        /* ===== 对比信息栏 ===== */
+        .compare-info {
+            background: var(--obs-info-bg);
+            border: 1px solid rgba(6,182,212,0.15);
+            border-radius: var(--border-radius);
+            padding: 0.6rem 1rem;
+            font-size: 0.8rem;
+            color: var(--obs-info-light);
+        }
+
+        /* ===== 动画 ===== */
+        @keyframes fadeInUp {
+            from { opacity: 0; transform: translateY(10px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+        .fade-in-up {
+            animation: fadeInUp 0.35s cubic-bezier(0.4, 0, 0.2, 1) forwards;
         }
     </style>
 {% endblock %}
@@ -45,69 +302,58 @@
 {% block content %}
     <div class="container-fluid">
         <!-- 页面标题 -->
-        <div class="row mb-4">
+        <div class="row mb-3">
             <div class="col-12">
-                <div class="card">
-                    <div class="card-header">
-                        <h4 class="mb-0">
-                            <i class="fas fa-chart-bar me-2"></i>实时技术指标分析
-                        </h4>
-                    </div>
-                    <div class="card-body">
-                        <p class="mb-0">当前页面基于已入库的 Baostock 分钟数据计算指标。</p>
-                    </div>
+                <div class="page-hero">
+                    <h4><i class="fas fa-chart-bar me-2" style="color:var(--obs-primary-light)"></i>实时技术指标分析</h4>
+                    <p>基于已入库的分钟数据计算技术指标，支持多周期对比与多股票分析</p>
                 </div>
             </div>
         </div>
 
-        <!-- 功能导航 -->
-        <div class="row mb-4">
+        <!-- Tab 导航 -->
+        <div class="row mb-3">
             <div class="col-12">
-                <ul class="nav nav-pills" id="indicatorTabs" role="tablist">
+                <ul class="nav indicator-tabs" id="indicatorTabs" role="tablist">
                     <li class="nav-item" role="presentation">
                         <button class="nav-link active" id="calculate-tab" data-bs-toggle="pill" data-bs-target="#calculate" type="button" role="tab">
-                            <i class="fas fa-calculator me-2"></i>指标计算
+                            <i class="fas fa-calculator"></i>指标计算
                         </button>
                     </li>
                     <li class="nav-item" role="presentation">
                         <button class="nav-link" id="multi-period-tab" data-bs-toggle="pill" data-bs-target="#multi-period" type="button" role="tab">
-                            <i class="fas fa-layer-group me-2"></i>多周期分析
+                            <i class="fas fa-layer-group"></i>多周期分析
                         </button>
                     </li>
                     <li class="nav-item" role="presentation">
                         <button class="nav-link" id="compare-tab" data-bs-toggle="pill" data-bs-target="#compare" type="button" role="tab">
-                            <i class="fas fa-balance-scale me-2"></i>指标对比
+                            <i class="fas fa-code-branch"></i>指标对比
                         </button>
                     </li>
                     <li class="nav-item" role="presentation">
                         <button class="nav-link" id="stats-tab" data-bs-toggle="pill" data-bs-target="#stats" type="button" role="tab">
-                            <i class="fas fa-chart-pie me-2"></i>统计信息
+                            <i class="fas fa-th-large"></i>统计信息
                         </button>
                     </li>
                 </ul>
             </div>
         </div>
 
-        <!-- 功能面板 -->
+        <!-- Tab 内容 -->
         <div class="tab-content" id="indicatorTabsContent">
             <!-- 指标计算面板 -->
             <div class="tab-pane fade show active" id="calculate" role="tabpanel">
                 <div class="row">
-                    <!-- 计算配置 -->
                     <div class="col-md-4">
-                        <div class="card">
-                            <div class="card-header">
-                                <h5 class="mb-0">计算配置</h5>
-                            </div>
+                        <div class="card mb-3">
+                            <div class="card-header"><h5 class="mb-0" style="font-size:0.9rem">计算配置</h5></div>
                             <div class="card-body">
                                 <form id="calculateForm">
                                     <div class="mb-3">
                                         <label for="stockCode" class="form-label">股票代码</label>
-                                        <select class="form-select" id="stockCode" required>
-                                            <option value="">请选择股票</option>
-                                        </select>
+                                        <input type="text" class="form-control" id="stockCode" placeholder="如 300502" required>
+                                        <small class="form-text">支持 300502、300502.SZ、sz.300502，输入 6 位数字会自动识别沪深</small>
                                     </div>
-                                    
                                     <div class="mb-3">
                                         <label for="periodType" class="form-label">周期类型</label>
                                         <select class="form-select" id="periodType">
@@ -117,31 +363,26 @@
                                             <option value="60min">60分钟</option>
                                         </select>
                                     </div>
-                                    
                                     <div class="mb-3">
                                         <label for="lookbackDays" class="form-label">回看天数</label>
                                         <input type="number" class="form-control" id="lookbackDays" value="30" min="1" max="90">
                                     </div>
-                                    
                                     <div class="mb-3">
                                         <label class="form-label">选择指标</label>
-                                        <div id="indicatorCheckboxes">
-                                            <!-- 动态加载指标选项 -->
+                                        <div class="d-flex justify-content-between align-items-center mb-1">
+                                            <small class="form-text">已选 <span id="indicatorCount">0</span> 项</small>
+                                            <button type="button" class="btn btn-sm btn-outline-light py-0 px-2" style="font-size:0.72rem;border-radius:4px" onclick="toggleAll('indicatorCheckboxes','indicatorCount')">全选/取消</button>
                                         </div>
+                                        <div id="indicatorCheckboxes"></div>
                                     </div>
-                                    
-                                    <button type="submit" class="btn btn-primary w-100">
+                                    <button type="submit" class="btn btn-primary-financial btn-financial w-100">
                                         <i class="fas fa-play me-2"></i>开始计算
                                     </button>
                                 </form>
                             </div>
                         </div>
-                        
-                        <!-- 进度显示 -->
-                        <div class="card mt-3 progress-container" id="progressContainer">
-                            <div class="card-header">
-                                <h6 class="mb-0">计算进度</h6>
-                            </div>
+                        <div class="card progress-container" id="progressContainer">
+                            <div class="card-header"><h6 class="mb-0" style="font-size:0.82rem">计算进度</h6></div>
                             <div class="card-body">
                                 <div class="progress mb-2">
                                     <div class="progress-bar" id="progressBar" role="progressbar" style="width: 0%"></div>
@@ -150,17 +391,13 @@
                             </div>
                         </div>
                     </div>
-                    
-                    <!-- 计算结果 -->
                     <div class="col-md-8">
                         <div class="card">
-                            <div class="card-header">
-                                <h5 class="mb-0">计算结果</h5>
-                            </div>
+                            <div class="card-header"><h5 class="mb-0" style="font-size:0.9rem">计算结果</h5></div>
                             <div class="card-body">
                                 <div id="calculateResults">
-                                    <div class="text-center text-muted py-5">
-                                        <i class="fas fa-chart-line fa-3x mb-3"></i>
+                                    <div class="empty-state">
+                                        <i class="fas fa-chart-line"></i>
                                         <p>请选择股票和指标开始计算</p>
                                     </div>
                                 </div>
@@ -169,24 +406,20 @@
                     </div>
                 </div>
             </div>
-            
+
             <!-- 多周期分析面板 -->
             <div class="tab-pane fade" id="multi-period" role="tabpanel">
                 <div class="row">
                     <div class="col-md-4">
                         <div class="card">
-                            <div class="card-header">
-                                <h5 class="mb-0">多周期配置</h5>
-                            </div>
+                            <div class="card-header"><h5 class="mb-0" style="font-size:0.9rem">多周期配置</h5></div>
                             <div class="card-body">
                                 <form id="multiPeriodForm">
                                     <div class="mb-3">
                                         <label for="multiStockCode" class="form-label">股票代码</label>
-                                        <select class="form-select" id="multiStockCode" required>
-                                            <option value="">请选择股票</option>
-                                        </select>
+                                        <input type="text" class="form-control" id="multiStockCode" placeholder="如 300502" required>
+                                        <small class="form-text">支持 300502、300502.SZ、sz.300502，输入 6 位数字会自动识别沪深</small>
                                     </div>
-                                    
                                     <div class="mb-3">
                                         <label class="form-label">选择周期</label>
                                         <div class="form-check">
@@ -206,31 +439,28 @@
                                             <label class="form-check-label" for="period60min">60分钟</label>
                                         </div>
                                     </div>
-                                    
                                     <div class="mb-3">
                                         <label class="form-label">选择指标</label>
-                                        <div id="multiIndicatorCheckboxes">
-                                            <!-- 动态加载指标选项 -->
+                                        <div class="d-flex justify-content-between align-items-center mb-1">
+                                            <small class="form-text">已选 <span id="multiIndicatorCount">0</span> 项</small>
+                                            <button type="button" class="btn btn-sm btn-outline-light py-0 px-2" style="font-size:0.72rem;border-radius:4px" onclick="toggleAll('multiIndicatorCheckboxes','multiIndicatorCount')">全选/取消</button>
                                         </div>
+                                        <div id="multiIndicatorCheckboxes"></div>
                                     </div>
-                                    
-                                    <button type="submit" class="btn btn-success w-100">
+                                    <button type="submit" class="btn btn-success-financial btn-financial w-100">
                                         <i class="fas fa-layer-group me-2"></i>多周期分析
                                     </button>
                                 </form>
                             </div>
                         </div>
                     </div>
-                    
                     <div class="col-md-8">
                         <div class="card">
-                            <div class="card-header">
-                                <h5 class="mb-0">多周期分析结果</h5>
-                            </div>
+                            <div class="card-header"><h5 class="mb-0" style="font-size:0.9rem">多周期分析结果</h5></div>
                             <div class="card-body">
                                 <div id="multiPeriodResults">
-                                    <div class="text-center text-muted py-5">
-                                        <i class="fas fa-layer-group fa-3x mb-3"></i>
+                                    <div class="empty-state">
+                                        <i class="fas fa-layer-group"></i>
                                         <p>请选择股票和周期开始分析</p>
                                     </div>
                                 </div>
@@ -239,25 +469,20 @@
                     </div>
                 </div>
             </div>
-            
+
             <!-- 指标对比面板 -->
             <div class="tab-pane fade" id="compare" role="tabpanel">
                 <div class="row">
                     <div class="col-md-4">
                         <div class="card">
-                            <div class="card-header">
-                                <h5 class="mb-0">对比配置</h5>
-                            </div>
+                            <div class="card-header"><h5 class="mb-0" style="font-size:0.9rem">对比配置</h5></div>
                             <div class="card-body">
                                 <form id="compareForm">
                                     <div class="mb-3">
-                                        <label for="compareStocks" class="form-label">股票代码（多选）</label>
-                                        <select class="form-select" id="compareStocks" multiple size="5" required>
-                                            <!-- 动态加载股票选项 -->
-                                        </select>
-                                        <small class="form-text text-muted">按住Ctrl键可多选</small>
+                                        <label for="compareStocks" class="form-label">股票代码（多个用逗号分隔）</label>
+                                        <input type="text" class="form-control" id="compareStocks" placeholder="如 300502,600519" required>
+                                        <small class="form-text">支持 300502、300502.SZ、sz.300502，多个代码用逗号分隔</small>
                                     </div>
-                                    
                                     <div class="mb-3">
                                         <label for="comparePeriod" class="form-label">周期类型</label>
                                         <select class="form-select" id="comparePeriod">
@@ -267,31 +492,26 @@
                                             <option value="60min">60分钟</option>
                                         </select>
                                     </div>
-                                    
                                     <div class="mb-3">
                                         <label for="compareIndicator" class="form-label">对比指标</label>
                                         <select class="form-select" id="compareIndicator" required>
-                                            <!-- 动态加载指标选项 -->
+                                            <option value="">请选择指标</option>
                                         </select>
                                     </div>
-                                    
-                                    <button type="submit" class="btn btn-warning w-100">
-                                        <i class="fas fa-balance-scale me-2"></i>开始对比
+                                    <button type="submit" class="btn btn-warning-financial btn-financial w-100">
+                                        <i class="fas fa-code-branch me-2"></i>开始对比
                                     </button>
                                 </form>
                             </div>
                         </div>
                     </div>
-                    
                     <div class="col-md-8">
                         <div class="card">
-                            <div class="card-header">
-                                <h5 class="mb-0">指标对比结果</h5>
-                            </div>
+                            <div class="card-header"><h5 class="mb-0" style="font-size:0.9rem">指标对比结果</h5></div>
                             <div class="card-body">
                                 <div id="compareResults">
-                                    <div class="text-center text-muted py-5">
-                                        <i class="fas fa-balance-scale fa-3x mb-3"></i>
+                                    <div class="empty-state">
+                                        <i class="fas fa-code-branch"></i>
                                         <p>请选择股票和指标开始对比</p>
                                     </div>
                                 </div>
@@ -300,52 +520,44 @@
                     </div>
                 </div>
             </div>
-            
+
             <!-- 统计信息面板 -->
             <div class="tab-pane fade" id="stats" role="tabpanel">
-                <div class="row">
+                <div class="row mb-3">
                     <div class="col-md-6">
                         <div class="card">
-                            <div class="card-header">
-                                <h5 class="mb-0">指标统计概览</h5>
-                            </div>
+                            <div class="card-header"><h5 class="mb-0" style="font-size:0.9rem">指标统计概览</h5></div>
                             <div class="card-body">
                                 <div id="indicatorStats">
-                                    <div class="text-center">
-                                        <div class="spinner-border" role="status">
-                                            <span class="visually-hidden">加载中...</span>
-                                        </div>
+                                    <div class="text-center py-4">
+                                        <div class="loading-spinner"></div>
+                                        <div class="loading-text mt-2">加载中...</div>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                    
                     <div class="col-md-6">
                         <div class="card">
-                            <div class="card-header">
-                                <h5 class="mb-0">支持的指标</h5>
-                            </div>
+                            <div class="card-header"><h5 class="mb-0" style="font-size:0.9rem">支持的指标</h5></div>
                             <div class="card-body">
                                 <div id="supportedIndicators">
-                                    <div class="text-center">
-                                        <div class="spinner-border" role="status">
-                                            <span class="visually-hidden">加载中...</span>
-                                        </div>
+                                    <div class="text-center py-4">
+                                        <div class="loading-spinner"></div>
+                                        <div class="loading-text mt-2">加载中...</div>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </div>
                 </div>
-                
-                <div class="row mt-4">
+                <div class="row">
                     <div class="col-12">
-                        <div class="card">
-                            <div class="card-header">
-                                <h5 class="mb-0">指标分布图表</h5>
+                        <div class="chart-card">
+                            <div class="chart-card-header">
+                                <h6><i class="fas fa-chart-pie me-2"></i>指标分布图表</h6>
                             </div>
-                            <div class="card-body">
+                            <div class="chart-card-body">
                                 <div id="indicatorChart" class="chart-container"></div>
                             </div>
                         </div>
@@ -356,116 +568,165 @@
     </div>
 
     <script>
-        // 全局变量
+        // ===== 全局变量 =====
         let supportedIndicators = [];
         let availableStocks = [];
-        
-        // 页面加载完成后初始化
-        document.addEventListener('DOMContentLoaded', function() {
-            console.log('页面初始化开始...');
-            
-            try {
-                loadSupportedIndicators();
-                loadAvailableStocks();
-                loadIndicatorStats();
-                
-                // 绑定表单事件
-                const calculateForm = document.getElementById('calculateForm');
-                const multiPeriodForm = document.getElementById('multiPeriodForm');
-                const compareForm = document.getElementById('compareForm');
-                
-                if (calculateForm) {
-                    calculateForm.addEventListener('submit', handleCalculate);
-                    console.log('计算表单事件绑定成功');
-                } else {
-                    console.error('找不到calculateForm元素');
-                }
-                
-                if (multiPeriodForm) {
-                    multiPeriodForm.addEventListener('submit', handleMultiPeriod);
-                    console.log('多周期表单事件绑定成功');
-                } else {
-                    console.error('找不到multiPeriodForm元素');
-                }
-                
-                if (compareForm) {
-                    compareForm.addEventListener('submit', handleCompare);
-                    console.log('对比表单事件绑定成功');
-                } else {
-                    console.error('找不到compareForm元素');
-                }
-                
-                console.log('页面初始化完成');
-            } catch (error) {
-                console.error('页面初始化失败:', error);
+
+        // ===== 股票代码标准化：6位数字 → ts_code =====
+        function normalizeStockCode(input) {
+            if (!input) return '';
+            let code = input.trim().toUpperCase();
+            // 兼容 "SZ.300502" / "sz.300502" 这类输入，统一转成 "300502.SZ"
+            const prefixMatch = code.match(/^(SZ|SH)\.(\d{6})$/);
+            if (prefixMatch) {
+                return `${prefixMatch[2]}.${prefixMatch[1]}`;
             }
+            // 去掉已有的后缀
+            code = code.replace(/\.(SZ|SH|sz|sh)$/, '');
+            // 去掉空格和常见分隔符
+            code = code.replace(/[\s\-\/\\]+/g, '');
+            if (!/^\d{6}$/.test(code)) return code; // 非6位数字原样返回
+            // 6开头 → 上海，其余 → 深圳
+            const market = code.startsWith('6') ? 'SH' : 'SZ';
+            return `${code}.${market}`;
+        }
+
+        // ===== ECharts 金融主题配色 =====
+        const CHART_COLORS = ['#6366f1','#22d3ee','#4ade80','#fbbf24','#f87171','#a78bfa','#34d399','#fb923c'];
+        const AREA_COLORS = [
+            'rgba(99,102,241,0.12)','rgba(34,211,238,0.12)','rgba(74,222,128,0.12)',
+            'rgba(251,191,36,0.12)','rgba(248,113,113,0.12)','rgba(167,139,250,0.12)'
+        ];
+
+        // ===== 工具：创建金融风格 ECharts option 的公共部分 =====
+        function baseChartOption(title, categories) {
+            return {
+                backgroundColor: 'transparent',
+                title: {
+                    text: title || '',
+                    left: 12,
+                    top: 8,
+                    textStyle: {
+                        color: '#e2e8f0',
+                        fontWeight: 600,
+                        fontSize: 13,
+                        fontFamily: "'DM Sans','PingFang SC',sans-serif"
+                    }
+                },
+                tooltip: {
+                    trigger: 'axis',
+                    backgroundColor: 'rgba(30,41,59,0.95)',
+                    borderColor: '#334155',
+                    borderWidth: 1,
+                    textStyle: { color: '#e2e8f0', fontSize: 12 },
+                    axisPointer: {
+                        type: 'cross',
+                        crossStyle: { color: '#64748b' },
+                        lineStyle: { color: 'rgba(99,102,241,0.4)', type: 'dashed' }
+                    }
+                },
+                legend: {
+                    top: 32,
+                    textStyle: { color: '#94a3b8', fontSize: 11 },
+                    itemWidth: 14, itemHeight: 8, itemGap: 16
+                },
+                grid: {
+                    left: 12, right: 16, top: 72, bottom: 12,
+                    containLabel: true
+                },
+                xAxis: {
+                    type: 'category',
+                    data: categories || [],
+                    boundaryGap: false,
+                    axisLine: { lineStyle: { color: '#334155' } },
+                    axisTick: { show: false },
+                    axisLabel: {
+                        color: '#64748b', fontSize: 10,
+                        formatter: function(v) {
+                            if (!v) return '';
+                            // 只显示 HH:mm，每天第一个点显示 MM-DD
+                            var parts = v.split(' ');
+                            var time = parts.length > 1 ? parts[1].substring(0, 5) : v;
+                            return time;
+                        }
+                    },
+                    splitLine: { show: false }
+                },
+                yAxis: {
+                    type: 'value',
+                    scale: true,
+                    axisLine: { show: false },
+                    axisTick: { show: false },
+                    axisLabel: { color: '#64748b', fontSize: 10 },
+                    splitLine: { lineStyle: { color: 'rgba(51,65,85,0.4)', type: 'dashed' } }
+                }
+            };
+        }
+
+        // ===== 页面初始化 =====
+        document.addEventListener('DOMContentLoaded', function() {
+            loadSupportedIndicators();
+            loadAvailableStocks();
+            loadIndicatorStats();
+
+            document.getElementById('calculateForm').addEventListener('submit', handleCalculate);
+            document.getElementById('multiPeriodForm').addEventListener('submit', handleMultiPeriod);
+            document.getElementById('compareForm').addEventListener('submit', handleCompare);
         });
-        
-        // 加载支持的指标
+
+        // ===== 加载指标列表 =====
         async function loadSupportedIndicators() {
             try {
-                console.log('开始加载支持的指标...');
                 const response = await axios.get('/api/realtime-analysis/indicators/supported');
-                console.log('指标API响应:', response.data);
-                
                 if (response.data.success) {
                     supportedIndicators = response.data.data;
-                    console.log('支持的指标数量:', supportedIndicators.length);
                     renderIndicatorCheckboxes();
                     renderSupportedIndicators();
-                } else {
-                    console.error('加载指标失败:', response.data.message);
-                    showError('indicatorCheckboxes', '加载指标失败: ' + response.data.message);
                 }
             } catch (error) {
-                console.error('加载支持的指标失败:', error);
-                showError('indicatorCheckboxes', '加载指标失败: ' + error.message);
+                console.error('加载指标失败:', error);
+                showError('indicatorCheckboxes', '加载指标失败');
             }
         }
-        
-        // 加载可用股票
+
+        // ===== 加载股票列表 =====
         async function loadAvailableStocks() {
             try {
-                console.log('开始加载可用股票...');
                 const response = await axios.get('/api/realtime-analysis/data/stock-list');
-                console.log('股票API响应:', response.data);
-                
                 if (response.data.success) {
                     availableStocks = response.data.data;
-                    console.log('可用股票数量:', availableStocks.length);
                     renderStockOptions();
-                } else {
-                    console.error('加载股票失败:', response.data.message);
-                    showError('stockCode', '加载股票失败: ' + response.data.message);
                 }
             } catch (error) {
-                console.error('加载可用股票失败:', error);
-                showError('stockCode', '加载股票失败: ' + error.message);
+                console.error('加载股票失败:', error);
             }
         }
-        
-        // 渲染指标复选框
+
+        // ===== 渲染指标复选框 =====
         function renderIndicatorCheckboxes() {
-            const containers = ['indicatorCheckboxes', 'multiIndicatorCheckboxes'];
-            
-            containers.forEach(containerId => {
+            const countIds = { indicatorCheckboxes: 'indicatorCount', multiIndicatorCheckboxes: 'multiIndicatorCount' };
+
+            ['indicatorCheckboxes', 'multiIndicatorCheckboxes'].forEach(containerId => {
                 const container = document.getElementById(containerId);
+                if (!container) return;
                 container.innerHTML = '';
-                
                 supportedIndicators.forEach(indicator => {
                     const div = document.createElement('div');
                     div.className = 'form-check';
                     div.innerHTML = `
                         <input class="form-check-input" type="checkbox" value="${indicator.code}" id="${containerId}_${indicator.code}">
                         <label class="form-check-label" for="${containerId}_${indicator.code}" title="${indicator.description}">
-                            ${indicator.name} (${indicator.code})
-                        </label>
-                    `;
+                            ${indicator.name} <small class="text-muted">(${indicator.code})</small>
+                        </label>`;
+                    // 勾选变化时更新计数
+                    div.querySelector('input').addEventListener('change', () => {
+                        updateCheckCount(containerId, countIds[containerId]);
+                    });
                     container.appendChild(div);
                 });
+                updateCheckCount(containerId, countIds[containerId]);
             });
-            
-            // 渲染对比指标下拉框
+
             const compareSelect = document.getElementById('compareIndicator');
             compareSelect.innerHTML = '<option value="">请选择指标</option>';
             supportedIndicators.forEach(indicator => {
@@ -475,553 +736,585 @@
                 compareSelect.appendChild(option);
             });
         }
-        
-        // 渲染股票选项
-        function renderStockOptions() {
-            const selects = ['stockCode', 'multiStockCode', 'compareStocks'];
-            
-            selects.forEach(selectId => {
-                const select = document.getElementById(selectId);
-                if (selectId !== 'compareStocks') {
-                    select.innerHTML = '<option value="">请选择股票</option>';
-                } else {
-                    select.innerHTML = '';
-                }
-                
-                availableStocks.forEach(stock => {
-                    const option = document.createElement('option');
-                    option.value = stock;
-                    option.textContent = stock;
-                    select.appendChild(option);
-                });
-            });
+
+        function updateCheckCount(containerId, countId) {
+            const total = document.querySelectorAll(`#${containerId} input[type="checkbox"]`).length;
+            const checked = document.querySelectorAll(`#${containerId} input[type="checkbox"]:checked`).length;
+            const el = document.getElementById(countId);
+            if (el) el.textContent = `${checked}/${total}`;
         }
-        
-        // 处理指标计算
+
+        function toggleAll(containerId, countId) {
+            const boxes = document.querySelectorAll(`#${containerId} input[type="checkbox"]`);
+            const allChecked = Array.from(boxes).every(b => b.checked);
+            boxes.forEach(b => b.checked = !allChecked);
+            updateCheckCount(containerId, countId);
+        }
+
+        // ===== 股票列表已加载（用于校验，不再渲染下拉框） =====
+        function renderStockOptions() {}
+
+        // ===== 处理指标计算 =====
         async function handleCalculate(event) {
             event.preventDefault();
-            console.log('开始处理指标计算...');
-            
-            const formData = new FormData(event.target);
-            const stockCode = document.getElementById('stockCode').value;
+            const rawCode = document.getElementById('stockCode').value;
+            const stockCode = normalizeStockCode(rawCode);
             const periodType = document.getElementById('periodType').value;
             const lookbackDays = parseInt(document.getElementById('lookbackDays').value);
-            
-            // 获取选中的指标
             const selectedIndicators = [];
-            document.querySelectorAll('#indicatorCheckboxes input[type="checkbox"]:checked').forEach(checkbox => {
-                selectedIndicators.push(checkbox.value);
-            });
-            
-            console.log('表单数据:', {
-                stockCode,
-                periodType,
-                lookbackDays,
-                selectedIndicators
-            });
-            
-            if (!stockCode) {
-                alert('请选择股票代码');
-                return;
-            }
-            
-            if (selectedIndicators.length === 0) {
-                alert('请至少选择一个指标');
-                return;
-            }
-            
+            document.querySelectorAll('#indicatorCheckboxes input[type="checkbox"]:checked').forEach(cb => selectedIndicators.push(cb.value));
+
+            if (!rawCode.trim()) { alert('请输入股票代码'); return; }
+            if (!selectedIndicators.length) { alert('请至少选择一个指标'); return; }
+
             showProgress('开始计算技术指标...');
-            
             try {
-                console.log('发送API请求...');
                 const response = await axios.post('/api/realtime-analysis/indicators/calculate', {
-                    ts_code: stockCode,
-                    period_type: periodType,
-                    indicators: selectedIndicators,
-                    lookback_days: lookbackDays
+                    ts_code: stockCode, period_type: periodType, indicators: selectedIndicators, lookback_days: lookbackDays
                 });
-                
-                console.log('API响应:', response.data);
                 updateProgress(100, '计算完成');
-                
                 if (response.data.success) {
                     renderCalculateResults(response.data);
                 } else {
                     showError('calculateResults', response.data.message);
                 }
-                
             } catch (error) {
-                console.error('计算指标失败:', error);
                 showError('calculateResults', '计算指标失败: ' + error.message);
             } finally {
                 hideProgress();
             }
         }
-        
-        // 处理多周期分析
+
+        // ===== 处理多周期分析 =====
         async function handleMultiPeriod(event) {
             event.preventDefault();
-            
-            const stockCode = document.getElementById('multiStockCode').value;
-            
-            // 获取选中的周期
+            const rawCode = document.getElementById('multiStockCode').value;
+            const stockCode = normalizeStockCode(rawCode);
             const selectedPeriods = [];
-            document.querySelectorAll('#multi-period input[type="checkbox"]:checked').forEach(checkbox => {
-                selectedPeriods.push(checkbox.value);
-            });
-            
-            // 获取选中的指标
+            document.querySelectorAll('#multi-period input[type="checkbox"]:checked').forEach(cb => selectedPeriods.push(cb.value));
             const selectedIndicators = [];
-            document.querySelectorAll('#multiIndicatorCheckboxes input[type="checkbox"]:checked').forEach(checkbox => {
-                selectedIndicators.push(checkbox.value);
-            });
-            
-            if (!stockCode) {
-                alert('请选择股票代码');
-                return;
-            }
-            
-            if (selectedPeriods.length === 0) {
-                alert('请至少选择一个周期');
-                return;
-            }
-            
-            if (selectedIndicators.length === 0) {
-                alert('请至少选择一个指标');
-                return;
-            }
-            
+            document.querySelectorAll('#multiIndicatorCheckboxes input[type="checkbox"]:checked').forEach(cb => selectedIndicators.push(cb.value));
+
+            if (!rawCode.trim()) { alert('请输入股票代码'); return; }
+            if (!selectedPeriods.length) { alert('请至少选择一个周期'); return; }
+            if (!selectedIndicators.length) { alert('请至少选择一个指标'); return; }
+
             try {
                 const response = await axios.post('/api/realtime-analysis/indicators/multi-period', {
-                    ts_code: stockCode,
-                    periods: selectedPeriods,
-                    indicators: selectedIndicators
+                    ts_code: stockCode, periods: selectedPeriods, indicators: selectedIndicators
                 });
-                
                 if (response.data.success) {
                     renderMultiPeriodResults(response.data);
                 } else {
                     showError('multiPeriodResults', response.data.message);
                 }
-                
             } catch (error) {
-                console.error('多周期分析失败:', error);
                 showError('multiPeriodResults', '多周期分析失败: ' + error.message);
             }
         }
-        
-        // 处理指标对比
+
+        // ===== 处理指标对比 =====
         async function handleCompare(event) {
             event.preventDefault();
-            
-            const stockCodes = Array.from(document.getElementById('compareStocks').selectedOptions).map(option => option.value);
+            const rawInput = document.getElementById('compareStocks').value;
+            const stockCodes = rawInput.split(/[,，\s]+/).map(s => normalizeStockCode(s)).filter(Boolean);
             const periodType = document.getElementById('comparePeriod').value;
             const indicatorName = document.getElementById('compareIndicator').value;
-            
-            if (stockCodes.length === 0) {
-                alert('请至少选择一个股票');
-                return;
-            }
-            
-            if (!indicatorName) {
-                alert('请选择对比指标');
-                return;
-            }
-            
+
+            if (!stockCodes.length) { alert('请输入至少一个股票代码'); return; }
+            if (!indicatorName) { alert('请选择对比指标'); return; }
+
             try {
                 const response = await axios.post('/api/realtime-analysis/indicators/compare', {
-                    stock_codes: stockCodes,
-                    period_type: periodType,
-                    indicator_name: indicatorName,
-                    limit: 50
+                    stock_codes: stockCodes, period_type: periodType, indicator_name: indicatorName, limit: 50
                 });
-                
                 if (response.data.success) {
                     renderCompareResults(response.data);
                 } else {
                     showError('compareResults', response.data.message);
                 }
-                
             } catch (error) {
-                console.error('指标对比失败:', error);
                 showError('compareResults', '指标对比失败: ' + error.message);
             }
         }
-        
-        // 加载指标统计信息
+
+        // ===== 加载统计 =====
         async function loadIndicatorStats() {
             try {
                 const response = await axios.get('/api/realtime-analysis/indicators/stats');
-                if (response.data.success) {
-                    renderIndicatorStats(response.data.data);
-                }
+                if (response.data.success) renderIndicatorStats(response.data.data);
             } catch (error) {
-                console.error('加载指标统计失败:', error);
                 document.getElementById('indicatorStats').innerHTML = '<div class="alert alert-danger">加载统计信息失败</div>';
             }
         }
-        
-        // 渲染计算结果
+
+        // ===== 渲染计算结果 =====
         function renderCalculateResults(data) {
             const container = document.getElementById('calculateResults');
-            
-            let html = `
-                <div class="alert alert-success">
-                    <h6>计算完成</h6>
-                    <p class="mb-0">
-                        总指标数: ${data.total_indicators} | 
-                        数据点数: ${data.data_points} | 
-                        存储记录: ${data.stored_records}
-                    </p>
-                </div>
-            `;
-            
-            // 显示各指标的计算结果摘要
-            if (data.data) {
-                html += '<div class="row">';
-                Object.keys(data.data).forEach(indicator => {
+            let html = `<div class="summary-bar mb-3 fade-in-up">
+                <span class="summary-item">总指标数 <strong>${data.total_indicators}</strong></span>
+                <span class="summary-item">数据点 <strong>${data.data_points}</strong></span>
+                <span class="summary-item">存储记录 <strong>${data.stored_records}</strong></span>
+            </div>`;
+
+            // 指标值卡片
+            if (data.latest_values) {
+                html += '<div class="row mb-3">';
+                Object.keys(data.latest_values).forEach((indicator, idx) => {
+                    const summary = data.indicator_summary ? data.indicator_summary[indicator] : null;
+                    const latestValues = data.latest_values[indicator] || {};
+                    const records = summary && summary.stored_records ? summary.stored_records : 0;
+                    html += `<div class="col-md-6 mb-2">
+                        <div class="indicator-result-card fade-in-up" style="animation-delay:${idx * 60}ms">
+                            <div class="indicator-result-header">
+                                <h6>${indicator}</h6>
+                                <span class="indicator-badge indicator-badge-success">${records} 条</span>
+                            </div>
+                            <div class="indicator-result-body">
+                                ${renderValueList(latestValues)}
+                            </div>
+                        </div>
+                    </div>`;
+                });
+                html += '</div>';
+            } else if (data.data) {
+                html += '<div class="row mb-3">';
+                Object.keys(data.data).forEach((indicator, idx) => {
                     const result = data.data[indicator];
-                    if (result.error) {
-                        html += `
-                            <div class="col-md-6 mb-3">
-                                <div class="card border-danger">
-                                    <div class="card-header bg-danger text-white">
-                                        <h6 class="mb-0">${indicator}</h6>
-                                    </div>
-                                    <div class="card-body">
-                                        <p class="text-danger mb-0">错误: ${result.error}</p>
-                                    </div>
-                                </div>
+                    const isError = result.error;
+                    html += `<div class="col-md-6 mb-2">
+                        <div class="indicator-result-card fade-in-up" style="animation-delay:${idx * 60}ms">
+                            <div class="indicator-result-header">
+                                <h6>${indicator}</h6>
+                                <span class="indicator-badge ${isError ? 'indicator-badge-error' : 'indicator-badge-success'}">${isError ? '失败' : '成功'}</span>
                             </div>
-                        `;
-                    } else {
-                        const subIndicators = Object.keys(result);
-                        html += `
-                            <div class="col-md-6 mb-3">
-                                <div class="card border-success">
-                                    <div class="card-header bg-success text-white">
-                                        <h6 class="mb-0">${indicator}</h6>
-                                    </div>
-                                    <div class="card-body">
-                                        <p class="mb-0">子指标: ${subIndicators.join(', ')}</p>
-                                        <small class="text-muted">计算成功</small>
-                                    </div>
-                                </div>
+                            <div class="indicator-result-body">
+                                ${isError
+                                    ? `<div style="color:var(--obs-danger-light);font-size:0.8rem">${result.error}</div>`
+                                    : `<div style="color:var(--obs-text-muted);font-size:0.8rem">子指标: ${Object.keys(result).join(', ')}</div>`
+                                }
                             </div>
-                        `;
-                    }
+                        </div>
+                    </div>`;
                 });
                 html += '</div>';
             }
-            
+
+            // 走势图
+            if (data.timeline && data.data) {
+                Object.keys(data.data).forEach(indicator => {
+                    const result = data.data[indicator];
+                    if (!result || result.error) return;
+                    const chartId = `indicatorChart_${indicator}`;
+                    html += `<div class="chart-card mb-3 fade-in-up">
+                        <div class="chart-card-header"><h6><i class="fas fa-chart-area me-2"></i>${indicator} 走势</h6></div>
+                        <div class="chart-card-body"><div id="${chartId}" class="chart-container"></div></div>
+                    </div>`;
+                });
+            }
+
             container.innerHTML = html;
+
+            // 渲染图表
+            if (data.timeline && data.data) {
+                Object.keys(data.data).forEach(indicator => {
+                    const result = data.data[indicator];
+                    if (!result || result.error) return;
+                    renderIndicatorSeriesChart(indicator, result, data.timeline);
+                });
+            }
         }
-        
-        // 渲染多周期结果
+
+        // ===== 渲染多周期结果 =====
         function renderMultiPeriodResults(data) {
             const container = document.getElementById('multiPeriodResults');
-            
-            let html = '<div class="row">';
-            
-            Object.keys(data.data).forEach(period => {
-                const result = data.data[period];
-                const statusClass = result.success ? 'border-success' : 'border-danger';
-                const statusIcon = result.success ? 'fa-check-circle text-success' : 'fa-times-circle text-danger';
-                
-                html += `
-                    <div class="col-md-6 mb-3">
-                        <div class="card ${statusClass}">
-                            <div class="card-header">
-                                <h6 class="mb-0">
-                                    <i class="fas ${statusIcon} me-2"></i>${period}
-                                </h6>
-                            </div>
-                            <div class="card-body">
-                `;
-                
-                if (result.success) {
-                    html += `
-                        <p class="mb-1">指标数: ${result.total_indicators}</p>
-                        <p class="mb-1">数据点: ${result.data_points}</p>
-                        <p class="mb-0">存储记录: ${result.stored_records}</p>
-                    `;
-                } else {
-                    html += `<p class="text-danger mb-0">${result.message}</p>`;
+            let html = '';
+
+            if (data.summary) {
+                const s = data.summary;
+                html += `<div class="summary-bar mb-3 fade-in-up">
+                    <span class="summary-item">对比周期 <strong>${s.period_count || 0}</strong></span>
+                    <span class="summary-item">有数据周期 <strong>${(s.available_periods || []).length}</strong></span>
+                    <span class="summary-item">分析指标 <strong>${(data.indicators || []).length}</strong></span>
+                    <span class="summary-item">股票 <strong>${data.ts_code || '-'}</strong></span>
+                </div>`;
+                if (data.data_source) {
+                    html += `<div class="alert alert-secondary py-2 px-3 mb-3" style="font-size:0.8rem">
+                        数据来源: ${data.data_source.type || 'parquet'} · ${data.data_source.minute_root || data.data_source.data_dir || '-'}
+                    </div>`;
                 }
-                
-                html += `
-                            </div>
+            }
+
+            html += '<div class="row">';
+            Object.keys(data.data).forEach((period, idx) => {
+                const result = data.data[period];
+                const ok = result.success;
+                html += `<div class="col-md-6 mb-3">
+                    <div class="indicator-result-card fade-in-up" style="animation-delay:${idx * 60}ms">
+                        <div class="indicator-result-header">
+                            <h6><i class="fas ${ok ? 'fa-check-circle' : 'fa-times-circle'} me-2" style="color:${ok ? 'var(--obs-success)' : 'var(--obs-danger)'}"></i>${period}</h6>
+                            <span class="indicator-badge ${ok ? 'indicator-badge-success' : 'indicator-badge-error'}">${ok ? '成功' : '失败'}</span>
                         </div>
-                    </div>
-                `;
+                        <div class="indicator-result-body">`;
+                if (ok) {
+                    html += renderValueList({ '指标数': result.total_indicators, '数据点': result.data_points, '存储记录': result.stored_records });
+                    if (result.latest_values) {
+                        html += '<hr style="border-color:var(--obs-border);margin:8px 0">';
+                        html += renderValueList(result.latest_values);
+                    }
+                } else {
+                    html += `<div style="color:var(--obs-danger-light);font-size:0.8rem">${result.message}</div>`;
+                }
+                html += `</div></div></div>`;
             });
-            
             html += '</div>';
             container.innerHTML = html;
         }
-        
-        // 渲染对比结果
+
+        // ===== 渲染对比结果 =====
         function renderCompareResults(data) {
             const container = document.getElementById('compareResults');
-            
-            // 创建图表
-            const chartContainer = document.createElement('div');
-            chartContainer.style.height = '400px';
-            chartContainer.id = 'compareChart';
-            
-            let html = `
-                <div class="alert alert-info">
-                    <h6>对比指标: ${data.indicator_name}</h6>
-                    <p class="mb-0">周期: ${data.period_type} | 股票数: ${data.stock_codes.length}</p>
-                </div>
-            `;
-            
+            const hasSeries = Object.values(data.data).some(items => items && items.length > 0);
+
+            let html = `<div class="compare-info mb-3 fade-in-up">
+                <i class="fas fa-info-circle me-2"></i>
+                对比指标: <strong>${data.indicator_name}</strong> &nbsp;|&nbsp; 周期: ${data.period_type} &nbsp;|&nbsp; 股票数: ${data.stock_codes.length}
+            </div>`;
+
+            if (data.empty_state && !data.empty_state.has_data) {
+                html += `<div class="alert alert-warning fade-in-up">
+                    <strong>${data.empty_state.message}</strong>
+                    <div class="mt-1" style="font-size:0.8rem">无数据: ${data.empty_state.empty_stock_codes.join(', ')}</div>
+                </div>`;
+            }
+
             container.innerHTML = html;
-            container.appendChild(chartContainer);
-            
-            // 渲染图表
-            renderCompareChart(data);
+
+            if (hasSeries) {
+                const chartDiv = document.createElement('div');
+                chartDiv.className = 'chart-card fade-in-up';
+                chartDiv.innerHTML = '<div class="chart-card-body"><div id="compareChart" class="chart-container"></div></div>';
+                container.appendChild(chartDiv);
+                // 等DOM就绪
+                requestAnimationFrame(() => renderCompareChart(data));
+            }
         }
-        
-        // 渲染对比图表
+
+        // ===== 渲染对比图表 =====
         function renderCompareChart(data) {
-            const chart = echarts.init(document.getElementById('compareChart'));
-            
+            const dom = document.getElementById('compareChart');
+            if (!dom) return;
+            const chart = echarts.init(dom, 'financial');
+
+            const componentLabels = {
+                MACD: ['DIF','DEA','HIST'], KDJ: ['K','D','J'],
+                BOLL: ['UPPER','MIDDLE','LOWER'], BOLLINGER: ['UPPER','MIDDLE','LOWER']
+            };
+            const labels = componentLabels[data.indicator_name] || ['VALUE'];
             const series = [];
-            const legend = [];
-            
+
+            // 收集所有唯一时间点作为 category
+            const allTimes = new Set();
+            const stockSorted = {};
             Object.keys(data.data).forEach(stockCode => {
-                const stockData = data.data[stockCode];
-                if (stockData.length > 0) {
-                    legend.push(stockCode);
-                    
-                    const seriesData = stockData.map(item => [
-                        item.datetime,
-                        item.value1
-                    ]);
-                    
+                const sorted = (data.data[stockCode] || []).slice().sort((a, b) => new Date(a.datetime) - new Date(b.datetime));
+                stockSorted[stockCode] = sorted;
+                sorted.forEach(item => allTimes.add(item.datetime));
+            });
+            const categories = Array.from(allTimes).sort();
+
+            Object.keys(data.data).forEach(stockCode => {
+                const stockData = stockSorted[stockCode];
+                if (!stockData.length) return;
+
+                // 建立 datetime → index 的映射
+                const timeMap = {};
+                stockData.forEach(item => { timeMap[item.datetime] = item; });
+
+                labels.forEach((label, li) => {
+                    const seriesData = categories.map(dt => {
+                        const item = timeMap[dt];
+                        if (!item) return null;
+                        const v = [item.value1, item.value2, item.value3, item.value4][li];
+                        return (v === null || v === undefined) ? null : v;
+                    });
+                    if (!seriesData.some(v => v !== null)) return;
+
+                    const colorIdx = series.length % CHART_COLORS.length;
                     series.push({
-                        name: stockCode,
+                        name: `${stockCode} ${label}`,
                         type: 'line',
                         data: seriesData,
-                        smooth: true
+                        smooth: true,
+                        showSymbol: false,
+                        connectNulls: false,
+                        lineStyle: { width: 2, color: CHART_COLORS[colorIdx] },
+                        areaStyle: { color: AREA_COLORS[colorIdx % AREA_COLORS.length] }
                     });
-                }
+                });
             });
-            
-            const option = {
-                title: {
-                    text: `${data.indicator_name} 对比分析`,
-                    left: 'center'
-                },
-                tooltip: {
-                    trigger: 'axis',
-                    axisPointer: {
-                        type: 'cross'
-                    }
-                },
-                legend: {
-                    data: legend,
-                    top: 30
-                },
-                grid: {
-                    left: '3%',
-                    right: '4%',
-                    bottom: '3%',
-                    top: '15%',
-                    containLabel: true
-                },
-                xAxis: {
-                    type: 'time',
-                    boundaryGap: false
-                },
-                yAxis: {
-                    type: 'value'
-                },
-                series: series
-            };
-            
-            chart.setOption(option);
+
+            if (!series.length) {
+                document.getElementById('compareResults').insertAdjacentHTML('beforeend', '<div class="alert alert-secondary mt-3">暂无可绘制的数据</div>');
+                return;
+            }
+
+            chart.setOption({
+                ...baseChartOption(`${data.indicator_name} 对比分析`, categories),
+                legend: { ...baseChartOption('', []).legend, data: series.map(s => s.name) },
+                series
+            });
+            window.addEventListener('resize', () => chart.resize());
         }
-        
-        // 渲染指标统计信息
+
+        // ===== 渲染统计信息 =====
         function renderIndicatorStats(stats) {
             const container = document.getElementById('indicatorStats');
-            
             if (stats.error) {
                 container.innerHTML = `<div class="alert alert-danger">${stats.error}</div>`;
                 return;
             }
-            
-            let html = `
-                <div class="row text-center">
-                    <div class="col-6">
-                        <h3 class="text-primary">${stats.total_records || 0}</h3>
-                        <p class="mb-0">总记录数</p>
-                    </div>
-                    <div class="col-6">
-                        <h3 class="text-success">${stats.total_stocks || 0}</h3>
-                        <p class="mb-0">股票数量</p>
-                    </div>
+
+            let html = `<div class="stat-grid mb-3">
+                <div class="stat-block">
+                    <div class="stat-value" style="color:var(--obs-primary-light)">${stats.total_records || 0}</div>
+                    <div class="stat-label">总记录数</div>
                 </div>
-                <hr>
-            `;
-            
-            if (stats.indicator_stats) {
-                html += '<h6>指标分布</h6>';
-                Object.keys(stats.indicator_stats).forEach(indicator => {
-                    const count = stats.indicator_stats[indicator];
-                    html += `
-                        <div class="d-flex justify-content-between">
-                            <span>${indicator}</span>
-                            <span class="badge bg-primary">${count}</span>
-                        </div>
-                    `;
+                <div class="stat-block">
+                    <div class="stat-value" style="color:var(--obs-success-light)">${stats.total_stocks || 0}</div>
+                    <div class="stat-label">股票数量</div>
+                </div>
+            </div>`;
+
+            // 最活跃指标
+            const topIndicators = Object.entries(stats.indicator_stats || {}).sort((a, b) => b[1] - a[1]).slice(0, 5);
+            const maxCount = topIndicators.length ? topIndicators[0][1] : 1;
+            if (topIndicators.length) {
+                html += '<div style="font-size:0.82rem;font-weight:600;color:var(--obs-text-secondary);margin-bottom:8px">指标分布</div>';
+                topIndicators.forEach(([indicator, count]) => {
+                    const pct = Math.round(count / maxCount * 100);
+                    html += `<div class="distribution-row">
+                        <span style="min-width:60px">${indicator}</span>
+                        <div class="distribution-bar"><div class="distribution-bar-fill" style="width:${pct}%"></div></div>
+                        <span style="color:var(--obs-text);font-weight:600;min-width:40px;text-align:right">${count}</span>
+                    </div>`;
                 });
             }
-            
+
+            // 周期分布
             if (stats.period_stats) {
-                html += '<hr><h6>周期分布</h6>';
-                Object.keys(stats.period_stats).forEach(period => {
-                    const count = stats.period_stats[period];
-                    html += `
-                        <div class="d-flex justify-content-between">
-                            <span>${period}</span>
-                            <span class="badge bg-secondary">${count}</span>
-                        </div>
-                    `;
+                html += '<hr style="border-color:var(--obs-border);margin:12px 0">';
+                html += '<div style="font-size:0.82rem;font-weight:600;color:var(--obs-text-secondary);margin-bottom:6px">周期分布</div>';
+                Object.entries(stats.period_stats).forEach(([period, count]) => {
+                    html += `<div class="distribution-row">
+                        <span style="min-width:60px">${period}</span>
+                        <div class="distribution-bar"><div class="distribution-bar-fill" style="width:100%;background:var(--obs-info)"></div></div>
+                        <span style="color:var(--obs-text);font-weight:600;min-width:40px;text-align:right">${count}</span>
+                    </div>`;
                 });
             }
-            
+
             if (stats.earliest_time && stats.latest_time) {
-                html += `
-                    <hr>
-                    <small class="text-muted">
-                        数据时间范围: ${new Date(stats.earliest_time).toLocaleString()} - ${new Date(stats.latest_time).toLocaleString()}
-                    </small>
-                `;
+                html += `<div style="margin-top:12px;font-size:0.72rem;color:var(--obs-text-muted)">
+                    数据范围: ${new Date(stats.earliest_time).toLocaleString()} — ${new Date(stats.latest_time).toLocaleString()}
+                </div>`;
             }
-            
+
             container.innerHTML = html;
-            
-            // 渲染指标分布图表
-            if (stats.indicator_stats) {
-                renderIndicatorChart(stats.indicator_stats);
-            }
+            if (stats.indicator_stats) renderIndicatorChart(stats.indicator_stats);
         }
-        
-        // 渲染支持的指标
+
+        // ===== 值列表渲染 =====
+        function renderValueList(values) {
+            if (!values || !Object.keys(values).length) {
+                return '<div style="color:var(--obs-text-muted);font-size:0.8rem">暂无数据</div>';
+            }
+            const compositeLabels = { MACD: ['DIF','DEA','HIST'], KDJ: ['K','D','J'], BOLL: ['UPPER','MIDDLE','LOWER'] };
+            let html = '';
+            Object.entries(values).forEach(([key, val]) => {
+                // 复合指标：值是数组，拆成带标签的多行
+                if (Array.isArray(val) && compositeLabels[key]) {
+                    const labels = compositeLabels[key];
+                    val.forEach((v, i) => {
+                        html += `<div class="value-row"><span class="label">${labels[i] || i}</span><span class="value">${formatDisplayValue(v)}</span></div>`;
+                    });
+                } else {
+                    html += `<div class="value-row"><span class="label">${key}</span><span class="value">${formatDisplayValue(val)}</span></div>`;
+                }
+            });
+            return html;
+        }
+
+        function formatDisplayValue(value) {
+            if (value === null || value === undefined) return '—';
+            if (typeof value === 'number') return Number.isFinite(value) ? value.toFixed(2) : '—';
+            if (typeof value === 'string') { const p = Number(value); return !Number.isNaN(p) && value.trim() ? p.toFixed(2) : value; }
+            if (Array.isArray(value)) return value.map(formatDisplayValue).join(' / ');
+            if (typeof value === 'object') return Object.entries(value).map(([k, v]) => `${k}: ${formatDisplayValue(v)}`).join(' | ');
+            return String(value);
+        }
+
+        // ===== 指标走势图（核心改进） =====
+        function renderIndicatorSeriesChart(indicator, result, timeline) {
+            const dom = document.getElementById(`indicatorChart_${indicator}`);
+            if (!dom) return;
+            const chart = echarts.init(dom, 'financial');
+
+            // 复合指标：值是 [v1,v2,v3] 数组，需要拆成多条 series
+            const compositeLabels = { MACD: ['DIF','DEA','HIST'], KDJ: ['K','D','J'], BOLL: ['UPPER','MIDDLE','LOWER'] };
+            const isComposite = indicator in compositeLabels;
+            const series = [];
+
+            // 所有 series 共用：null 断线，connectNulls: false
+            const lineBase = { showSymbol: false, connectNulls: false };
+
+            if (isComposite) {
+                const labels = compositeLabels[indicator];
+                const subKey = Object.keys(result)[0];
+                const rawValues = result[subKey];
+
+                labels.forEach((label, compIdx) => {
+                    // data: 纯值数组，null 表示断线
+                    const data = timeline.map((_, i) => {
+                        const item = rawValues[i];
+                        if (!item || !Array.isArray(item)) return null;
+                        const v = item[compIdx];
+                        return (v === null || v === undefined) ? null : v;
+                    });
+
+                    const colorIdx = compIdx % CHART_COLORS.length;
+                    const color = CHART_COLORS[colorIdx];
+                    const areaColor = AREA_COLORS[colorIdx % AREA_COLORS.length];
+                    const isHist = indicator === 'MACD' && label === 'HIST';
+
+                    series.push({
+                        name: label,
+                        type: isHist ? 'bar' : 'line',
+                        data: isHist ? data.map(v => ({
+                            value: v,
+                            itemStyle: { color: v !== null && v >= 0 ? 'rgba(74,222,128,0.7)' : 'rgba(248,113,113,0.7)' }
+                        })) : data,
+                        ...lineBase,
+                        smooth: !isHist,
+                        lineStyle: { width: 1.8, color },
+                        areaStyle: isHist ? undefined : { color: areaColor },
+                        barWidth: isHist ? '60%' : undefined,
+                        z: isHist ? 1 : 2
+                    });
+                });
+            } else {
+                const keys = Object.keys(result || {});
+                keys.forEach((subKey, index) => {
+                    const values = result[subKey];
+                    const data = timeline.map((_, i) => {
+                        const raw = Array.isArray(values) ? values[i] : null;
+                        return (raw === null || raw === undefined) ? null : raw;
+                    });
+
+                    const color = CHART_COLORS[index % CHART_COLORS.length];
+                    const areaColor = AREA_COLORS[index % AREA_COLORS.length];
+                    series.push({
+                        name: subKey,
+                        type: 'line',
+                        data,
+                        ...lineBase,
+                        smooth: true,
+                        lineStyle: { width: 1.8, color },
+                        areaStyle: { color: areaColor }
+                    });
+                });
+            }
+
+            chart.setOption({
+                ...baseChartOption(`${indicator} 走势图`, timeline),
+                legend: { ...baseChartOption('', []).legend, data: series.map(s => s.name) },
+                series
+            });
+            window.addEventListener('resize', () => chart.resize());
+        }
+
+        // ===== 支持的指标列表 =====
         function renderSupportedIndicators() {
             const container = document.getElementById('supportedIndicators');
-            
-            let html = '';
-            supportedIndicators.forEach(indicator => {
-                html += `
-                    <div class="card mb-2">
-                        <div class="card-body py-2">
-                            <h6 class="mb-1">${indicator.name} (${indicator.code})</h6>
-                            <small class="text-muted">${indicator.description}</small>
-                        </div>
-                    </div>
-                `;
-            });
-            
-            container.innerHTML = html;
+            container.innerHTML = supportedIndicators.map(ind =>
+                `<span class="indicator-tag"><span class="tag-code">${ind.code}</span><span class="tag-name">${ind.name}</span></span>`
+            ).join('');
         }
-        
-        // 渲染指标分布图表
+
+        // ===== 指标分布饼图 =====
         function renderIndicatorChart(indicatorStats) {
-            const chart = echarts.init(document.getElementById('indicatorChart'));
-            
-            const data = Object.keys(indicatorStats).map(indicator => ({
-                name: indicator,
-                value: indicatorStats[indicator]
-            }));
-            
-            const option = {
+            const dom = document.getElementById('indicatorChart');
+            if (!dom) return;
+            const chart = echarts.init(dom, 'financial');
+
+            const data = Object.entries(indicatorStats).map(([name, value]) => ({ name, value }));
+
+            chart.setOption({
+                backgroundColor: 'transparent',
                 title: {
                     text: '指标数据分布',
-                    left: 'center'
+                    left: 12, top: 8,
+                    textStyle: { color: '#e2e8f0', fontWeight: 600, fontSize: 13 }
                 },
                 tooltip: {
                     trigger: 'item',
-                    formatter: '{a} <br/>{b}: {c} ({d}%)'
+                    backgroundColor: 'rgba(30,41,59,0.95)',
+                    borderColor: '#334155',
+                    textStyle: { color: '#e2e8f0' },
+                    formatter: '{b}: {c} ({d}%)'
                 },
                 legend: {
-                    orient: 'vertical',
-                    left: 'left'
+                    orient: 'vertical', right: 16, top: 'middle',
+                    textStyle: { color: '#94a3b8', fontSize: 11 },
+                    itemWidth: 10, itemHeight: 10
                 },
-                series: [
-                    {
-                        name: '指标数据',
-                        type: 'pie',
-                        radius: '50%',
-                        data: data,
-                        emphasis: {
-                            itemStyle: {
-                                shadowBlur: 10,
-                                shadowOffsetX: 0,
-                                shadowColor: 'rgba(0, 0, 0, 0.5)'
-                            }
-                        }
-                    }
-                ]
-            };
-            
-            chart.setOption(option);
+                series: [{
+                    type: 'pie',
+                    radius: ['40%', '70%'],
+                    center: ['35%', '55%'],
+                    avoidLabelOverlap: false,
+                    itemStyle: { borderRadius: 6, borderColor: '#1e293b', borderWidth: 2 },
+                    label: { show: false },
+                    emphasis: {
+                        label: { show: true, fontSize: 12, fontWeight: 'bold', color: '#e2e8f0' },
+                        itemStyle: { shadowBlur: 20, shadowColor: 'rgba(99,102,241,0.3)' }
+                    },
+                    labelLine: { show: false },
+                    data,
+                    color: CHART_COLORS
+                }]
+            });
+            window.addEventListener('resize', () => chart.resize());
         }
-        
-        // 显示进度
+
+        // ===== 进度条 =====
         function showProgress(message) {
             document.getElementById('progressContainer').style.display = 'block';
             updateProgress(0, message);
         }
-        
-        // 更新进度
         function updateProgress(percent, message) {
-            const progressBar = document.getElementById('progressBar');
-            const logContainer = document.getElementById('logContainer');
-            
-            progressBar.style.width = percent + '%';
-            progressBar.textContent = percent + '%';
-            
-            const timestamp = new Date().toLocaleTimeString();
-            logContainer.innerHTML += `<div>[${timestamp}] ${message}</div>`;
-            logContainer.scrollTop = logContainer.scrollHeight;
+            const bar = document.getElementById('progressBar');
+            const log = document.getElementById('logContainer');
+            bar.style.width = percent + '%';
+            const ts = new Date().toLocaleTimeString();
+            log.innerHTML += `<div>[${ts}] ${message}</div>`;
+            log.scrollTop = log.scrollHeight;
         }
-        
-        // 隐藏进度
         function hideProgress() {
-            setTimeout(() => {
-                document.getElementById('progressContainer').style.display = 'none';
-            }, 2000);
+            setTimeout(() => { document.getElementById('progressContainer').style.display = 'none'; }, 2000);
         }
-        
-        // 显示错误信息
+
+        // ===== 错误提示 =====
         function showError(containerId, message) {
             const container = document.getElementById(containerId);
-            if (!container) {
-                console.error('找不到容器:', containerId);
-                return;
-            }
-            
-            // 如果是select元素，在其父容器中显示错误
+            if (!container) return;
             if (container.tagName === 'SELECT') {
-                const parentDiv = container.parentElement;
-                let errorDiv = parentDiv.querySelector('.error-message');
-                if (!errorDiv) {
-                    errorDiv = document.createElement('div');
-                    errorDiv.className = 'error-message alert alert-danger mt-2';
-                    parentDiv.appendChild(errorDiv);
-                }
-                errorDiv.innerHTML = `<i class="fas fa-exclamation-triangle me-2"></i>${message}`;
+                const parent = container.parentElement;
+                let err = parent.querySelector('.error-message');
+                if (!err) { err = document.createElement('div'); err.className = 'error-message alert alert-danger mt-2'; parent.appendChild(err); }
+                err.innerHTML = `<i class="fas fa-exclamation-triangle me-2"></i>${message}`;
             } else {
-                container.innerHTML = `
-                    <div class="alert alert-danger">
-                        <i class="fas fa-exclamation-triangle me-2"></i>
-                        ${message}
-                    </div>
-                `;
+                container.innerHTML = `<div class="alert alert-danger"><i class="fas fa-exclamation-triangle me-2"></i>${message}</div>`;
             }
         }
     </script>

--- a/app/utils/db_utils.py
+++ b/app/utils/db_utils.py
@@ -7,31 +7,8 @@ load_dotenv()
 
 
 class DatabaseUtils:
-    # 兼容层 MySQL 连接信息
-    _host = os.getenv('DB_HOST', '').strip()
-    _user = os.getenv('DB_USER', '').strip()
-    _password = os.getenv('DB_PASSWORD', '')
-    _database = os.getenv('DB_NAME', '').strip()
-    _charset = os.getenv('DB_CHARSET', 'utf8mb4').strip() or 'utf8mb4'
-    _mysql_compat_enabled = os.getenv('MYSQL_COMPAT_ENABLED', 'false').strip().lower() in {'1', 'true', 'yes', 'y', 'on'}
-
     # Tushare API token
     _tushare_token = os.getenv('TUSHARE_TOKEN') or os.getenv('tushare_token')
-
-    @classmethod
-    def _validate_db_config(cls):
-        missing_keys = [
-            key for key, value in {
-                'DB_HOST': cls._host,
-                'DB_USER': cls._user,
-                'DB_PASSWORD': cls._password,
-                'DB_NAME': cls._database,
-            }.items() if not value
-        ]
-        if missing_keys:
-            raise ValueError(
-                f"未配置数据库连接参数: {', '.join(missing_keys)}，请在.env中设置后重试"
-            )
 
     @classmethod
     def init_tushare_api(cls):
@@ -42,28 +19,3 @@ class DatabaseUtils:
         if not cls._tushare_token:
             raise ValueError('未配置TUSHARE_TOKEN，请在.env中设置后重试')
         return ts.pro_api(cls._tushare_token)
-
-    @classmethod
-    def connect_to_mysql(cls):
-        """
-        连接到遗留 MySQL 兼容层
-        :return: MySQL连接对象和游标
-        """
-        if not cls._mysql_compat_enabled:
-            raise RuntimeError('MySQL compatibility layer is disabled; use Parquet data sources instead')
-        cls._validate_db_config()
-        try:
-            import pymysql
-        except ImportError as exc:
-            raise RuntimeError(
-                'PyMySQL is not installed; install the legacy MySQL compatibility dependencies to use connect_to_mysql()'
-            ) from exc
-        conn = pymysql.connect(
-            host=cls._host,
-            user=cls._user,
-            password=cls._password,
-            database=cls._database,
-            charset=cls._charset
-        )
-        cursor = conn.cursor()
-        return conn, cursor 

--- a/app/utils/db_utils.py
+++ b/app/utils/db_utils.py
@@ -13,7 +13,7 @@ class DatabaseUtils:
     _password = os.getenv('DB_PASSWORD', '')
     _database = os.getenv('DB_NAME', '').strip()
     _charset = os.getenv('DB_CHARSET', 'utf8mb4').strip() or 'utf8mb4'
-    _mysql_compat_enabled = os.getenv('MYSQL_COMPAT_ENABLED', 'true').strip().lower() in {'1', 'true', 'yes', 'y', 'on'}
+    _mysql_compat_enabled = os.getenv('MYSQL_COMPAT_ENABLED', 'false').strip().lower() in {'1', 'true', 'yes', 'y', 'on'}
 
     # Tushare API token
     _tushare_token = os.getenv('TUSHARE_TOKEN') or os.getenv('tushare_token')

--- a/config.py
+++ b/config.py
@@ -25,33 +25,13 @@ def _build_sqlalchemy_engine_options(database_uri: str) -> dict:
 class Config:
     """基础配置类"""
 
-    # ORM 默认使用 SQLite；MySQL 仅保留给显式 legacy/compatibility 路径
     SQLITE_DATABASE_PATH = os.getenv(
         "SQLITE_DATABASE_PATH",
         os.path.join(BASE_DIR, "stock_cursor.sqlite3"),
     )
-    SQLITE_DATABASE_URI = os.getenv(
-        "SQLALCHEMY_DATABASE_URI",
-        f"sqlite:///{SQLITE_DATABASE_PATH}",
-    )
+    SQLITE_DATABASE_URI = f"sqlite:///{SQLITE_DATABASE_PATH}"
     SQLALCHEMY_DATABASE_URI = SQLITE_DATABASE_URI
     SQLALCHEMY_ENGINE_OPTIONS = _build_sqlalchemy_engine_options(SQLALCHEMY_DATABASE_URI)
-
-    MYSQL_COMPAT_ENABLED = os.getenv(
-        "MYSQL_COMPAT_ENABLED",
-        "false",
-    ).strip().lower() in {"1", "true", "yes", "y", "on"}
-
-    DB_HOST = os.getenv('DB_HOST', 'localhost')
-    DB_USER = os.getenv('DB_USER', 'root')
-    DB_PASSWORD = os.getenv('DB_PASSWORD', '')
-    DB_NAME = os.getenv('DB_NAME', 'stock_cursor')
-    DB_CHARSET = os.getenv('DB_CHARSET', 'utf8mb4')
-    
-    MYSQL_DATABASE_URI = os.getenv(
-        'MYSQL_DATABASE_URI',
-        f"mysql+pymysql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}/{DB_NAME}?charset={DB_CHARSET}",
-    )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     
     # Flask配置
@@ -75,7 +55,7 @@ class Config:
     
     # 默认数据源：Parquet
     DATA_DIR = os.getenv('DATA_DIR', os.path.join(os.path.dirname(__file__), 'data'))
-    DATA_SOURCE = os.getenv('DATA_SOURCE', 'parquet')  # 'parquet' | 'mysql'
+    DATA_SOURCE = 'parquet'
 
     # 数据更新配置
     DATA_UPDATE_HOUR = int(os.getenv('DATA_UPDATE_HOUR', 18))  # 每日18点更新数据
@@ -93,18 +73,18 @@ class Config:
     
     # 大模型配置
     LLM_CONFIG = {
-        'provider': 'ollama',  # 支持 'ollama', 'openai', 'azure'
+        'provider': os.getenv('LLM_PROVIDER', 'ollama'),  # 'ollama' | 'openai'
         'ollama': {
-            'base_url': 'http://localhost:11434',
-            'model': 'qwen2.5-coder:latest',
+            'base_url': os.getenv('LLM_BASE_URL', 'http://localhost:11434'),
+            'model': os.getenv('LLM_MODEL', 'qwen2.5-coder:latest'),
             'timeout': 60,
             'temperature': 0.1,
             'max_tokens': 2048
         },
         'openai': {
-            'api_key': os.environ.get('OPENAI_API_KEY'),
-            'model': 'gpt-3.5-turbo',
-            'base_url': 'https://api.openai.com/v1',
+            'api_key': os.getenv('LLM_API_KEY'),
+            'model': os.getenv('LLM_MODEL', 'gpt-3.5-turbo'),
+            'base_url': os.getenv('LLM_BASE_URL', 'https://api.openai.com/v1'),
             'timeout': 60,
             'temperature': 0.1,
             'max_tokens': 2048

--- a/config.py
+++ b/config.py
@@ -5,10 +5,43 @@ from datetime import timedelta
 # 加载环境变量
 load_dotenv()
 
+
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+
+
+def _build_sqlalchemy_engine_options(database_uri: str) -> dict:
+    if database_uri.startswith("sqlite"):
+        return {
+            "connect_args": {
+                "check_same_thread": False,
+            }
+        }
+    return {
+        "pool_size": 10,
+        "pool_recycle": 3600,
+        "pool_pre_ping": True,
+    }
+
 class Config:
     """基础配置类"""
-    
-    # 兼容层：MySQL 仅用于遗留 ORM / 手工维护场景
+
+    # ORM 默认使用 SQLite；MySQL 仅保留给显式 legacy/compatibility 路径
+    SQLITE_DATABASE_PATH = os.getenv(
+        "SQLITE_DATABASE_PATH",
+        os.path.join(BASE_DIR, "stock_cursor.sqlite3"),
+    )
+    SQLITE_DATABASE_URI = os.getenv(
+        "SQLALCHEMY_DATABASE_URI",
+        f"sqlite:///{SQLITE_DATABASE_PATH}",
+    )
+    SQLALCHEMY_DATABASE_URI = SQLITE_DATABASE_URI
+    SQLALCHEMY_ENGINE_OPTIONS = _build_sqlalchemy_engine_options(SQLALCHEMY_DATABASE_URI)
+
+    MYSQL_COMPAT_ENABLED = os.getenv(
+        "MYSQL_COMPAT_ENABLED",
+        "false",
+    ).strip().lower() in {"1", "true", "yes", "y", "on"}
+
     DB_HOST = os.getenv('DB_HOST', 'localhost')
     DB_USER = os.getenv('DB_USER', 'root')
     DB_PASSWORD = os.getenv('DB_PASSWORD', '')
@@ -19,13 +52,7 @@ class Config:
         'MYSQL_DATABASE_URI',
         f"mysql+pymysql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}/{DB_NAME}?charset={DB_CHARSET}",
     )
-    SQLALCHEMY_DATABASE_URI = MYSQL_DATABASE_URI
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    SQLALCHEMY_ENGINE_OPTIONS = {
-        'pool_size': 10,
-        'pool_recycle': 3600,
-        'pool_pre_ping': True
-    }
     
     # Flask配置
     SECRET_KEY = os.getenv('SECRET_KEY', '')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,19 +23,3 @@ services:
     image: redis:7-alpine
     ports:
       - "6379:6379"
-
-  mysql:
-    image: mysql:8
-    command: --default-authentication-plugin=mysql_native_password
-    profiles:
-      - legacy-mysql
-    environment:
-      MYSQL_DATABASE: stock_cursor
-      MYSQL_ROOT_PASSWORD: root
-    ports:
-      - "3306:3306"
-    volumes:
-      - mysql_data:/var/lib/mysql
-
-volumes:
-  mysql_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
     env_file:
       - .env
     depends_on:
-      - mysql
       - redis
 
   worker:
@@ -18,7 +17,6 @@ services:
     env_file:
       - .env
     depends_on:
-      - mysql
       - redis
 
   redis:
@@ -29,6 +27,8 @@ services:
   mysql:
     image: mysql:8
     command: --default-authentication-plugin=mysql_native_password
+    profiles:
+      - legacy-mysql
     environment:
       MYSQL_DATABASE: stock_cursor
       MYSQL_ROOT_PASSWORD: root

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ eventlet>=0.33.0
 
 # 数据库相关
 SQLAlchemy>=2.0.0
-PyMySQL>=1.1.0
 Flask-SQLAlchemy>=3.0.0
 Flask-Migrate>=4.0.0
 

--- a/tests/api/test_portfolio_create_api.py
+++ b/tests/api/test_portfolio_create_api.py
@@ -16,9 +16,9 @@ def test_create_portfolio_position_endpoint_creates_first_position(app):
         "sector": "银行",
     }
 
-    with patch("app.api.realtime_risk.PortfolioPosition") as portfolio_model, patch("app.api.realtime_risk.db") as db:
+    with patch("app.api.realtime_risk.PortfolioPosition") as portfolio_model:
         portfolio_model.get_position_by_stock.return_value = None
-        portfolio_model.return_value.to_dict.return_value = {
+        portfolio_model.create_position.return_value.to_dict.return_value = {
             "portfolio_id": "growth_a",
             "ts_code": "000001.SZ",
         }
@@ -29,8 +29,7 @@ def test_create_portfolio_position_endpoint_creates_first_position(app):
     data = response.get_json()
     assert data["success"] is True
     assert data["data"]["portfolio_id"] == "growth_a"
-    db.session.add.assert_called_once()
-    db.session.commit.assert_called_once()
+    portfolio_model.create_position.assert_called_once()
 
 
 def test_create_portfolio_position_endpoint_rejects_duplicate_stock(app):

--- a/tests/api/test_portfolio_position_update_api.py
+++ b/tests/api/test_portfolio_position_update_api.py
@@ -16,22 +16,25 @@ def test_update_portfolio_position_endpoint_updates_supported_fields(app):
         "stop_loss_price": 9.8,
         "take_profit_price": 12.6,
     }
-    position = type(
-        "Position",
-        (),
-        {
-            "position_size": 1000.0,
-            "avg_cost": 10.0,
-            "current_price": 10.0,
-            "sector": None,
-            "stop_loss_price": None,
-            "take_profit_price": None,
-            "market_value": None,
-            "unrealized_pnl": None,
-            "to_dict": lambda self: {
-                "id": 7,
-                "portfolio_id": "growth_a",
-                "ts_code": "000001.SZ",
+    class Position:
+        def __init__(self):
+            self.id = 7
+            self.portfolio_id = "growth_a"
+            self.ts_code = "000001.SZ"
+            self.position_size = 1000.0
+            self.avg_cost = 10.0
+            self.current_price = 10.0
+            self.sector = None
+            self.stop_loss_price = None
+            self.take_profit_price = None
+            self.market_value = None
+            self.unrealized_pnl = None
+
+        def to_dict(self):
+            return {
+                "id": self.id,
+                "portfolio_id": self.portfolio_id,
+                "ts_code": self.ts_code,
                 "position_size": self.position_size,
                 "avg_cost": self.avg_cost,
                 "current_price": self.current_price,
@@ -40,12 +43,19 @@ def test_update_portfolio_position_endpoint_updates_supported_fields(app):
                 "take_profit_price": self.take_profit_price,
                 "market_value": self.market_value,
                 "unrealized_pnl": self.unrealized_pnl,
-            },
-        },
-    )()
+            }
 
-    with patch("app.api.realtime_risk.PortfolioPosition") as portfolio_model, patch("app.api.realtime_risk.db") as db:
-        portfolio_model.query.filter_by.return_value.first.return_value = position
+    def update_position_by_id(*_args, **kwargs):
+        position = Position()
+        for key, value in kwargs.items():
+            if value is not None:
+                setattr(position, key, value)
+        position.market_value = position.position_size * position.current_price
+        position.unrealized_pnl = (position.current_price - position.avg_cost) * position.position_size
+        return position
+
+    with patch("app.api.realtime_risk.PortfolioPosition") as portfolio_model:
+        portfolio_model.update_position_by_id.side_effect = update_position_by_id
 
         response = client.put("/api/realtime-analysis/risk/portfolio/growth_a/positions/7", json=payload)
 
@@ -58,14 +68,14 @@ def test_update_portfolio_position_endpoint_updates_supported_fields(app):
     assert data["data"]["sector"] == "银行"
     assert data["data"]["market_value"] == 13440.0
     assert data["data"]["unrealized_pnl"] == pytest.approx(840.0)
-    db.session.commit.assert_called_once()
+    portfolio_model.update_position_by_id.assert_called_once()
 
 
 def test_update_portfolio_position_endpoint_returns_not_found_when_missing(app):
     client = app.test_client()
 
     with patch("app.api.realtime_risk.PortfolioPosition") as portfolio_model:
-        portfolio_model.query.filter_by.return_value.first.return_value = None
+        portfolio_model.update_position_by_id.return_value = None
 
         response = client.put(
             "/api/realtime-analysis/risk/portfolio/growth_a/positions/7",

--- a/tests/api/test_realtime_report_contract.py
+++ b/tests/api/test_realtime_report_contract.py
@@ -46,11 +46,6 @@ class _ReportTypeGroupQuery:
         ]
 
 
-class _FakeSession:
-    def query(self, *args, **kwargs):
-        return _ReportTypeGroupQuery()
-
-
 def test_reports_blueprint_is_registered_under_expected_prefix():
     app = _build_app()
     client = app.test_client()
@@ -130,7 +125,7 @@ def test_report_metadata_endpoints_expose_stable_response_shape():
             patch("app.api.realtime_report.RealtimeReport.query", report_query),
             patch("app.api.realtime_report.ReportTemplate.query", template_query),
             patch("app.api.realtime_report.ReportSubscription.query", subscription_query),
-            patch("app.api.realtime_report.db.session", _FakeSession()),
+            patch("app.models.realtime_report.db.session.query", return_value=_ReportTypeGroupQuery()),
         ):
             report_types = client.get("/api/realtime-analysis/reports/report-types")
             schedule_types = client.get("/api/realtime-analysis/reports/schedule-types")
@@ -154,3 +149,67 @@ def test_report_metadata_endpoints_expose_stable_response_shape():
     assert statistics_data["data"]["templates"]["active"] == 2
     assert statistics_data["data"]["subscriptions"]["active"] == 3
     assert statistics_data["data"]["report_type_stats"]["daily_summary"] == 2
+
+
+def test_update_report_template_forwards_updated_fields():
+    app = _build_app()
+    client = app.test_client()
+
+    template = SimpleNamespace(
+        id=12,
+        template_name="原模板",
+        template_type="daily_summary",
+        description="原描述",
+        is_active=True,
+        is_default=False,
+        to_dict=lambda: {
+            "id": 12,
+            "template_name": "原模板",
+            "template_type": "daily_summary",
+            "description": "原描述",
+            "components": [],
+            "is_active": True,
+            "is_default": False,
+        },
+    )
+
+    updated_template = SimpleNamespace(
+        to_dict=lambda: {
+            "id": 12,
+            "template_name": "新模板",
+            "template_type": "market_overview",
+            "description": "新描述",
+            "components": ["summary"],
+            "is_active": False,
+            "is_default": True,
+        }
+    )
+
+    with (
+        patch("app.api.realtime_report.ReportTemplate.get_by_id", return_value=template),
+        patch("app.api.realtime_report.ReportTemplate.update_template_by_id", return_value=updated_template) as update_template,
+    ):
+        response = client.put(
+            "/api/realtime-analysis/reports/templates/12",
+            json={
+                "template_name": "新模板",
+                "template_type": "market_overview",
+                "description": "新描述",
+                "components": ["summary"],
+                "is_active": False,
+                "is_default": True,
+            },
+        )
+
+    assert response.status_code == 200
+    assert update_template.call_args.kwargs == {
+        "template_name": "新模板",
+        "template_type": "market_overview",
+        "description": "新描述",
+        "components": ["summary"],
+        "is_active": False,
+        "is_default": True,
+    }
+    data = response.get_json()
+    assert data["success"] is True
+    assert data["data"]["template_name"] == "新模板"

--- a/tests/api/test_sqlite_parquet_runtime_contract.py
+++ b/tests/api/test_sqlite_parquet_runtime_contract.py
@@ -3,6 +3,9 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pandas as pd
+from flask import Flask
+
+from app.api.realtime_indicators import realtime_indicators_bp
 
 
 class _BlockedQuery:
@@ -44,20 +47,27 @@ def _write_minute_parquet(root: Path) -> None:
     pd.DataFrame(rows).to_parquet(minute_dir / "data.parquet", index=False)
 
 
-def test_indicator_calculation_runs_without_orm_backed_mysql_path(app, tmp_path, monkeypatch):
+def _build_app() -> Flask:
+    app = Flask(__name__)
+    app.register_blueprint(realtime_indicators_bp, url_prefix="/api/realtime-analysis/indicators")
+    return app
+
+
+def test_indicator_calculation_runs_without_orm_backed_mysql_path(tmp_path, monkeypatch):
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
     _write_minute_parquet(tmp_path)
 
     with patch("app.services.realtime_indicator_engine.RealtimeIndicator", _BlockedRealtimeIndicator):
-        response = app.test_client().post(
-            "/api/realtime-analysis/indicators/calculate",
-            json={
-                "ts_code": "000001.SZ",
-                "period_type": "1min",
-                "indicators": ["RSI"],
-                "lookback_days": 7,
-            },
-        )
+        with _build_app().test_client() as client:
+            response = client.post(
+                "/api/realtime-analysis/indicators/calculate",
+                json={
+                    "ts_code": "000001.SZ",
+                    "period_type": "1min",
+                    "indicators": ["RSI"],
+                    "lookback_days": 7,
+                },
+            )
 
     payload = response.get_json()
     assert response.status_code == 200

--- a/tests/api/test_sqlite_parquet_runtime_contract.py
+++ b/tests/api/test_sqlite_parquet_runtime_contract.py
@@ -1,0 +1,65 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+
+
+class _BlockedQuery:
+    def filter(self, *args, **kwargs):
+        raise AssertionError("indicator flow should not touch ORM-backed storage")
+
+
+class _BlockedRealtimeIndicator:
+    query = _BlockedQuery()
+
+    @staticmethod
+    def batch_insert(*args, **kwargs):
+        raise AssertionError("indicator flow should not write through ORM-backed storage")
+
+
+def _write_minute_parquet(root: Path) -> None:
+    minute_dir = root / "stock_minute" / "1min" / "year=2026" / "month=06" / "day=04"
+    minute_dir.mkdir(parents=True, exist_ok=True)
+
+    base_time = datetime(2026, 6, 4, 9, 31)
+    rows = []
+    for idx in range(60):
+        dt = base_time + timedelta(minutes=idx)
+        close = 10.0 + idx * 0.05
+        rows.append(
+            {
+                "ts_code": "000001.SZ",
+                "period_type": "1min",
+                "datetime": dt,
+                "open": close - 0.05,
+                "high": close + 0.1,
+                "low": close - 0.1,
+                "close": close,
+                "volume": 1000 + idx * 20,
+                "amount": (1000 + idx * 20) * close,
+            }
+        )
+
+    pd.DataFrame(rows).to_parquet(minute_dir / "data.parquet", index=False)
+
+
+def test_indicator_calculation_runs_without_orm_backed_mysql_path(app, tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    _write_minute_parquet(tmp_path)
+
+    with patch("app.services.realtime_indicator_engine.RealtimeIndicator", _BlockedRealtimeIndicator):
+        response = app.test_client().post(
+            "/api/realtime-analysis/indicators/calculate",
+            json={
+                "ts_code": "000001.SZ",
+                "period_type": "1min",
+                "indicators": ["RSI"],
+                "lookback_days": 7,
+            },
+        )
+
+    payload = response.get_json()
+    assert response.status_code == 200
+    assert payload["success"] is True
+    assert payload["stored_records"] > 0

--- a/tests/data_jobs/test_state_store.py
+++ b/tests/data_jobs/test_state_store.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from types import SimpleNamespace
 
 import pytest
 
@@ -7,32 +7,62 @@ from app.services.data_jobs.state_store import DataJobStateStore
 pytestmark = pytest.mark.module_data_jobs
 
 
-def test_create_run_sets_pending_status():
-    session = MagicMock()
-    store = DataJobStateStore(session)
+class _FakeStateStore:
+    def __init__(self):
+        self.calls = []
 
-    run = store.create_run("stock_basic", {"start_date": "20250101"})
+    def create_run(self, **kwargs):
+        self.calls.append(("create_run", kwargs))
+        return SimpleNamespace(**kwargs)
 
-    assert run.status == "pending"
+    def find_active_duplicate(self, job_type, params):
+        self.calls.append(("find_active_duplicate", job_type, params))
+        return None
+
+    def get_run(self, run_id):
+        self.calls.append(("get_run", run_id))
+        return SimpleNamespace(id=run_id)
+
+    def update_run_status(self, run, status, progress=None, error_message=None, progress_message=None):
+        self.calls.append(("update_run_status", run, status, progress, error_message, progress_message))
+        return SimpleNamespace(id=run.id, status=status)
+
+    def save_run(self, run):
+        self.calls.append(("save_run", run))
+        return run
+
+    def upsert_cursor(self, job_type, cursor_key, cursor_value):
+        self.calls.append(("upsert_cursor", job_type, cursor_key, cursor_value))
+        return SimpleNamespace(job_type=job_type, cursor_key=cursor_key, cursor_value=cursor_value)
+
+    def list_runs(self, limit=50, status=None):
+        self.calls.append(("list_runs", limit, status))
+        return [SimpleNamespace(id=1)]
+
+
+def test_state_store_delegates_to_parquet_backend():
+    backend = _FakeStateStore()
+    store = DataJobStateStore(state_store=backend)
+
+    run = store.create_run("stock_basic", {"start_date": "20260101"}, source_name="tushare")
     assert run.job_type == "stock_basic"
-    session.add.assert_called_once()
-    session.commit.assert_called_once()
 
+    assert store.find_active_duplicate("stock_basic", {"start_date": "20260101"}) is None
+    assert store.get_run(7).id == 7
 
-def test_update_run_status_persists_progress_message():
-    session = MagicMock()
-    run = MagicMock(
-        status="pending",
-        progress=0.0,
-        error_message=None,
-        started_at=None,
-        finished_at=None,
-    )
-    store = DataJobStateStore(session)
+    updated = store.update_run_status(SimpleNamespace(id=7), "running", progress=10.0, progress_message="处理中")
+    assert updated.status == "running"
 
-    store.update_run_status(run, "running", progress=15.0, progress_message="下载中")
+    assert store.save_run(SimpleNamespace(id=8)).id == 8
+    assert store.upsert_cursor("stock_basic", "daily", "2026-06-05").cursor_key == "daily"
+    assert len(store.list_runs(limit=5, status="failed")) == 1
 
-    assert run.status == "running"
-    assert run.progress == 15.0
-    assert run.progress_message == "下载中"
-    session.commit.assert_called_once()
+    assert [call[0] for call in backend.calls] == [
+        "create_run",
+        "find_active_duplicate",
+        "get_run",
+        "update_run_status",
+        "save_run",
+        "upsert_cursor",
+        "list_runs",
+    ]

--- a/tests/data_jobs/test_utils_scripts_incremental.py
+++ b/tests/data_jobs/test_utils_scripts_incremental.py
@@ -15,10 +15,10 @@ SCRIPTS = [
 ]
 
 
-def test_scripts_use_job_env_helper():
+def test_scripts_use_parquet_job_helpers():
     for rel in SCRIPTS:
         content = Path(rel).read_text(encoding="utf-8").lower()
-        assert "from job_env import" in content
+        assert "from parquet_job_helpers import" in content
 
 
 def test_scripts_do_not_truncate_tables():

--- a/tests/docs/test_mysql_language_contract.py
+++ b/tests/docs/test_mysql_language_contract.py
@@ -21,6 +21,8 @@ def test_docs_and_prompt_language_default_to_parquet_not_mysql():
         assert phrase not in claude
         assert phrase not in llm_service
 
-    assert "Parquet 文件（默认）" in readme
+    # README should describe Parquet as the data source
+    assert "不需要 MySQL" in readme or "不需要再安装mysql" in readme
     assert "DATA_SOURCE" in claude
-    assert "默认兼容 MySQL 语法" in llm_service
+    # LLM prompt should target SQLite, not MySQL
+    assert "目标数据库是 SQLite" in llm_service

--- a/tests/services/test_realtime_report_generator.py
+++ b/tests/services/test_realtime_report_generator.py
@@ -71,9 +71,15 @@ class _FakeSignal:
 
     def to_dict(self):
         return {
+            "datetime": self.created_at,
             "signal_type": self.signal_type,
             "strategy_name": self.strategy_name,
             "signal_strength": self.signal_strength,
+            "period_type": "5min",
+            "ts_code": "000001.SZ",
+            "confidence": 0.8,
+            "trigger_price": 10.0,
+            "status": "ACTIVE",
         }
 
 
@@ -116,6 +122,25 @@ class _FakeDBSession:
         return _FakeStatsQuery(self.indicator_rows)
 
 
+class _FakeEventStore:
+    def __init__(self, indicator_rows=None, signal_rows=None, minute_frame=None):
+        self.indicator_rows = indicator_rows or []
+        self.signal_rows = signal_rows or []
+        self.minute_frame = minute_frame or pd.DataFrame()
+
+    def get_indicators_by_time_range(self, **kwargs):
+        return pd.DataFrame(self.indicator_rows)
+
+    def get_signals_by_time_range(self, **kwargs):
+        rows = []
+        for row in self.signal_rows:
+            if hasattr(row, "to_dict"):
+                rows.append(row.to_dict())
+            else:
+                rows.append(row)
+        return pd.DataFrame(rows)
+
+
 def _write_minute_assets(tmp_path: Path):
     minute_dir = tmp_path / "stock_minute" / "5min" / "year=2026" / "month=06" / "day=05"
     minute_dir.mkdir(parents=True)
@@ -153,22 +178,18 @@ def test_daily_summary_and_market_overview_use_5min_parquet(tmp_path, monkeypatc
 
     generator = RealtimeReportGenerator()
 
-    indicator_rows = [type("Row", (), {"indicator_name": "RSI", "count": 3})(), type("Row", (), {"indicator_name": "MACD", "count": 2})()]
-    fake_indicator_model = type(
-        "FakeIndicatorModel",
-        (),
-        {
-            "id": _ComparableField("id"),
-            "datetime": _ComparableField("datetime"),
-            "period_type": _ComparableField("period_type"),
-            "indicator_name": _ComparableField("indicator_name"),
-            "query": _ReportQuery(rows=[object(), object()]),
-        },
+    fake_store = _FakeEventStore(
+        indicator_rows=[
+            {"indicator_name": "RSI"},
+            {"indicator_name": "RSI"},
+            {"indicator_name": "RSI"},
+            {"indicator_name": "MACD"},
+            {"indicator_name": "MACD"},
+        ],
+        signal_rows=[_FakeSignal(signal_type="BUY", strategy_name="trend_following", signal_strength=0.7)],
     )
 
-    with patch("app.services.realtime_report_generator.RealtimeIndicator", fake_indicator_model), patch(
-        "app.services.realtime_report_generator.TradingSignal", _FakeSignalModel
-    ), patch("app.services.realtime_report_generator.db.session", _FakeDBSession(indicator_rows)), patch(
+    with patch.object(generator, "event_store", fake_store), patch(
         "app.services.realtime_report_generator.datetime", FixedDateTime
     ):
         daily = generator._collect_daily_summary_data()
@@ -176,7 +197,7 @@ def test_daily_summary_and_market_overview_use_5min_parquet(tmp_path, monkeypatc
 
     assert daily["market_data"]["minute_data_points"] == 2
     assert daily["market_data"]["active_stocks"] == 2
-    assert daily["market_data"]["technical_indicators"] == 2
+    assert daily["market_data"]["technical_indicators"] == 5
     assert daily["market_data"]["trading_signals"] == 1
     assert market["market_overview"]["active_stocks"] == 2
     assert market["market_overview"]["total_volume"] == 3000
@@ -188,30 +209,19 @@ def test_signal_analysis_filters_by_five_minute_period(tmp_path, monkeypatch):
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
 
     generator = RealtimeReportGenerator()
-    query = _ReportQuery(rows=[_FakeSignal(signal_type="BUY", strategy_name="trend_following", signal_strength=0.7)])
+    signal_rows = [
+        _FakeSignal(signal_type="BUY", strategy_name="trend_following", signal_strength=0.7),
+        _FakeSignal(signal_type="SELL", strategy_name="trend_following", signal_strength=-0.5),
+    ]
+    fake_store = _FakeEventStore(signal_rows=signal_rows)
 
-    fake_signal_model = type(
-        "FakeSignalModel",
-        (),
-        {
-            "created_at": _ComparableField("created_at"),
-            "period_type": _ComparableField("period_type"),
-            "signal_type": _ComparableField("signal_type"),
-            "strategy_name": _ComparableField("strategy_name"),
-            "query": query,
-        },
-    )
-
-    with patch("app.services.realtime_report_generator.TradingSignal", fake_signal_model), patch(
+    with patch.object(generator, "event_store", fake_store), patch(
         "app.services.realtime_report_generator.datetime", FixedDateTime
     ):
         signal_data = generator._collect_signal_data()
 
-    assert query.filters, "expected report generator to query trading signals"
-    assert any(
-        isinstance(item, tuple) and item[:3] == ("eq", "period_type", "5min") for item in query.filters
-    ), query.filters
-    assert signal_data["signal_summary"]["total_signals"] == 1
+    assert signal_data["signal_summary"]["total_signals"] == 2
+    assert signal_data["signal_summary"]["period_type"] == "5min"
 
 
 def test_generate_report_keeps_market_overview_payload_shape(tmp_path, monkeypatch):
@@ -231,13 +241,14 @@ def test_generate_report_keeps_market_overview_payload_shape(tmp_path, monkeypat
         report.id = 1
         report.report_name = "mock"
         report.report_type = "market_overview"
-        report.update_status.return_value = None
+        report.update_generation_result.return_value = None
 
         result = generator.generate_report("market_overview", parameters={})
 
     assert result["success"] is True
     assert "content" in result["data"]
     assert "data" in result["data"]
+    report.update_generation_result.assert_called()
 
 
 def test_daily_summary_and_market_overview_count_today_five_minute_data_only(tmp_path, monkeypatch):
@@ -245,32 +256,12 @@ def test_daily_summary_and_market_overview_count_today_five_minute_data_only(tmp
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
 
     generator = RealtimeReportGenerator()
-    indicator_rows = [type("Row", (), {"indicator_name": "RSI", "count": 2})()]
-
-    fake_indicator_model = type(
-        "FakeIndicatorModel",
-        (),
-        {
-            "id": _ComparableField("id"),
-            "datetime": _ComparableField("datetime"),
-            "period_type": _ComparableField("period_type"),
-            "indicator_name": _ComparableField("indicator_name"),
-            "query": _ReportQuery(rows=[object(), object()]),
-        },
-    )
-    fake_signal_model = type(
-        "FakeSignalModel",
-        (),
-        {
-            "created_at": _ComparableField("created_at"),
-            "period_type": _ComparableField("period_type"),
-            "query": _ReportQuery(rows=[_FakeSignal(signal_type="BUY", strategy_name="trend_following", signal_strength=0.7)]),
-        },
+    fake_store = _FakeEventStore(
+        indicator_rows=[{"indicator_name": "RSI"}, {"indicator_name": "RSI"}],
+        signal_rows=[_FakeSignal(signal_type="BUY", strategy_name="trend_following", signal_strength=0.7)],
     )
 
-    with patch("app.services.realtime_report_generator.RealtimeIndicator", fake_indicator_model), patch(
-        "app.services.realtime_report_generator.TradingSignal", fake_signal_model
-    ), patch("app.services.realtime_report_generator.db.session", _FakeDBSession(indicator_rows)), patch(
+    with patch.object(generator, "event_store", fake_store), patch(
         "app.services.realtime_report_generator.datetime", FixedDateTime
     ):
         daily = generator._collect_daily_summary_data()

--- a/tests/test_config_data_source_contract.py
+++ b/tests/test_config_data_source_contract.py
@@ -1,16 +1,9 @@
-import pytest
-
 from config import Config
-from app.utils.db_utils import DatabaseUtils
 
 
 def test_parquet_is_the_default_data_source():
     assert Config.DATA_SOURCE == "parquet"
-    assert Config.MYSQL_DATABASE_URI.startswith("mysql+pymysql://")
-
-
-def test_mysql_connection_is_explicitly_compatibility_only(monkeypatch):
-    monkeypatch.setattr(DatabaseUtils, "_mysql_compat_enabled", False, raising=False)
-
-    with pytest.raises(RuntimeError, match="MySQL compatibility layer is disabled"):
-        DatabaseUtils.connect_to_mysql()
+    assert Config.SQLALCHEMY_DATABASE_URI.startswith("sqlite:///")
+    assert Config.SQLITE_DATABASE_URI == Config.SQLALCHEMY_DATABASE_URI
+    assert not hasattr(Config, "MYSQL_DATABASE_URI")
+    assert not hasattr(Config, "MYSQL_COMPAT_ENABLED")

--- a/tests/test_storage_boundary_contract.py
+++ b/tests/test_storage_boundary_contract.py
@@ -14,8 +14,8 @@ def test_sqlalchemy_defaults_to_sqlite_while_market_data_defaults_to_parquet():
     assert config_module.Config.SQLALCHEMY_DATABASE_URI.startswith("sqlite:///")
     assert config_module.Config.SQLALCHEMY_DATABASE_URI.endswith("stock_cursor.sqlite3")
     assert config_module.Config.SQLITE_DATABASE_URI == config_module.Config.SQLALCHEMY_DATABASE_URI
-    assert config_module.Config.MYSQL_COMPAT_ENABLED is False
-    assert config_module.Config.MYSQL_DATABASE_URI.startswith("mysql+pymysql://")
+    assert not hasattr(config_module.Config, "MYSQL_COMPAT_ENABLED")
+    assert not hasattr(config_module.Config, "MYSQL_DATABASE_URI")
 
 
 def test_app_models_initialize_against_sqlite_default():
@@ -23,5 +23,6 @@ def test_app_models_initialize_against_sqlite_default():
 
     with app.app_context():
         assert app.config["SQLALCHEMY_DATABASE_URI"].startswith("sqlite:///")
+        assert app.config["DATA_SOURCE"] == "parquet"
         assert db.engine.url.get_backend_name() == "sqlite"
         assert db.engine.url.database.endswith("stock_cursor.sqlite3")

--- a/tests/test_storage_boundary_contract.py
+++ b/tests/test_storage_boundary_contract.py
@@ -1,0 +1,11 @@
+import importlib
+from unittest.mock import patch
+
+
+def test_sqlalchemy_defaults_to_sqlite_while_market_data_defaults_to_parquet():
+    with patch("dotenv.load_dotenv", return_value=False):
+        config_module = importlib.import_module("config")
+        config_module = importlib.reload(config_module)
+
+    assert config_module.Config.DATA_SOURCE == "parquet"
+    assert config_module.Config.SQLALCHEMY_DATABASE_URI.startswith("sqlite:///")

--- a/tests/test_storage_boundary_contract.py
+++ b/tests/test_storage_boundary_contract.py
@@ -1,6 +1,9 @@
 import importlib
 from unittest.mock import patch
 
+from app import create_app
+from app.extensions import db
+
 
 def test_sqlalchemy_defaults_to_sqlite_while_market_data_defaults_to_parquet():
     with patch("dotenv.load_dotenv", return_value=False):
@@ -9,3 +12,16 @@ def test_sqlalchemy_defaults_to_sqlite_while_market_data_defaults_to_parquet():
 
     assert config_module.Config.DATA_SOURCE == "parquet"
     assert config_module.Config.SQLALCHEMY_DATABASE_URI.startswith("sqlite:///")
+    assert config_module.Config.SQLALCHEMY_DATABASE_URI.endswith("stock_cursor.sqlite3")
+    assert config_module.Config.SQLITE_DATABASE_URI == config_module.Config.SQLALCHEMY_DATABASE_URI
+    assert config_module.Config.MYSQL_COMPAT_ENABLED is False
+    assert config_module.Config.MYSQL_DATABASE_URI.startswith("mysql+pymysql://")
+
+
+def test_app_models_initialize_against_sqlite_default():
+    app = create_app()
+
+    with app.app_context():
+        assert app.config["SQLALCHEMY_DATABASE_URI"].startswith("sqlite:///")
+        assert db.engine.url.get_backend_name() == "sqlite"
+        assert db.engine.url.database.endswith("stock_cursor.sqlite3")

--- a/tests/utils/test_no_mysql_runtime_contract.py
+++ b/tests/utils/test_no_mysql_runtime_contract.py
@@ -1,12 +1,18 @@
 from pathlib import Path
 
 
-def test_docs_and_config_label_mysql_as_legacy_only():
+def test_docs_config_and_llm_prompt_do_not_assume_mysql_as_default():
     readme = Path("README.md").read_text(encoding="utf-8")
     claude = Path("CLAUDE.md").read_text(encoding="utf-8")
     config_source = Path("config.py").read_text(encoding="utf-8")
+    llm_service = Path("app/services/llm_service.py").read_text(encoding="utf-8")
 
     assert "仍需 MySQL 5.7 或 8.x" not in readme
     assert "默认会同时启动 Web、MySQL 和 Redis" not in readme
-    assert "MySQL-compatible app state" not in claude
-    assert "SQLALCHEMY_DATABASE_URI = MYSQL_DATABASE_URI" not in config_source
+    assert "DB_HOST, DB_USER, DB_PASSWORD, DB_NAME" not in claude
+    assert "MYSQL_DATABASE_URI" not in config_source
+    assert "MYSQL_COMPAT_ENABLED" not in config_source
+    assert "默认兼容 MySQL 语法" not in llm_service
+    assert "MySQL" not in llm_service
+    assert "目标数据库是 SQLite" in llm_service
+    assert "SQLite 兼容" in llm_service

--- a/tests/utils/test_no_mysql_runtime_contract.py
+++ b/tests/utils/test_no_mysql_runtime_contract.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_docs_and_config_label_mysql_as_legacy_only():
+    readme = Path("README.md").read_text(encoding="utf-8")
+    claude = Path("CLAUDE.md").read_text(encoding="utf-8")
+    config_source = Path("config.py").read_text(encoding="utf-8")
+
+    assert "仍需 MySQL 5.7 或 8.x" not in readme
+    assert "默认会同时启动 Web、MySQL 和 Redis" not in readme
+    assert "MySQL-compatible app state" not in claude
+    assert "SQLALCHEMY_DATABASE_URI = MYSQL_DATABASE_URI" not in config_source


### PR DESCRIPTION
## Summary

Remove MySQL from the normal project runtime by moving market data and derived analytics to Parquet, and moving application state tables to SQLite.

## Plan

Based on `docs/plans/2026-06-05-sqlite-parquet-migration-plan.md` — 6 tasks, all complete.

## Commits

| # | Commit | Scope |
|---|---|---|
| 1 | `feat: move app state models to sqlite` | Report templates/subscriptions, risk alerts, query templates/history, portfolio positions → SQLite ORM via `persistence.py` helpers |
| 2 | `feat: move indicator and signal history to parquet` | `ParquetEventStore` for indicator/signal events; `BigInteger` → `Integer` AUTOINCREMENT fix; index name collision fix |
| 3 | `docs: align runtime guidance with sqlite parquet migration` | Remove all MySQL config, add DeepSeek LLM env-var config, fix LLM prompt to SQLite dialect |
| 4 | `test: fix pre-existing test failures and verify migration` | Fix 12 pre-existing test failures (startup_health, UI copy contracts, etc.) |

## Bugs Fixed (found during verification)

- `ml_predictions.py` index name `idx_ts_code_date` conflicted with `factor_values.py` → `db.create_all()` failed
- 5 models used `db.BigInteger` primary key — SQLite does not AUTOINCREMENT `BIGINT` → `db.Integer`
- `text2sql_engine.py` used `logger` without importing it → `NameError` at runtime
- LLM prompt generated MySQL SQL (`DATE_SUB`, `CURDATE()`) while backend is SQLite → added SQLite dialect instructions

## Test Results

```
334 passed, 0 failed, 1 skipped, 81 warnings
```

## Verification Performed

- [x] All 14 migration contract tests pass
- [x] Full regression suite: 334 passed, 0 failed
- [x] API end-to-end tested with running server:
  - Report template CRUD ✅
  - Report subscription CRUD ✅
  - Report generation (reads Parquet data) ✅
  - Risk alert create + resolve ✅
  - Text2SQL query → SQLite execution + history persistence ✅
  - DeepSeek LLM integration → generates SQLite-compatible SQL ✅
  - Indicator stats from Parquet ✅
  - Signal history from Parquet ✅
  - Portfolio list ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)