### PR TITLE
fix: 风险管理页面数据源对齐及前端Bug修复

### DIFF
--- a/app/api/realtime_risk.py
+++ b/app/api/realtime_risk.py
@@ -1,14 +1,14 @@
 """
 实时风险管理API接口
 提供风险计算、监控、预警和止损止盈管理功能
+数据源：Parquet（通过 PortfolioRepository）
 """
 
 from flask import Blueprint, request, jsonify
 from datetime import datetime
 import logging
 
-from app.services.realtime_risk_manager import RealtimeRiskManager
-from app.models.portfolio_position import PortfolioPosition
+from app.services.realtime_risk_manager import RealtimeRiskManager, _portfolio_repo, _update_market_data_inplace, _save_position
 from app.models.risk_alert import RiskAlert
 
 logger = logging.getLogger(__name__)
@@ -27,13 +27,13 @@ def calculate_portfolio_risk():
         data = request.get_json()
         portfolio_id = data.get('portfolio_id')
         period_days = data.get('period_days', 252)
-        
+
         if not portfolio_id:
             return jsonify({'success': False, 'message': '组合ID不能为空'})
-        
+
         result = risk_manager.calculate_portfolio_risk(portfolio_id, period_days)
         return jsonify(result)
-        
+
     except Exception as e:
         logger.error(f"计算组合风险失败: {str(e)}")
         return jsonify({'success': False, 'message': str(e)})
@@ -44,13 +44,13 @@ def monitor_position_risk():
     """监控持仓风险"""
     try:
         portfolio_id = request.args.get('portfolio_id')
-        
+
         if not portfolio_id:
             return jsonify({'success': False, 'message': '组合ID不能为空'})
-        
+
         result = risk_manager.monitor_position_risk(portfolio_id)
         return jsonify(result)
-        
+
     except Exception as e:
         logger.error(f"监控持仓风险失败: {str(e)}")
         return jsonify({'success': False, 'message': str(e)})
@@ -66,10 +66,10 @@ def manage_stop_loss_take_profit():
         stop_loss_value = float(data.get('stop_loss_value', 0.10))
         take_profit_method = data.get('take_profit_method', 'percentage')
         take_profit_value = float(data.get('take_profit_value', 0.20))
-        
+
         if not portfolio_id:
             return jsonify({'success': False, 'message': '组合ID不能为空'})
-        
+
         result = risk_manager.manage_stop_loss_take_profit(
             portfolio_id=portfolio_id,
             stop_loss_method=stop_loss_method,
@@ -77,9 +77,9 @@ def manage_stop_loss_take_profit():
             take_profit_method=take_profit_method,
             take_profit_value=take_profit_value
         )
-        
+
         return jsonify(result)
-        
+
     except Exception as e:
         logger.error(f"管理止损止盈失败: {str(e)}")
         return jsonify({'success': False, 'message': str(e)})
@@ -92,15 +92,15 @@ def get_risk_alerts():
         portfolio_id = request.args.get('portfolio_id')
         alert_level = request.args.get('alert_level')
         active_only = request.args.get('active_only', 'true').lower() == 'true'
-        
+
         result = risk_manager.get_risk_alerts(
             portfolio_id=portfolio_id,
             alert_level=alert_level,
             active_only=active_only
         )
-        
+
         return jsonify(result)
-        
+
     except Exception as e:
         logger.error(f"获取风险预警失败: {str(e)}")
         return jsonify({'success': False, 'message': str(e)})
@@ -117,10 +117,10 @@ def create_risk_alert():
         alert_message = data.get('alert_message')
         risk_value = data.get('risk_value')
         threshold_value = data.get('threshold_value')
-        
+
         if not all([ts_code, alert_type, alert_level, alert_message]):
             return jsonify({'success': False, 'message': '必填字段不能为空'})
-        
+
         result = risk_manager.create_risk_alert(
             ts_code=ts_code,
             alert_type=alert_type,
@@ -129,9 +129,9 @@ def create_risk_alert():
             risk_value=risk_value,
             threshold_value=threshold_value
         )
-        
+
         return jsonify(result)
-        
+
     except Exception as e:
         logger.error(f"创建风险预警失败: {str(e)}")
         return jsonify({'success': False, 'message': str(e)})
@@ -142,16 +142,16 @@ def resolve_risk_alert(alert_id):
     """解决风险预警"""
     try:
         alert = RiskAlert.resolve_by_id(alert_id)
-        
+
         if not alert:
             return jsonify({'success': False, 'message': '预警记录不存在'})
-        
+
         return jsonify({
             'success': True,
             'data': alert.to_dict(),
             'message': '预警已解决'
         })
-        
+
     except Exception as e:
         logger.error(f"解决风险预警失败: {str(e)}")
         return jsonify({'success': False, 'message': str(e)})
@@ -167,32 +167,34 @@ def create_portfolio_position():
         position_size = float(data.get('position_size'))
         avg_cost = float(data.get('avg_cost'))
         sector = data.get('sector')
-        
+
         if not all([portfolio_id, ts_code, position_size, avg_cost]):
             return jsonify({'success': False, 'message': '必填字段不能为空'})
-        
+
         # 检查是否已存在
-        existing_position = PortfolioPosition.get_position_by_stock(portfolio_id, ts_code)
+        existing_position = _portfolio_repo.get_position_by_stock(portfolio_id, ts_code)
         if existing_position:
             return jsonify({'success': False, 'message': '该股票持仓已存在'})
-        
+
         # 创建持仓
-        position = PortfolioPosition.create_position(
-            portfolio_id=portfolio_id,
-            ts_code=ts_code,
-            position_size=position_size,
-            avg_cost=avg_cost,
-            current_price=avg_cost,  # 初始价格设为成本价
-            market_value=position_size * avg_cost,
-            sector=sector
-        )
+        position = _portfolio_repo.upsert_position({
+            'portfolio_id': portfolio_id,
+            'ts_code': ts_code,
+            'position_size': position_size,
+            'avg_cost': avg_cost,
+            'current_price': avg_cost,  # 初始价格设为成本价
+            'market_value': position_size * avg_cost,
+            'unrealized_pnl': 0,
+            'sector': sector,
+            'is_active': True,
+        })
 
         return jsonify({
             'success': True,
-            'data': position.to_dict(),
+            'data': position,
             'message': '持仓创建成功'
         })
-        
+
     except Exception as e:
         logger.error(f"创建持仓失败: {str(e)}")
         return jsonify({'success': False, 'message': str(e)})
@@ -203,19 +205,19 @@ def get_portfolio_positions(portfolio_id):
     """获取投资组合持仓"""
     try:
         active_only = request.args.get('active_only', 'true').lower() == 'true'
-        
-        positions = PortfolioPosition.get_portfolio_positions(portfolio_id, active_only)
-        
+
+        positions = _portfolio_repo.list_positions(portfolio_id, active_only)
+
         return jsonify({
             'success': True,
             'data': {
                 'portfolio_id': portfolio_id,
-                'positions': [pos.to_dict() for pos in positions],
+                'positions': positions,
                 'total_positions': len(positions)
             },
             'message': f'获取到 {len(positions)} 个持仓'
         })
-        
+
     except Exception as e:
         logger.error(f"获取持仓失败: {str(e)}")
         return jsonify({'success': False, 'message': str(e)})
@@ -225,17 +227,17 @@ def get_portfolio_positions(portfolio_id):
 def get_portfolio_metrics(portfolio_id):
     """获取投资组合指标"""
     try:
-        metrics = PortfolioPosition.calculate_portfolio_metrics(portfolio_id)
-        
+        metrics = _portfolio_repo.calculate_metrics(portfolio_id)
+
         if not metrics:
             return jsonify({'success': False, 'message': '组合中没有持仓数据'})
-        
+
         return jsonify({
             'success': True,
             'data': metrics,
             'message': '组合指标计算成功'
         })
-        
+
     except Exception as e:
         logger.error(f"获取组合指标失败: {str(e)}")
         return jsonify({'success': False, 'message': str(e)})
@@ -246,27 +248,46 @@ def update_portfolio_position(portfolio_id, position_id):
     """更新投资组合持仓"""
     try:
         data = request.get_json()
-        
-        position = PortfolioPosition.update_position_by_id(
-            portfolio_id,
-            position_id,
-            position_size=float(data['position_size']) if 'position_size' in data else None,
-            avg_cost=float(data['avg_cost']) if 'avg_cost' in data else None,
-            current_price=float(data['current_price']) if 'current_price' in data else None,
-            sector=data.get('sector'),
-            stop_loss_price=float(data['stop_loss_price']) if 'stop_loss_price' in data else None,
-            take_profit_price=float(data['take_profit_price']) if 'take_profit_price' in data else None,
-        )
-        
-        if not position:
+
+        # 从 Parquet 中找到该持仓
+        positions = _portfolio_repo.list_positions(portfolio_id, active_only=False)
+        target = None
+        for pos in positions:
+            if pos.get('id') == position_id:
+                target = pos
+                break
+
+        if not target:
             return jsonify({'success': False, 'message': '持仓记录不存在'})
-        
+
+        # 更新字段
+        if 'position_size' in data:
+            target['position_size'] = float(data['position_size'])
+        if 'avg_cost' in data:
+            target['avg_cost'] = float(data['avg_cost'])
+        if 'current_price' in data:
+            target['current_price'] = float(data['current_price'])
+        if 'sector' in data:
+            target['sector'] = data['sector']
+        if 'stop_loss_price' in data:
+            target['stop_loss_price'] = float(data['stop_loss_price'])
+        if 'take_profit_price' in data:
+            target['take_profit_price'] = float(data['take_profit_price'])
+
+        # 重算市值和浮动盈亏
+        cp = float(target.get('current_price') or 0)
+        if cp:
+            target['market_value'] = float(target.get('position_size') or 0) * cp
+            target['unrealized_pnl'] = (cp - float(target.get('avg_cost') or 0)) * float(target.get('position_size') or 0)
+
+        _save_position(target)
+
         return jsonify({
             'success': True,
-            'data': position.to_dict(),
+            'data': target,
             'message': '持仓更新成功'
         })
-        
+
     except Exception as e:
         logger.error(f"更新持仓失败: {str(e)}")
         return jsonify({'success': False, 'message': str(e)})
@@ -274,16 +295,26 @@ def update_portfolio_position(portfolio_id, position_id):
 
 @realtime_risk_bp.route('/portfolio/<portfolio_id>/positions/<int:position_id>', methods=['DELETE'])
 def delete_portfolio_position(portfolio_id, position_id):
-    """删除投资组合持仓"""
+    """删除投资组合持仓（软删除）"""
     try:
-        if not PortfolioPosition.delete_position_by_id(portfolio_id, position_id):
+        positions = _portfolio_repo.list_positions(portfolio_id, active_only=False)
+        target = None
+        for pos in positions:
+            if pos.get('id') == position_id:
+                target = pos
+                break
+
+        if not target:
             return jsonify({'success': False, 'message': '持仓记录不存在'})
-        
+
+        target['is_active'] = False
+        _save_position(target)
+
         return jsonify({
             'success': True,
             'message': '持仓删除成功'
         })
-        
+
     except Exception as e:
         logger.error(f"删除持仓失败: {str(e)}")
         return jsonify({'success': False, 'message': str(e)})
@@ -298,7 +329,7 @@ def get_risk_thresholds():
             'data': risk_manager.risk_thresholds,
             'message': '风险阈值获取成功'
         })
-        
+
     except Exception as e:
         logger.error(f"获取风险阈值失败: {str(e)}")
         return jsonify({'success': False, 'message': str(e)})
@@ -309,18 +340,17 @@ def update_risk_thresholds():
     """更新风险阈值配置"""
     try:
         data = request.get_json()
-        
-        # 更新阈值
+
         for key, value in data.items():
             if key in risk_manager.risk_thresholds:
                 risk_manager.risk_thresholds[key] = float(value)
-        
+
         return jsonify({
             'success': True,
             'data': risk_manager.risk_thresholds,
             'message': '风险阈值更新成功'
         })
-        
+
     except Exception as e:
         logger.error(f"更新风险阈值失败: {str(e)}")
         return jsonify({'success': False, 'message': str(e)})
@@ -332,20 +362,20 @@ def batch_update_prices():
     try:
         data = request.get_json()
         portfolio_id = data.get('portfolio_id')
-        
+
         if not portfolio_id:
             return jsonify({'success': False, 'message': '组合ID不能为空'})
-        
-        positions = PortfolioPosition.get_portfolio_positions(portfolio_id)
+
+        positions = _portfolio_repo.list_positions(portfolio_id)
         updated_count = 0
-        
+
         for position in positions:
-            # 获取最新价格
-            current_price = risk_manager._get_current_price(position.ts_code)
+            current_price = risk_manager._get_current_price(position.get('ts_code', ''))
             if current_price:
-                position.update_market_data(current_price)
+                _update_market_data_inplace(position, current_price)
+                _save_position(position)
                 updated_count += 1
-        
+
         return jsonify({
             'success': True,
             'data': {
@@ -355,7 +385,7 @@ def batch_update_prices():
             },
             'message': f'成功更新 {updated_count} 个持仓的价格'
         })
-        
+
     except Exception as e:
         logger.error(f"批量更新价格失败: {str(e)}")
         return jsonify({'success': False, 'message': str(e)})
@@ -368,46 +398,43 @@ def run_stress_test():
         data = request.get_json()
         portfolio_id = data.get('portfolio_id')
         scenarios = data.get('scenarios', [])
-        
+
         if not portfolio_id:
             return jsonify({'success': False, 'message': '组合ID不能为空'})
-        
+
         if not scenarios:
-            # 默认压力测试场景
             scenarios = [
                 {'name': '市场下跌10%', 'market_shock': -0.10},
                 {'name': '市场下跌20%', 'market_shock': -0.20},
                 {'name': '波动率上升50%', 'volatility_shock': 0.50},
                 {'name': '相关性上升至0.9', 'correlation_shock': 0.90}
             ]
-        
-        # 获取组合持仓
-        positions = PortfolioPosition.get_portfolio_positions(portfolio_id)
-        
+
+        positions = _portfolio_repo.list_positions(portfolio_id)
+
         if not positions:
             return jsonify({'success': False, 'message': '组合中没有持仓数据'})
-        
+
         stress_results = []
-        
+
         for scenario in scenarios:
             scenario_result = {
                 'scenario_name': scenario['name'],
-                'original_value': sum(pos.market_value or 0 for pos in positions),
+                'original_value': sum(float(pos.get('market_value') or 0) for pos in positions),
                 'stressed_value': 0,
                 'pnl_change': 0,
                 'pnl_percentage': 0
             }
-            
-            # 简化的压力测试计算
+
             if 'market_shock' in scenario:
                 shock = scenario['market_shock']
-                stressed_value = sum((pos.market_value or 0) * (1 + shock) for pos in positions)
+                stressed_value = sum(float(pos.get('market_value') or 0) * (1 + shock) for pos in positions)
                 scenario_result['stressed_value'] = stressed_value
                 scenario_result['pnl_change'] = stressed_value - scenario_result['original_value']
-                scenario_result['pnl_percentage'] = scenario_result['pnl_change'] / scenario_result['original_value'] * 100
-            
+                scenario_result['pnl_percentage'] = scenario_result['pnl_change'] / scenario_result['original_value'] * 100 if scenario_result['original_value'] > 0 else 0
+
             stress_results.append(scenario_result)
-        
+
         return jsonify({
             'success': True,
             'data': {
@@ -419,7 +446,7 @@ def run_stress_test():
             },
             'message': f'压力测试完成，测试了 {len(scenarios)} 个场景'
         })
-        
+
     except Exception as e:
         logger.error(f"压力测试失败: {str(e)}")
-        return jsonify({'success': False, 'message': str(e)}) 
+        return jsonify({'success': False, 'message': str(e)})

--- a/app/services/realtime_risk_manager.py
+++ b/app/services/realtime_risk_manager.py
@@ -145,24 +145,24 @@ class RealtimeRiskManager:
             risk_positions = []
             alerts = []
 
-            # 先计算实时权重（Parquet positions 的 weight 字段可能为空）
-            total_value = sum(float(pos.get('market_value') or 0) for pos in positions)
-            if total_value > 0:
-                for pos in positions:
-                    pos['weight'] = float(pos.get('market_value') or 0) / total_value * 100
-
+            # 第一步：刷新实时价格
             for position in positions:
-                # 更新当前价格
                 current_price = self._get_current_price(position.get('ts_code', ''))
                 if current_price:
                     _update_market_data_inplace(position, current_price)
                     _save_position(position)
 
-                # 检查持仓风险
+            # 第二步：基于刷新后的市值计算实时权重
+            total_value = sum(float(pos.get('market_value') or 0) for pos in positions)
+            if total_value > 0:
+                for pos in positions:
+                    pos['weight'] = float(pos.get('market_value') or 0) / total_value * 100
+
+            # 第三步：分析风险和预警
+            for position in positions:
                 position_risk = self._analyze_position_risk(position)
                 risk_positions.append(position_risk)
 
-                # 检查预警条件
                 position_alerts = self._check_position_alerts(position)
                 alerts.extend(position_alerts)
 

--- a/app/services/realtime_risk_manager.py
+++ b/app/services/realtime_risk_manager.py
@@ -145,6 +145,12 @@ class RealtimeRiskManager:
             risk_positions = []
             alerts = []
 
+            # 先计算实时权重（Parquet positions 的 weight 字段可能为空）
+            total_value = sum(float(pos.get('market_value') or 0) for pos in positions)
+            if total_value > 0:
+                for pos in positions:
+                    pos['weight'] = float(pos.get('market_value') or 0) / total_value * 100
+
             for position in positions:
                 # 更新当前价格
                 current_price = self._get_current_price(position.get('ts_code', ''))

--- a/app/services/realtime_risk_manager.py
+++ b/app/services/realtime_risk_manager.py
@@ -1,24 +1,68 @@
 """
 实时风险管理服务
 提供实时风险计算、持仓风险监控、止损止盈管理和风险预警功能
+数据源：Parquet（通过 PortfolioRepository）
 """
 
 import pandas as pd
 import numpy as np
 from datetime import datetime, timedelta
-from typing import List, Dict, Optional, Tuple
+from typing import List, Dict, Optional
 import logging
 
-from app.models.portfolio_position import PortfolioPosition
 from app.models.risk_alert import RiskAlert
 from app.services.data_reader import ParquetDataReader
+from app.services.parquet_state_store import ParquetStateStore, PortfolioRepository
 
 logger = logging.getLogger(__name__)
+
+# ── Parquet 数据源（与 ml_factor_api 共享同一模式）──────────────
+_state_store = ParquetStateStore()
+_portfolio_repo = PortfolioRepository(_state_store)
+
+
+# ── 辅助函数（替代 SQLite Model 实例方法，操作 dict）────────────
+
+def _now_iso():
+    return datetime.utcnow().isoformat()
+
+
+def _calc_pnl_pct(pos: dict) -> float:
+    avg_cost = float(pos.get('avg_cost') or 0)
+    if avg_cost > 0:
+        return (float(pos.get('current_price') or 0) - avg_cost) / avg_cost * 100
+    return 0.0
+
+
+def _is_sl_triggered(pos: dict) -> bool:
+    sl = pos.get('stop_loss_price')
+    cp = pos.get('current_price')
+    return sl is not None and cp is not None and float(cp) <= float(sl)
+
+
+def _is_tp_triggered(pos: dict) -> bool:
+    tp = pos.get('take_profit_price')
+    cp = pos.get('current_price')
+    return tp is not None and cp is not None and float(cp) >= float(tp)
+
+
+def _update_market_data_inplace(pos: dict, current_price: float) -> dict:
+    """更新价格并计算市值/浮动盈亏（原地修改 dict）。"""
+    pos['current_price'] = current_price
+    pos['market_value'] = float(pos.get('position_size') or 0) * current_price
+    pos['unrealized_pnl'] = (current_price - float(pos.get('avg_cost') or 0)) * float(pos.get('position_size') or 0)
+    pos['updated_at'] = _now_iso()
+    return pos
+
+
+def _save_position(pos: dict) -> dict:
+    """持久化持仓到 Parquet。"""
+    return _portfolio_repo.upsert_position(pos)
 
 
 class RealtimeRiskManager:
     """实时风险管理服务"""
-    
+
     def __init__(self):
         self.confidence_levels = [0.95, 0.99]  # VaR置信水平
         self.risk_thresholds = {
@@ -30,53 +74,41 @@ class RealtimeRiskManager:
             'drawdown_limit': 0.15  # 最大回撤限制
         }
         self.minute_reader = ParquetDataReader().get_minute_reader()
-    
+
+    # ── 公共方法 ──────────────────────────────────────────────────
+
     def calculate_portfolio_risk(self, portfolio_id: str, period_days: int = 252) -> Dict:
         """计算投资组合风险指标"""
         try:
-            # 获取组合持仓
-            positions = PortfolioPosition.get_portfolio_positions(portfolio_id)
-            
+            positions = _portfolio_repo.list_positions(portfolio_id)
+
             if not positions:
                 return {
                     'success': False,
                     'message': '组合中没有持仓数据'
                 }
-            
-            # 获取股票代码列表
-            stock_codes = [pos.ts_code for pos in positions]
-            
-            # 获取历史价格数据
+
+            stock_codes = [pos.get('ts_code') for pos in positions]
+
             end_date = datetime.now()
-            start_date = end_date - timedelta(days=period_days + 30)  # 多取一些数据
-            
+            start_date = end_date - timedelta(days=period_days + 30)
+
             price_data = self._get_price_data(stock_codes, start_date, end_date)
-            
+
             if price_data.empty:
                 return {
                     'success': False,
                     'message': '无法获取价格数据'
                 }
-            
-            # 计算收益率
+
             returns = price_data.pct_change().dropna()
-            
-            # 计算组合权重
             weights = self._get_portfolio_weights(positions)
-            
-            # 计算风险指标
+
             risk_metrics = self._calculate_risk_metrics(returns, weights, positions)
-            
-            # 计算VaR和CVaR
             var_metrics = self._calculate_var_cvar(returns, weights)
-            
-            # 计算相关性矩阵
             correlation_matrix = self._calculate_correlation_matrix(returns)
-            
-            # 计算Beta值
             beta_metrics = self._calculate_portfolio_beta(returns, weights)
-            
-            # 组合结果
+
             result = {
                 'portfolio_id': portfolio_id,
                 'calculation_date': datetime.now().isoformat(),
@@ -88,48 +120,49 @@ class RealtimeRiskManager:
                 'beta_metrics': beta_metrics,
                 'risk_alerts': self._check_risk_thresholds(portfolio_id, risk_metrics, var_metrics)
             }
-            
+
             return {
                 'success': True,
                 'data': result,
                 'message': f'成功计算组合 {portfolio_id} 的风险指标'
             }
-            
+
         except Exception as e:
             logger.error(f"计算组合风险失败: {str(e)}")
             return {'success': False, 'message': str(e)}
-    
+
     def monitor_position_risk(self, portfolio_id: str) -> Dict:
         """监控持仓风险"""
         try:
-            positions = PortfolioPosition.get_portfolio_positions(portfolio_id)
-            
+            positions = _portfolio_repo.list_positions(portfolio_id)
+
             if not positions:
                 return {
                     'success': False,
                     'message': '组合中没有持仓数据'
                 }
-            
+
             risk_positions = []
             alerts = []
-            
+
             for position in positions:
                 # 更新当前价格
-                current_price = self._get_current_price(position.ts_code)
+                current_price = self._get_current_price(position.get('ts_code', ''))
                 if current_price:
-                    position.update_market_data(current_price)
-                
+                    _update_market_data_inplace(position, current_price)
+                    _save_position(position)
+
                 # 检查持仓风险
                 position_risk = self._analyze_position_risk(position)
                 risk_positions.append(position_risk)
-                
+
                 # 检查预警条件
                 position_alerts = self._check_position_alerts(position)
                 alerts.extend(position_alerts)
-            
+
             # 计算组合级别风险
-            portfolio_metrics = PortfolioPosition.calculate_portfolio_metrics(portfolio_id)
-            
+            portfolio_metrics = _portfolio_repo.calculate_metrics(portfolio_id)
+
             return {
                 'success': True,
                 'data': {
@@ -142,31 +175,30 @@ class RealtimeRiskManager:
                 },
                 'message': f'成功监控组合 {portfolio_id} 的持仓风险'
             }
-            
+
         except Exception as e:
             logger.error(f"监控持仓风险失败: {str(e)}")
             return {'success': False, 'message': str(e)}
-    
-    def manage_stop_loss_take_profit(self, portfolio_id: str, 
-                                   stop_loss_method: str = 'percentage',
-                                   stop_loss_value: float = 0.10,
-                                   take_profit_method: str = 'percentage',
-                                   take_profit_value: float = 0.20) -> Dict:
+
+    def manage_stop_loss_take_profit(self, portfolio_id: str,
+                                     stop_loss_method: str = 'percentage',
+                                     stop_loss_value: float = 0.10,
+                                     take_profit_method: str = 'percentage',
+                                     take_profit_value: float = 0.20) -> Dict:
         """管理止损止盈"""
         try:
-            positions = PortfolioPosition.get_portfolio_positions(portfolio_id)
-            
+            positions = _portfolio_repo.list_positions(portfolio_id)
+
             if not positions:
                 return {
                     'success': False,
                     'message': '组合中没有持仓数据'
                 }
-            
+
             updated_positions = []
             triggered_orders = []
-            
+
             for position in positions:
-                # 计算止损止盈价格
                 stop_loss_price = self._calculate_stop_loss_price(
                     position, stop_loss_method, stop_loss_value
                 )
@@ -175,42 +207,43 @@ class RealtimeRiskManager:
                 )
 
                 # 更新止损止盈价格
-                position.update_risk_limits(
-                    stop_loss_price=stop_loss_price,
-                    take_profit_price=take_profit_price,
-                )
-                
+                position['stop_loss_price'] = stop_loss_price
+                position['take_profit_price'] = take_profit_price
+                position['updated_at'] = _now_iso()
+                _save_position(position)
+
                 # 检查是否触发
-                if position.is_stop_loss_triggered():
+                if _is_sl_triggered(position):
                     triggered_orders.append({
-                        'ts_code': position.ts_code,
+                        'ts_code': position.get('ts_code'),
                         'order_type': 'stop_loss',
-                        'trigger_price': position.current_price,
+                        'trigger_price': position.get('current_price'),
                         'stop_loss_price': stop_loss_price,
-                        'position_size': position.position_size,
-                        'unrealized_pnl': position.unrealized_pnl
+                        'position_size': position.get('position_size'),
+                        'unrealized_pnl': position.get('unrealized_pnl')
                     })
-                
-                if position.is_take_profit_triggered():
+
+                if _is_tp_triggered(position):
                     triggered_orders.append({
-                        'ts_code': position.ts_code,
+                        'ts_code': position.get('ts_code'),
                         'order_type': 'take_profit',
-                        'trigger_price': position.current_price,
+                        'trigger_price': position.get('current_price'),
                         'take_profit_price': take_profit_price,
-                        'position_size': position.position_size,
-                        'unrealized_pnl': position.unrealized_pnl
+                        'position_size': position.get('position_size'),
+                        'unrealized_pnl': position.get('unrealized_pnl')
                     })
-                
+
+                current_price = float(position.get('current_price') or 0)
                 updated_positions.append({
-                    'ts_code': position.ts_code,
-                    'current_price': position.current_price,
-                    'avg_cost': position.avg_cost,
+                    'ts_code': position.get('ts_code'),
+                    'current_price': position.get('current_price'),
+                    'avg_cost': position.get('avg_cost'),
                     'stop_loss_price': stop_loss_price,
                     'take_profit_price': take_profit_price,
-                    'stop_loss_distance': (position.current_price - stop_loss_price) / position.current_price * 100,
-                    'take_profit_distance': (take_profit_price - position.current_price) / position.current_price * 100
+                    'stop_loss_distance': (current_price - stop_loss_price) / current_price * 100 if current_price > 0 else 0,
+                    'take_profit_distance': (take_profit_price - current_price) / current_price * 100 if current_price > 0 else 0
                 })
-            
+
             return {
                 'success': True,
                 'data': {
@@ -226,41 +259,42 @@ class RealtimeRiskManager:
                 },
                 'message': f'成功更新组合 {portfolio_id} 的止损止盈设置'
             }
-            
+
         except Exception as e:
             logger.error(f"管理止损止盈失败: {str(e)}")
             return {'success': False, 'message': str(e)}
-    
-    def get_risk_alerts(self, portfolio_id: str = None, 
-                       alert_level: str = None, 
-                       active_only: bool = True) -> Dict:
+
+    def get_risk_alerts(self, portfolio_id: str = None,
+                        alert_level: str = None,
+                        active_only: bool = True) -> Dict:
         """获取风险预警"""
         try:
-            # 获取预警记录
             alerts = RiskAlert.get_active_alerts(
                 alert_level=alert_level
             ) if active_only else RiskAlert.list_all()
-            
-            # 如果指定了组合ID，需要过滤相关股票
+
+            # 如果指定了组合ID，过滤相关股票
             if portfolio_id:
-                position_codes = [pos.ts_code for pos in PortfolioPosition.get_portfolio_positions(portfolio_id)]
+                position_codes = [pos.get('ts_code') for pos in _portfolio_repo.list_positions(portfolio_id)]
                 alerts = [alert for alert in alerts if alert.ts_code in position_codes]
-            
+
             # 按级别分组
             alerts_by_level = {
                 'high': [],
                 'medium': [],
                 'low': []
             }
-            
+
             for alert in alerts:
                 level = alert.alert_level.lower()
                 if level in alerts_by_level:
                     alerts_by_level[level].append(alert.to_dict())
-            
-            # 获取统计信息
+
             alert_stats = RiskAlert.get_alert_stats()
-            
+
+            # active_alerts 返回列表（而非整数），前端需要遍历
+            active_alert_list = [alert.to_dict() for alert in alerts if alert.is_active]
+
             return {
                 'success': True,
                 'data': {
@@ -269,38 +303,31 @@ class RealtimeRiskManager:
                     'alerts_by_level': alerts_by_level,
                     'alert_stats': alert_stats,
                     'total_alerts': len(alerts),
-                    'active_alerts': len([a for a in alerts if a.is_active])
+                    'active_alerts': active_alert_list
                 },
-                'message': f'成功获取风险预警信息'
+                'message': '成功获取风险预警信息'
             }
-            
+
         except Exception as e:
             logger.error(f"获取风险预警失败: {str(e)}")
             return {'success': False, 'message': str(e)}
-    
-    def create_risk_alert(self, ts_code: str, alert_type: str, 
-                         alert_level: str, alert_message: str,
-                         risk_value: float = None, threshold_value: float = None) -> Dict:
+
+    def create_risk_alert(self, ts_code: str, alert_type: str,
+                          alert_level: str, alert_message: str,
+                          risk_value: float = None, threshold_value: float = None) -> Dict:
         """创建风险预警"""
         try:
-            # 检查是否已存在相同的活跃预警
             existing_alert = RiskAlert.get_existing_active_alert(ts_code, alert_type)
-            
+
             if existing_alert:
                 return {
                     'success': False,
                     'message': f'股票 {ts_code} 已存在相同类型的活跃预警'
                 }
-            
-            # 获取当前价格和持仓信息
+
             current_price = self._get_current_price(ts_code)
-            position = None
-            for candidate in PortfolioPosition.list_positions(active_only=True):
-                if candidate.ts_code == ts_code:
-                    position = candidate
-                    break
-            
-            # 创建预警
+            position = self._find_position_by_ts_code(ts_code)
+
             alert = RiskAlert.create_alert(
                 ts_code=ts_code,
                 alert_type=alert_type,
@@ -309,20 +336,30 @@ class RealtimeRiskManager:
                 risk_value=risk_value,
                 threshold_value=threshold_value,
                 current_price=current_price,
-                position_size=position.position_size if position else None,
-                portfolio_weight=position.weight if position else None
+                position_size=position.get('position_size') if position else None,
+                portfolio_weight=position.get('weight') if position else None
             )
-            
+
             return {
                 'success': True,
                 'data': alert.to_dict(),
                 'message': f'成功创建风险预警: {alert_message}'
             }
-            
+
         except Exception as e:
             logger.error(f"创建风险预警失败: {str(e)}")
             return {'success': False, 'message': str(e)}
-    
+
+    # ── 私有辅助方法 ──────────────────────────────────────────────
+
+    def _find_position_by_ts_code(self, ts_code: str) -> Optional[dict]:
+        """在所有组合中查找指定股票的持仓。"""
+        for pid in _portfolio_repo.list_portfolio_ids():
+            for pos in _portfolio_repo.list_positions(pid, active_only=True):
+                if pos.get('ts_code') == ts_code:
+                    return pos
+        return None
+
     def _get_price_data(self, stock_codes: List[str], start_date: datetime, end_date: datetime) -> pd.DataFrame:
         """获取价格数据"""
         try:
@@ -355,45 +392,39 @@ class RealtimeRiskManager:
         except Exception as e:
             logger.error(f"获取价格数据失败: {str(e)}")
             return pd.DataFrame()
-    
-    def _get_portfolio_weights(self, positions: List[PortfolioPosition]) -> Dict[str, float]:
+
+    def _get_portfolio_weights(self, positions: List[dict]) -> Dict[str, float]:
         """获取组合权重"""
-        total_value = sum(pos.market_value or 0 for pos in positions)
-        
+        total_value = sum(float(pos.get('market_value') or 0) for pos in positions)
+
         if total_value == 0:
             return {}
-        
+
         return {
-            pos.ts_code: (pos.market_value or 0) / total_value 
+            pos.get('ts_code', ''): float(pos.get('market_value') or 0) / total_value
             for pos in positions
         }
-    
-    def _calculate_risk_metrics(self, returns: pd.DataFrame, weights: Dict, positions: List) -> Dict:
+
+    def _calculate_risk_metrics(self, returns: pd.DataFrame, weights: Dict, positions: List[dict]) -> Dict:
         """计算风险指标"""
         try:
-            # 组合收益率
             portfolio_returns = pd.Series(0, index=returns.index)
             for ts_code, weight in weights.items():
                 if ts_code in returns.columns:
                     portfolio_returns += returns[ts_code] * weight
-            
-            # 基础统计
+
             annual_return = portfolio_returns.mean() * 252
             annual_volatility = portfolio_returns.std() * np.sqrt(252)
             sharpe_ratio = annual_return / annual_volatility if annual_volatility > 0 else 0
-            
-            # 最大回撤
+
             cumulative_returns = (1 + portfolio_returns).cumprod()
             rolling_max = cumulative_returns.expanding().max()
             drawdown = (cumulative_returns - rolling_max) / rolling_max
             max_drawdown = drawdown.min()
-            
-            # 行业集中度
+
             sector_concentration = self._calculate_sector_concentration(positions)
-            
-            # 持仓集中度
             position_concentration = max(weights.values()) if weights else 0
-            
+
             return {
                 'annual_return': annual_return,
                 'annual_volatility': annual_volatility,
@@ -403,50 +434,44 @@ class RealtimeRiskManager:
                 'position_concentration': position_concentration,
                 'tracking_error': portfolio_returns.std() * np.sqrt(252)
             }
-            
+
         except Exception as e:
             logger.error(f"计算风险指标失败: {str(e)}")
             return {}
-    
+
     def _calculate_var_cvar(self, returns: pd.DataFrame, weights: Dict) -> Dict:
         """计算VaR和CVaR"""
         try:
-            # 组合收益率
             portfolio_returns = pd.Series(0, index=returns.index)
             for ts_code, weight in weights.items():
                 if ts_code in returns.columns:
                     portfolio_returns += returns[ts_code] * weight
-            
+
             var_metrics = {}
-            
+
             for confidence in self.confidence_levels:
-                # VaR计算
                 var = np.percentile(portfolio_returns, (1 - confidence) * 100)
-                
-                # CVaR计算（条件VaR）
                 cvar = portfolio_returns[portfolio_returns <= var].mean()
-                
+
                 var_metrics[f'var_{int(confidence*100)}'] = var
                 var_metrics[f'cvar_{int(confidence*100)}'] = cvar
-            
+
             return var_metrics
-            
+
         except Exception as e:
             logger.error(f"计算VaR/CVaR失败: {str(e)}")
             return {}
-    
+
     def _calculate_correlation_matrix(self, returns: pd.DataFrame) -> Dict:
         """计算相关性矩阵"""
         try:
             corr_matrix = returns.corr()
-            
-            # 计算平均相关性
+
             avg_correlation = corr_matrix.values[np.triu_indices_from(corr_matrix.values, k=1)].mean()
-            
-            # 找出高相关性股票对
+
             high_corr_pairs = []
             for i in range(len(corr_matrix.columns)):
-                for j in range(i+1, len(corr_matrix.columns)):
+                for j in range(i + 1, len(corr_matrix.columns)):
                     corr_value = corr_matrix.iloc[i, j]
                     if abs(corr_value) > self.risk_thresholds['correlation_limit']:
                         high_corr_pairs.append({
@@ -454,7 +479,7 @@ class RealtimeRiskManager:
                             'stock2': corr_matrix.columns[j],
                             'correlation': corr_value
                         })
-            
+
             return {
                 'average_correlation': avg_correlation,
                 'max_correlation': corr_matrix.values[np.triu_indices_from(corr_matrix.values, k=1)].max(),
@@ -462,67 +487,61 @@ class RealtimeRiskManager:
                 'high_correlation_pairs': high_corr_pairs,
                 'correlation_matrix': corr_matrix.to_dict()
             }
-            
+
         except Exception as e:
             logger.error(f"计算相关性矩阵失败: {str(e)}")
             return {}
-    
+
     def _calculate_portfolio_beta(self, returns: pd.DataFrame, weights: Dict) -> Dict:
         """计算组合Beta值"""
         try:
-            # 这里简化处理，实际应该使用市场指数数据
-            # 假设市场收益率为所有股票的等权重组合
             market_returns = returns.mean(axis=1)
-            
-            # 组合收益率
+
             portfolio_returns = pd.Series(0, index=returns.index)
             for ts_code, weight in weights.items():
                 if ts_code in returns.columns:
                     portfolio_returns += returns[ts_code] * weight
-            
-            # 计算Beta
+
             covariance = np.cov(portfolio_returns, market_returns)[0, 1]
             market_variance = np.var(market_returns)
-            
+
             beta = covariance / market_variance if market_variance > 0 else 1.0
-            
+
             return {
                 'portfolio_beta': beta,
                 'systematic_risk': beta * np.std(market_returns) * np.sqrt(252),
                 'idiosyncratic_risk': np.sqrt(max(0, np.var(portfolio_returns) - beta**2 * market_variance)) * np.sqrt(252)
             }
-            
+
         except Exception as e:
             logger.error(f"计算组合Beta失败: {str(e)}")
             return {'portfolio_beta': 1.0}
-    
-    def _calculate_sector_concentration(self, positions: List[PortfolioPosition]) -> float:
-        """计算行业集中度"""
+
+    def _calculate_sector_concentration(self, positions: List[dict]) -> float:
+        """计算行业集中度（赫芬达尔指数）"""
         try:
             sector_weights = {}
             total_weight = 0
-            
+
             for pos in positions:
-                sector = pos.sector or '未知'
-                weight = pos.weight or 0
-                
+                sector = pos.get('sector') or '未知'
+                weight = float(pos.get('weight') or 0)
+
                 if sector not in sector_weights:
                     sector_weights[sector] = 0
                 sector_weights[sector] += weight
                 total_weight += weight
-            
+
             if total_weight == 0:
                 return 0
-            
-            # 计算赫芬达尔指数
-            hhi = sum((weight / total_weight) ** 2 for weight in sector_weights.values())
-            
+
+            hhi = sum((w / total_weight) ** 2 for w in sector_weights.values())
             return hhi
-            
+
         except Exception as e:
             logger.error(f"计算行业集中度失败: {str(e)}")
             return 0
-    
+
     def _get_current_price(self, ts_code: str) -> Optional[float]:
         """获取当前价格"""
         try:
@@ -530,99 +549,93 @@ class RealtimeRiskManager:
             if latest_data.empty:
                 return None
             return float(latest_data.iloc[0]['close'])
-            
+
         except Exception as e:
             logger.error(f"获取 {ts_code} 当前价格失败: {str(e)}")
             return None
-    
-    def _analyze_position_risk(self, position: PortfolioPosition) -> Dict:
+
+    def _analyze_position_risk(self, position: dict) -> Dict:
         """分析单个持仓风险"""
         try:
-            # 计算基础指标
-            pnl_percentage = position.calculate_pnl_percentage()
-            
-            # 风险评级
+            pnl_percentage = _calc_pnl_pct(position)
+
             risk_level = 'low'
             if abs(pnl_percentage) > 15:
                 risk_level = 'high'
             elif abs(pnl_percentage) > 8:
                 risk_level = 'medium'
-            
-            # 权重风险
-            weight_risk = 'high' if (position.weight or 0) > self.risk_thresholds['position_weight'] * 100 else 'low'
-            
+
+            weight = float(position.get('weight') or 0)
+            weight_risk = 'high' if weight > self.risk_thresholds['position_weight'] * 100 else 'low'
+
             return {
-                'ts_code': position.ts_code,
-                'current_price': position.current_price,
-                'avg_cost': position.avg_cost,
+                'ts_code': position.get('ts_code'),
+                'current_price': position.get('current_price'),
+                'avg_cost': position.get('avg_cost'),
                 'pnl_percentage': pnl_percentage,
-                'weight': position.weight,
+                'weight': weight,
                 'risk_level': risk_level,
                 'weight_risk': weight_risk,
-                'var_1d': position.var_1d,
-                'var_5d': position.var_5d,
-                'volatility': position.volatility,
-                'beta': position.beta
+                'var_1d': position.get('var_1d'),
+                'var_5d': position.get('var_5d'),
+                'volatility': position.get('volatility'),
+                'beta': position.get('beta')
             }
-            
+
         except Exception as e:
             logger.error(f"分析持仓风险失败: {str(e)}")
             return {}
-    
-    def _check_position_alerts(self, position: PortfolioPosition) -> List[Dict]:
+
+    def _check_position_alerts(self, position: dict) -> List[Dict]:
         """检查持仓预警"""
         alerts = []
-        
+
         try:
-            # 止损预警
-            if position.is_stop_loss_triggered():
+            if _is_sl_triggered(position):
                 alerts.append({
-                    'ts_code': position.ts_code,
+                    'ts_code': position.get('ts_code'),
                     'alert_type': 'stop_loss_triggered',
                     'alert_level': 'high',
-                    'message': f'{position.ts_code} 触发止损，当前价格 {position.current_price}，止损价格 {position.stop_loss_price}'
+                    'message': f'{position.get("ts_code")} 触发止损，当前价格 {position.get("current_price")}，止损价格 {position.get("stop_loss_price")}'
                 })
-            
-            # 止盈预警
-            if position.is_take_profit_triggered():
+
+            if _is_tp_triggered(position):
                 alerts.append({
-                    'ts_code': position.ts_code,
+                    'ts_code': position.get('ts_code'),
                     'alert_type': 'take_profit_triggered',
                     'alert_level': 'medium',
-                    'message': f'{position.ts_code} 触发止盈，当前价格 {position.current_price}，止盈价格 {position.take_profit_price}'
+                    'message': f'{position.get("ts_code")} 触发止盈，当前价格 {position.get("current_price")}，止盈价格 {position.get("take_profit_price")}'
                 })
-            
-            # 权重过大预警
-            if (position.weight or 0) > self.risk_thresholds['position_weight'] * 100:
+
+            weight = float(position.get('weight') or 0)
+            if weight > self.risk_thresholds['position_weight'] * 100:
                 alerts.append({
-                    'ts_code': position.ts_code,
+                    'ts_code': position.get('ts_code'),
                     'alert_type': 'position_concentration',
                     'alert_level': 'medium',
-                    'message': f'{position.ts_code} 持仓权重过大: {position.weight:.1f}%'
+                    'message': f'{position.get("ts_code")} 持仓权重过大: {weight:.1f}%'
                 })
-            
-            # 大幅亏损预警
-            pnl_pct = position.calculate_pnl_percentage()
+
+            pnl_pct = _calc_pnl_pct(position)
             if pnl_pct < -15:
                 alerts.append({
-                    'ts_code': position.ts_code,
+                    'ts_code': position.get('ts_code'),
                     'alert_type': 'large_loss',
                     'alert_level': 'high',
-                    'message': f'{position.ts_code} 大幅亏损: {pnl_pct:.1f}%'
+                    'message': f'{position.get("ts_code")} 大幅亏损: {pnl_pct:.1f}%'
                 })
-            
+
             return alerts
-            
+
         except Exception as e:
             logger.error(f"检查持仓预警失败: {str(e)}")
             return []
-    
+
     def _check_risk_thresholds(self, portfolio_id: str, risk_metrics: Dict, var_metrics: Dict) -> List[Dict]:
         """检查风险阈值"""
         alerts = []
-        
+
         try:
-            # 检查VaR限制
             for key, value in var_metrics.items():
                 if 'var_' in key and abs(value) > self.risk_thresholds['var_limit']:
                     alerts.append({
@@ -630,87 +643,83 @@ class RealtimeRiskManager:
                         'alert_level': 'high',
                         'message': f'组合VaR超限: {key} = {value:.4f}'
                     })
-            
-            # 检查波动率限制
+
             if risk_metrics.get('annual_volatility', 0) > self.risk_thresholds['volatility_limit']:
                 alerts.append({
                     'alert_type': 'volatility_limit_exceeded',
                     'alert_level': 'medium',
                     'message': f'组合波动率过高: {risk_metrics["annual_volatility"]:.4f}'
                 })
-            
-            # 检查最大回撤
+
             if abs(risk_metrics.get('max_drawdown', 0)) > self.risk_thresholds['drawdown_limit']:
                 alerts.append({
                     'alert_type': 'drawdown_limit_exceeded',
                     'alert_level': 'high',
                     'message': f'最大回撤过大: {risk_metrics["max_drawdown"]:.4f}'
                 })
-            
-            # 检查行业集中度
+
             if risk_metrics.get('sector_concentration', 0) > self.risk_thresholds['sector_concentration']:
                 alerts.append({
                     'alert_type': 'sector_concentration_high',
                     'alert_level': 'medium',
                     'message': f'行业集中度过高: {risk_metrics["sector_concentration"]:.4f}'
                 })
-            
+
             return alerts
-            
+
         except Exception as e:
             logger.error(f"检查风险阈值失败: {str(e)}")
             return []
-    
-    def _calculate_stop_loss_price(self, position: PortfolioPosition, method: str, value: float) -> float:
+
+    def _calculate_stop_loss_price(self, position: dict, method: str, value: float) -> float:
         """计算止损价格"""
         try:
+            avg_cost = float(position.get('avg_cost') or 0)
+            current_price = float(position.get('current_price') or 0)
             if method == 'percentage':
-                return position.avg_cost * (1 - value)
+                return avg_cost * (1 - value)
             elif method == 'atr':
-                # 简化处理，实际应该计算ATR
-                return position.current_price * (1 - value * 0.02)
+                return current_price * (1 - value * 0.02)
             elif method == 'fixed':
-                return position.avg_cost - value
+                return avg_cost - value
             else:
-                return position.avg_cost * 0.9  # 默认10%止损
-                
+                return avg_cost * 0.9
         except Exception as e:
             logger.error(f"计算止损价格失败: {str(e)}")
-            return position.avg_cost * 0.9
-    
-    def _calculate_take_profit_price(self, position: PortfolioPosition, method: str, value: float) -> float:
+            return float(position.get('avg_cost') or 0) * 0.9
+
+    def _calculate_take_profit_price(self, position: dict, method: str, value: float) -> float:
         """计算止盈价格"""
         try:
+            avg_cost = float(position.get('avg_cost') or 0)
+            current_price = float(position.get('current_price') or 0)
             if method == 'percentage':
-                return position.avg_cost * (1 + value)
+                return avg_cost * (1 + value)
             elif method == 'atr':
-                # 简化处理，实际应该计算ATR
-                return position.current_price * (1 + value * 0.02)
+                return current_price * (1 + value * 0.02)
             elif method == 'fixed':
-                return position.avg_cost + value
+                return avg_cost + value
             else:
-                return position.avg_cost * 1.2  # 默认20%止盈
-                
+                return avg_cost * 1.2
         except Exception as e:
             logger.error(f"计算止盈价格失败: {str(e)}")
-            return position.avg_cost * 1.2
-    
+            return float(position.get('avg_cost') or 0) * 1.2
+
     def _summarize_portfolio_risk(self, position_risks: List[Dict], alerts: List[Dict]) -> Dict:
         """汇总组合风险"""
         try:
             high_risk_positions = len([p for p in position_risks if p.get('risk_level') == 'high'])
             medium_risk_positions = len([p for p in position_risks if p.get('risk_level') == 'medium'])
-            
+
             high_alerts = len([a for a in alerts if a.get('alert_level') == 'high'])
             medium_alerts = len([a for a in alerts if a.get('alert_level') == 'medium'])
-            
-            # 整体风险评级
+
             overall_risk = 'low'
             if high_risk_positions > 0 or high_alerts > 0:
                 overall_risk = 'high'
             elif medium_risk_positions > 2 or medium_alerts > 2:
                 overall_risk = 'medium'
-            
+
             return {
                 'overall_risk_level': overall_risk,
                 'high_risk_positions': high_risk_positions,
@@ -720,7 +729,7 @@ class RealtimeRiskManager:
                 'medium_priority_alerts': medium_alerts,
                 'risk_score': high_risk_positions * 3 + medium_risk_positions * 2 + high_alerts * 2 + medium_alerts
             }
-            
+
         except Exception as e:
             logger.error(f"汇总组合风险失败: {str(e)}")
-            return {'overall_risk_level': 'unknown'} 
+            return {'overall_risk_level': 'unknown'}

--- a/app/services/websocket_push_service.py
+++ b/app/services/websocket_push_service.py
@@ -14,7 +14,7 @@ from app.extensions import db
 from app.models.realtime_indicator import RealtimeIndicator
 from app.models.trading_signal import TradingSignal
 from app.models.risk_alert import RiskAlert
-from app.models.portfolio_position import PortfolioPosition
+from app.services.realtime_risk_manager import _portfolio_repo
 from app.services.realtime_data_manager import RealtimeDataManager
 from app.services.realtime_indicator_engine import RealtimeIndicatorEngine
 from app.services.realtime_trading_signal_engine import RealtimeTradingSignalEngine
@@ -308,7 +308,7 @@ class WebSocketPushService:
     def _get_active_portfolio_ids(self) -> List[str]:
         """获取存在真实持仓的活跃投资组合ID。"""
         try:
-            return PortfolioPosition.list_active_portfolio_ids()
+            return _portfolio_repo.list_portfolio_ids(active_only=True)
         except Exception as e:
             logger.error(f"获取活跃投资组合失败: {e}")
             return []

--- a/app/templates/realtime_analysis/risk_management.html
+++ b/app/templates/realtime_analysis/risk_management.html
@@ -440,6 +440,7 @@
         let currentPortfolioId = '';
         let portfolioData = {};
         let riskData = {};
+        let allAlerts = []; // 缓存预警列表，用于前端过滤
 
         // 页面加载完成后初始化
         document.addEventListener('DOMContentLoaded', function() {
@@ -685,16 +686,111 @@
                 </table>
             `;
             document.getElementById('riskMetricsTable').innerHTML = metricsHtml;
+
+            // 渲染 VaR 柱状图
+            updateVarChart(riskData);
+            // 渲染相关性热力图
+            updateCorrelationChart(riskData);
+        }
+
+        // VaR 柱状图
+        function updateVarChart(riskData) {
+            const el = document.getElementById('varChart');
+            if (!el) return;
+            const chart = echarts.init(el);
+
+            const labels = [];
+            const values = [];
+            const colors = [];
+
+            if (riskData.portfolio_metrics) {
+                const pm = riskData.portfolio_metrics;
+                if (pm.portfolio_var_1d != null) { labels.push('VaR(1日)'); values.push(pm.portfolio_var_1d); colors.push('#ee6666'); }
+                if (pm.portfolio_var_5d != null) { labels.push('VaR(5日)'); values.push(pm.portfolio_var_5d); colors.push('#fac858'); }
+            }
+
+            // 如果没有实际 VaR 数据，显示占位
+            if (labels.length === 0) {
+                labels.push('VaR(1日)', 'VaR(5日)');
+                values.push(0, 0);
+                colors.push('#ee6666', '#fac858');
+            }
+
+            chart.setOption({
+                title: { text: 'VaR 分析', left: 'center' },
+                tooltip: { trigger: 'axis', formatter: '{b}: {c}%' },
+                xAxis: { type: 'category', data: labels },
+                yAxis: { type: 'value', name: 'VaR (%)' },
+                series: [{
+                    type: 'bar',
+                    data: values.map((v, i) => ({ value: v, itemStyle: { color: colors[i] } })),
+                    barWidth: '40%'
+                }]
+            });
+        }
+
+        // 相关性热力图
+        function updateCorrelationChart(riskData) {
+            const el = document.getElementById('correlationChart');
+            if (!el) return;
+            const chart = echarts.init(el);
+
+            const pm = riskData.portfolio_metrics || {};
+            const positions = portfolioData.positions || [];
+
+            if (positions.length < 2) {
+                chart.setOption({
+                    title: { text: '相关性热力图', left: 'center' },
+                    graphic: { type: 'text', left: 'center', top: 'middle', style: { text: '需要至少2只股票', fill: '#999', fontSize: 14 } }
+                });
+                return;
+            }
+
+            // 从持仓列表构建简单的相关性矩阵展示
+            const codes = positions.map(p => p.ts_code);
+            const n = codes.length;
+
+            // 生成模拟相关性数据（对角线=1，其余用随机值作为占位）
+            // 实际相关性数据应来自后端的风险计算
+            const heatData = [];
+            for (let i = 0; i < n; i++) {
+                for (let j = 0; j < n; j++) {
+                    heatData.push([i, j, i === j ? 1 : (0.3 + Math.random() * 0.5).toFixed(2)]);
+                }
+            }
+
+            chart.setOption({
+                title: { text: '相关性热力图', left: 'center' },
+                tooltip: {
+                    formatter: function(p) { return `${codes[p.data[0]]} × ${codes[p.data[1]]}<br/>相关系数: ${p.data[2]}`; }
+                },
+                xAxis: { type: 'category', data: codes, splitArea: { show: true } },
+                yAxis: { type: 'category', data: codes, splitArea: { show: true } },
+                visualMap: { min: 0, max: 1, calculable: true, orient: 'horizontal', left: 'center', bottom: 0, inRange: { color: ['#313695', '#4575b4', '#74add1', '#abd9e9', '#e0f3f8', '#ffffbf', '#fee090', '#fdae61', '#f46d43', '#d73027', '#a50026'] } },
+                series: [{
+                    type: 'heatmap',
+                    data: heatData,
+                    label: { show: true },
+                    emphasis: { itemStyle: { shadowBlur: 10, shadowColor: 'rgba(0, 0, 0, 0.5)' } }
+                }]
+            });
         }
 
         // 更新预警列表
         function updateAlertsList(alertsData) {
-            const alertsContainer = document.getElementById('alertsList');
-            const alerts = alertsData.active_alerts || [];
-            
+            const alerts = Array.isArray(alertsData.active_alerts) ? alertsData.active_alerts : [];
+            allAlerts = alerts; // 缓存，供 filterAlerts 使用
+
             // 更新活跃预警数量
             document.getElementById('activeAlerts').textContent = alerts.length;
-            
+
+            renderAlerts(alerts);
+        }
+
+        // 渲染预警列表
+        function renderAlerts(alerts) {
+            const alertsContainer = document.getElementById('alertsList');
+
             if (alerts.length === 0) {
                 alertsContainer.innerHTML = '<div class="text-center text-muted">暂无活跃预警</div>';
                 return;
@@ -705,7 +801,7 @@
                     <div class="d-flex justify-content-between align-items-start">
                         <div>
                             <strong>${alert.ts_code}</strong> - ${alert.alert_type}
-                            <div class="mt-1">${alert.message}</div>
+                            <div class="mt-1">${alert.alert_message || alert.message || ''}</div>
                             <small class="text-muted">
                                 创建时间: ${new Date(alert.created_at).toLocaleString()}
                             </small>
@@ -716,6 +812,16 @@
                     </div>
                 </div>
             `).join('');
+        }
+
+        // 按级别过滤预警
+        function filterAlerts() {
+            const level = document.getElementById('alertLevelFilter').value;
+            if (!level) {
+                renderAlerts(allAlerts);
+            } else {
+                renderAlerts(allAlerts.filter(a => a.alert_level === level));
+            }
         }
 
         // 显示添加持仓模态框
@@ -729,11 +835,33 @@
         function showCreatePortfolioModal() {
             const name = prompt('请输入新组合名称:');
             if (!name || !name.trim()) return;
-            currentPortfolioId = name.trim();
-            loadPositions();
-            // 刷新下拉列表，选中新组合
-            loadPortfolioList().then(() => {
-                document.getElementById('portfolioId').value = currentPortfolioId;
+
+            // 调用后端真正创建组合（空组合：写入一个占位标记）
+            fetch('/api/ml-factor/portfolio', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    portfolio_id: name.trim(),
+                    ts_code: '__PLACEHOLDER__',
+                    position_size: 0,
+                    avg_cost: 0,
+                    sector: ''
+                })
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    currentPortfolioId = name.trim();
+                    loadPortfolioList().then(() => {
+                        document.getElementById('portfolioId').value = currentPortfolioId;
+                    });
+                } else {
+                    alert('创建组合失败: ' + (data.message || data.error));
+                }
+            })
+            .catch(error => {
+                console.error('创建组合失败:', error);
+                alert('创建组合失败');
             });
         }
 

--- a/app/templates/realtime_analysis/risk_management.html
+++ b/app/templates/realtime_analysis/risk_management.html
@@ -735,44 +735,55 @@
             if (!el) return;
             const chart = echarts.init(el);
 
-            const pm = riskData.portfolio_metrics || {};
             const positions = portfolioData.positions || [];
 
             if (positions.length < 2) {
                 chart.setOption({
                     title: { text: '相关性热力图', left: 'center' },
-                    graphic: { type: 'text', left: 'center', top: 'middle', style: { text: '需要至少2只股票', fill: '#999', fontSize: 14 } }
+                    graphic: { type: 'text', left: 'center', top: 'middle', style: { text: '需要至少2只股票才能计算相关性', fill: '#999', fontSize: 14 } }
                 });
                 return;
             }
 
-            // 从持仓列表构建简单的相关性矩阵展示
             const codes = positions.map(p => p.ts_code);
-            const n = codes.length;
 
-            // 生成模拟相关性数据（对角线=1，其余用随机值作为占位）
-            // 实际相关性数据应来自后端的风险计算
-            const heatData = [];
-            for (let i = 0; i < n; i++) {
-                for (let j = 0; j < n; j++) {
-                    heatData.push([i, j, i === j ? 1 : (0.3 + Math.random() * 0.5).toFixed(2)]);
+            // 尝试使用后端返回的相关性矩阵（来自 calculate_portfolio_risk）
+            const correlationMatrix = riskData.correlation_metrics?.correlation_matrix;
+            if (correlationMatrix) {
+                // 后端有真实相关性数据
+                const heatData = [];
+                for (let i = 0; i < codes.length; i++) {
+                    const row = correlationMatrix[codes[i]];
+                    if (!row) continue;
+                    for (let j = 0; j < codes.length; j++) {
+                        const val = row[codes[j]];
+                        heatData.push([i, j, val !== undefined ? parseFloat(val).toFixed(2) : 0]);
+                    }
+                }
+                if (heatData.length > 0) {
+                    chart.setOption({
+                        title: { text: '相关性热力图', left: 'center' },
+                        tooltip: {
+                            formatter: function(p) { return `${codes[p.data[0]]} × ${codes[p.data[1]]}<br/>相关系数: ${p.data[2]}`; }
+                        },
+                        xAxis: { type: 'category', data: codes, splitArea: { show: true } },
+                        yAxis: { type: 'category', data: codes, splitArea: { show: true } },
+                        visualMap: { min: -1, max: 1, calculable: true, orient: 'horizontal', left: 'center', bottom: 0, inRange: { color: ['#313695', '#4575b4', '#74add1', '#abd9e9', '#e0f3f8', '#ffffbf', '#fee090', '#fdae61', '#f46d43', '#d73027', '#a50026'] } },
+                        series: [{
+                            type: 'heatmap',
+                            data: heatData,
+                            label: { show: true },
+                            emphasis: { itemStyle: { shadowBlur: 10, shadowColor: 'rgba(0, 0, 0, 0.5)' } }
+                        }]
+                    });
+                    return;
                 }
             }
 
+            // 没有后端相关性数据时显示空状态
             chart.setOption({
                 title: { text: '相关性热力图', left: 'center' },
-                tooltip: {
-                    formatter: function(p) { return `${codes[p.data[0]]} × ${codes[p.data[1]]}<br/>相关系数: ${p.data[2]}`; }
-                },
-                xAxis: { type: 'category', data: codes, splitArea: { show: true } },
-                yAxis: { type: 'category', data: codes, splitArea: { show: true } },
-                visualMap: { min: 0, max: 1, calculable: true, orient: 'horizontal', left: 'center', bottom: 0, inRange: { color: ['#313695', '#4575b4', '#74add1', '#abd9e9', '#e0f3f8', '#ffffbf', '#fee090', '#fdae61', '#f46d43', '#d73027', '#a50026'] } },
-                series: [{
-                    type: 'heatmap',
-                    data: heatData,
-                    label: { show: true },
-                    emphasis: { itemStyle: { shadowBlur: 10, shadowColor: 'rgba(0, 0, 0, 0.5)' } }
-                }]
+                graphic: { type: 'text', left: 'center', top: 'middle', style: { text: '暂无相关性数据\n请通过「风险分析」Tab 的详细计算获取', fill: '#999', fontSize: 14 } }
             });
         }
 

--- a/app/templates/realtime_analysis/risk_management.html
+++ b/app/templates/realtime_analysis/risk_management.html
@@ -836,33 +836,14 @@
             const name = prompt('请输入新组合名称:');
             if (!name || !name.trim()) return;
 
-            // 调用后端真正创建组合（空组合：写入一个占位标记）
-            fetch('/api/ml-factor/portfolio', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    portfolio_id: name.trim(),
-                    ts_code: '__PLACEHOLDER__',
-                    position_size: 0,
-                    avg_cost: 0,
-                    sector: ''
-                })
-            })
-            .then(response => response.json())
-            .then(data => {
-                if (data.success) {
-                    currentPortfolioId = name.trim();
-                    loadPortfolioList().then(() => {
-                        document.getElementById('portfolioId').value = currentPortfolioId;
-                    });
-                } else {
-                    alert('创建组合失败: ' + (data.message || data.error));
-                }
-            })
-            .catch(error => {
-                console.error('创建组合失败:', error);
-                alert('创建组合失败');
-            });
+            currentPortfolioId = name.trim();
+            // 先更新下拉框，用户后续通过"添加持仓"真正写入数据
+            const select = document.getElementById('portfolioId');
+            const option = document.createElement('option');
+            option.value = currentPortfolioId;
+            option.textContent = currentPortfolioId + ' (0只股票)';
+            select.appendChild(option);
+            select.value = currentPortfolioId;
         }
 
         // 添加持仓（Parquet 数据源）

--- a/tests/api/test_portfolio_create_api.py
+++ b/tests/api/test_portfolio_create_api.py
@@ -2,10 +2,12 @@ from unittest.mock import patch
 
 import pytest
 
+from app.services.parquet_state_store import ParquetStateStore, PortfolioRepository
+
 pytestmark = pytest.mark.module_portfolio
 
 
-def test_create_portfolio_position_endpoint_creates_first_position(app):
+def test_create_portfolio_position_endpoint_creates_first_position(app, tmp_path):
     client = app.test_client()
 
     payload = {
@@ -16,23 +18,19 @@ def test_create_portfolio_position_endpoint_creates_first_position(app):
         "sector": "银行",
     }
 
-    with patch("app.api.realtime_risk.PortfolioPosition") as portfolio_model:
-        portfolio_model.get_position_by_stock.return_value = None
-        portfolio_model.create_position.return_value.to_dict.return_value = {
-            "portfolio_id": "growth_a",
-            "ts_code": "000001.SZ",
-        }
+    repo = PortfolioRepository(ParquetStateStore(base_dir=str(tmp_path / "state")))
 
+    with patch("app.api.realtime_risk._portfolio_repo", repo):
         response = client.post("/api/realtime-analysis/risk/portfolio", json=payload)
 
     assert response.status_code == 200
     data = response.get_json()
     assert data["success"] is True
     assert data["data"]["portfolio_id"] == "growth_a"
-    portfolio_model.create_position.assert_called_once()
+    assert data["data"]["ts_code"] == "000001.SZ"
 
 
-def test_create_portfolio_position_endpoint_rejects_duplicate_stock(app):
+def test_create_portfolio_position_endpoint_rejects_duplicate_stock(app, tmp_path):
     client = app.test_client()
 
     payload = {
@@ -42,9 +40,19 @@ def test_create_portfolio_position_endpoint_rejects_duplicate_stock(app):
         "avg_cost": 12.5,
     }
 
-    with patch("app.api.realtime_risk.PortfolioPosition") as portfolio_model:
-        portfolio_model.get_position_by_stock.return_value = object()
+    repo = PortfolioRepository(ParquetStateStore(base_dir=str(tmp_path / "state")))
+    # 先插入一条相同股票
+    repo.upsert_position({
+        "portfolio_id": "growth_a",
+        "ts_code": "000001.SZ",
+        "position_size": 500,
+        "avg_cost": 10.0,
+        "current_price": 10.0,
+        "market_value": 5000,
+        "is_active": True,
+    })
 
+    with patch("app.api.realtime_risk._portfolio_repo", repo):
         response = client.post("/api/realtime-analysis/risk/portfolio", json=payload)
 
     assert response.status_code == 200

--- a/tests/api/test_portfolio_position_update_api.py
+++ b/tests/api/test_portfolio_position_update_api.py
@@ -2,10 +2,12 @@ from unittest.mock import patch
 
 import pytest
 
+from app.services.parquet_state_store import ParquetStateStore, PortfolioRepository
+
 pytestmark = pytest.mark.module_portfolio
 
 
-def test_update_portfolio_position_endpoint_updates_supported_fields(app):
+def test_update_portfolio_position_endpoint_updates_supported_fields(app, tmp_path):
     client = app.test_client()
 
     payload = {
@@ -16,48 +18,28 @@ def test_update_portfolio_position_endpoint_updates_supported_fields(app):
         "stop_loss_price": 9.8,
         "take_profit_price": 12.6,
     }
-    class Position:
-        def __init__(self):
-            self.id = 7
-            self.portfolio_id = "growth_a"
-            self.ts_code = "000001.SZ"
-            self.position_size = 1000.0
-            self.avg_cost = 10.0
-            self.current_price = 10.0
-            self.sector = None
-            self.stop_loss_price = None
-            self.take_profit_price = None
-            self.market_value = None
-            self.unrealized_pnl = None
 
-        def to_dict(self):
-            return {
-                "id": self.id,
-                "portfolio_id": self.portfolio_id,
-                "ts_code": self.ts_code,
-                "position_size": self.position_size,
-                "avg_cost": self.avg_cost,
-                "current_price": self.current_price,
-                "sector": self.sector,
-                "stop_loss_price": self.stop_loss_price,
-                "take_profit_price": self.take_profit_price,
-                "market_value": self.market_value,
-                "unrealized_pnl": self.unrealized_pnl,
-            }
+    repo = PortfolioRepository(ParquetStateStore(base_dir=str(tmp_path / "state")))
+    repo.upsert_position({
+        "portfolio_id": "growth_a",
+        "ts_code": "000001.SZ",
+        "position_size": 1000.0,
+        "avg_cost": 10.0,
+        "current_price": 10.0,
+        "market_value": 10000,
+        "unrealized_pnl": 0,
+        "is_active": True,
+    })
 
-    def update_position_by_id(*_args, **kwargs):
-        position = Position()
-        for key, value in kwargs.items():
-            if value is not None:
-                setattr(position, key, value)
-        position.market_value = position.position_size * position.current_price
-        position.unrealized_pnl = (position.current_price - position.avg_cost) * position.position_size
-        return position
+    # 获取分配的 id
+    positions = repo.list_positions("growth_a", active_only=False)
+    position_id = positions[0]["id"]
 
-    with patch("app.api.realtime_risk.PortfolioPosition") as portfolio_model:
-        portfolio_model.update_position_by_id.side_effect = update_position_by_id
-
-        response = client.put("/api/realtime-analysis/risk/portfolio/growth_a/positions/7", json=payload)
+    with patch("app.api.realtime_risk._portfolio_repo", repo):
+        response = client.put(
+            f"/api/realtime-analysis/risk/portfolio/growth_a/positions/{position_id}",
+            json=payload,
+        )
 
     assert response.status_code == 200
     data = response.get_json()
@@ -68,17 +50,16 @@ def test_update_portfolio_position_endpoint_updates_supported_fields(app):
     assert data["data"]["sector"] == "银行"
     assert data["data"]["market_value"] == 13440.0
     assert data["data"]["unrealized_pnl"] == pytest.approx(840.0)
-    portfolio_model.update_position_by_id.assert_called_once()
 
 
-def test_update_portfolio_position_endpoint_returns_not_found_when_missing(app):
+def test_update_portfolio_position_endpoint_returns_not_found_when_missing(app, tmp_path):
     client = app.test_client()
 
-    with patch("app.api.realtime_risk.PortfolioPosition") as portfolio_model:
-        portfolio_model.update_position_by_id.return_value = None
+    repo = PortfolioRepository(ParquetStateStore(base_dir=str(tmp_path / "state")))
 
+    with patch("app.api.realtime_risk._portfolio_repo", repo):
         response = client.put(
-            "/api/realtime-analysis/risk/portfolio/growth_a/positions/7",
+            "/api/realtime-analysis/risk/portfolio/growth_a/positions/9999",
             json={"position_size": 1200},
         )
 

--- a/tests/services/test_realtime_risk_manager_monitor_contract.py
+++ b/tests/services/test_realtime_risk_manager_monitor_contract.py
@@ -1,0 +1,73 @@
+from unittest.mock import patch
+
+from app.services.realtime_risk_manager import RealtimeRiskManager
+
+
+def test_monitor_position_risk_updates_market_data():
+    manager = RealtimeRiskManager()
+
+    positions = [{
+        "ts_code": "000001.SZ",
+        "position_size": 1000.0,
+        "avg_cost": 10.0,
+        "current_price": 10.0,
+        "market_value": 10000.0,
+        "unrealized_pnl": 0.0,
+        "weight": 100.0,
+        "sector": "银行",
+        "var_1d": 0.01,
+        "var_5d": 0.02,
+        "beta": 1.0,
+        "volatility": 0.2,
+        "is_active": True,
+    }]
+
+    with patch("app.services.realtime_risk_manager._portfolio_repo") as repo:
+        repo.list_positions.return_value = positions
+        repo.calculate_metrics.return_value = {"total_market_value": 10000.0}
+
+        with patch.object(manager, "_get_current_price", return_value=11.0):
+            result = manager.monitor_position_risk("growth_a")
+
+    assert result["success"] is True
+    # upsert_position 应被调用以持久化更新的价格
+    assert repo.upsert_position.call_count == 1
+    saved = repo.upsert_position.call_args[0][0]
+    assert saved["current_price"] == 11.0
+    assert saved["market_value"] == 11000.0
+    assert saved["unrealized_pnl"] == 1000.0
+
+
+def test_create_risk_alert_uses_model_creator():
+    from types import SimpleNamespace
+
+    manager = RealtimeRiskManager()
+
+    alert = SimpleNamespace(
+        to_dict=lambda: {
+            "id": 9,
+            "ts_code": "000001.SZ",
+            "alert_type": "stop_loss_triggered",
+            "alert_level": "high",
+        }
+    )
+
+    positions = [{"ts_code": "000001.SZ", "position_size": 1000, "weight": 25.0}]
+
+    with patch("app.services.realtime_risk_manager.RiskAlert.get_existing_active_alert", return_value=None), \
+         patch("app.services.realtime_risk_manager._portfolio_repo") as repo, \
+         patch.object(manager, "_get_current_price", return_value=10.2), \
+         patch("app.services.realtime_risk_manager.RiskAlert.create_alert", return_value=alert) as create_alert:
+        repo.list_portfolio_ids.return_value = ["growth_a"]
+        repo.list_positions.return_value = positions
+
+        result = manager.create_risk_alert(
+            ts_code="000001.SZ",
+            alert_type="stop_loss_triggered",
+            alert_level="high",
+            alert_message="触发止损",
+        )
+
+    assert result["success"] is True
+    assert result["data"]["ts_code"] == "000001.SZ"
+    assert create_alert.call_count == 1

--- a/tests/services/test_realtime_risk_manager_monitor_contract.py
+++ b/tests/services/test_realtime_risk_manager_monitor_contract.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from app.services.realtime_risk_manager import RealtimeRiskManager
 
 
@@ -36,6 +38,50 @@ def test_monitor_position_risk_updates_market_data():
     assert saved["current_price"] == 11.0
     assert saved["market_value"] == 11000.0
     assert saved["unrealized_pnl"] == 1000.0
+
+
+def test_monitor_position_risk_computes_weights_after_price_refresh():
+    """Weight 应基于刷新后的市值计算，而非刷新前。"""
+    manager = RealtimeRiskManager()
+
+    positions = [
+        {
+            "ts_code": "000001.SZ",
+            "position_size": 1000.0,
+            "avg_cost": 10.0,
+            "current_price": 10.0,
+            "market_value": 10000.0,
+            "unrealized_pnl": 0.0,
+            "weight": None,
+            "is_active": True,
+        },
+        {
+            "ts_code": "000002.SZ",
+            "position_size": 500.0,
+            "avg_cost": 20.0,
+            "current_price": 20.0,
+            "market_value": 10000.0,
+            "unrealized_pnl": 0.0,
+            "weight": None,
+            "is_active": True,
+        },
+    ]
+
+    def fake_get_price(ts_code):
+        return 12.0 if ts_code == "000001.SZ" else 18.0
+
+    with patch("app.services.realtime_risk_manager._portfolio_repo") as repo:
+        repo.list_positions.return_value = positions
+        repo.calculate_metrics.return_value = {"total_market_value": 21000.0}
+
+        with patch.object(manager, "_get_current_price", side_effect=fake_get_price):
+            result = manager.monitor_position_risk("growth_a")
+
+    assert result["success"] is True
+    # 000001: 1000*12=12000, 000002: 500*18=9000, total=21000
+    # weight: 12000/21000*100 ≈ 57.14, 9000/21000*100 ≈ 42.86
+    assert positions[0]["weight"] == pytest.approx(57.142857, rel=1e-3)
+    assert positions[1]["weight"] == pytest.approx(42.857142, rel=1e-3)
 
 
 def test_create_risk_alert_uses_model_creator():

--- a/tests/services/test_realtime_risk_manager_update_contract.py
+++ b/tests/services/test_realtime_risk_manager_update_contract.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+
+from app.services.realtime_risk_manager import RealtimeRiskManager
+
+
+def test_manage_stop_loss_take_profit_updates_positions():
+    manager = RealtimeRiskManager()
+
+    positions = [{
+        "ts_code": "000001.SZ",
+        "position_size": 1000.0,
+        "avg_cost": 10.0,
+        "current_price": 10.0,
+        "market_value": 10000.0,
+        "unrealized_pnl": 0.0,
+        "stop_loss_price": None,
+        "take_profit_price": None,
+        "weight": 100.0,
+        "is_active": True,
+    }]
+
+    with patch("app.services.realtime_risk_manager._portfolio_repo") as repo:
+        repo.list_positions.return_value = positions
+        result = manager.manage_stop_loss_take_profit("growth_a")
+
+    assert result["success"] is True
+    # upsert_position 应被调用以持久化止损止盈价格
+    assert repo.upsert_position.call_count == 1
+    saved = repo.upsert_position.call_args[0][0]
+    assert saved["stop_loss_price"] == 9.0  # 10.0 * (1 - 0.10)
+    assert saved["take_profit_price"] == 12.0  # 10.0 * (1 + 0.20)


### PR DESCRIPTION
## 问题

风险管理页面 (`/realtime-analysis/risk`) 5 个 Tab 中只有"持仓管理"正常工作，其余 4 个 Tab（风险分析、预警管理、止损止盈、压力测试）全部返回空数据。

### 根因
- 持仓管理从 **Parquet** 读取（`PortfolioRepository`）
- 其余 4 个 Tab 从 **SQLite** 读取（`PortfolioPosition`），但 SQLite 中无数据

### 前端 Bug
1. `filterAlerts()` 未定义但被 `onchange` 调用
2. `alert.message` → 应为 `alert_message`（字段名不匹配）
3. `active_alerts` 后端返回 int，前端当数组用
4. `showCreatePortfolioModal()` 用 prompt 未持久化
5. VaR 图表和相关性热力图从未渲染

## 修复内容

### 后端（3 个文件）
| 文件 | 改动 |
|------|------|
| `app/services/realtime_risk_manager.py` | 重写：SQLite → Parquet，添加 dict 辅助函数 |
| `app/api/realtime_risk.py` | 所有端点改用 `PortfolioRepository` |
| `app/services/websocket_push_service.py` | 1 处引用改用 Parquet |

### 前端（1 个文件）
| 文件 | 改动 |
|------|------|
| `app/templates/realtime_analysis/risk_management.html` | 修复 5 个 Bug |

## 验证

```bash
# 风险分析 — 修复前返回空，修复后返回 2 持仓
curl -s "http://localhost:5000/api/realtime-analysis/risk/position-monitor?portfolio_id=test1"

# 止损止盈 — 修复前返回空，修复后正确计算 SL/TP
curl -s -X POST "http://localhost:5000/api/realtime-analysis/risk/stop-loss-take-profit" \
  -H "Content-Type: application/json" \
  -d '{"portfolio_id":"test1","stop_loss_method":"percentage","stop_loss_value":0.10}'

# 压力测试 — 修复前返回空，修复后 4 场景
curl -s -X POST "http://localhost:5000/api/realtime-analysis/risk/stress-test" \
  -H "Content-Type: application/json" \
  -d '{"portfolio_id":"test1"}'
```

## 不改动的文件
- `portfolio_position.py` — SQLite Model 保持不变
- `risk_alert.py` — 预警存储保持 SQLite
- `parquet_state_store.py` — 无需修改
- `ml_factor_api.py` — 持仓管理路由不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)