### PR TITLE
chore: persist Docker data and runtime state

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,35 @@
+# Docker deployment example.
+# Copy this file to .env before running docker compose:
+#   cp .env.docker.example .env
+
+# Flask
+DEBUG=True
+SECRET_KEY=change-this-secret
+
+# SQLite ORM default inside the container.
+# docker-compose.yml persists this file under ./instance on the host.
+SQLITE_DATABASE_PATH=/app/instance/stock_cursor.sqlite3
+
+# Redis / Celery inside the Docker Compose network.
+# Use the service name "redis" instead of localhost from containers.
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_DB=0
+CELERY_BROKER_URL=redis://redis:6379/0
+CELERY_RESULT_BACKEND=redis://redis:6379/0
+# Data source.
+# docker-compose.yml mounts the host ./data directory to /app/data.
+# Put the downloaded Parquet data package contents in ./data on the host.
+DATA_SOURCE=parquet
+DATA_DIR=/app/data
+TUSHARE_TOKEN=your_tushare_token
+
+# Runtime mode.
+# Docker Compose starts a worker service, so data jobs should use Celery.
+DATA_JOB_EXECUTION_MODE=celery
+
+# OpenAI / LLM optional
+LLM_PROVIDER=openai
+LLM_API_KEY=
+LLM_BASE_URL=https://api.deepseek.com
+LLM_MODEL=deepseek-v4-flash

--- a/.env.example
+++ b/.env.example
@@ -1,20 +1,25 @@
 # Flask
 DEBUG=True
-SECRET_KEY=change-this-secret
+SECRET_KEY=change-me
 
-# SQLite ORM default
-SQLITE_DATABASE_PATH=./instance/stock_cursor.sqlite3
+# SQLite ORM default inside the container.
+# docker-compose.yml persists this file under ./instance on the host.
+SQLITE_DATABASE_PATH=/app/instance/stock_cursor.sqlite3
 
-# Redis / Celery
-REDIS_HOST=localhost
+# Redis / Celery inside the Docker Compose network.
+# Use the service name "redis" instead of localhost from containers.
+REDIS_HOST=redis
 REDIS_PORT=6379
 REDIS_DB=0
-CELERY_BROKER_URL=redis://localhost:6379/0
-CELERY_RESULT_BACKEND=redis://localhost:6379/0
+CELERY_BROKER_URL=redis://redis:6379/0
+CELERY_RESULT_BACKEND=redis://redis:6379/0
 
-# Data source
+# Data source.
+# docker-compose.yml mounts the host ./data directory to /app/data.
+# Put the downloaded Parquet data package contents in ./data on the host.
 DATA_SOURCE=parquet
-TUSHARE_TOKEN=your_tushare_token
+DATA_DIR=/app/data
+TUSHARE_TOKEN=your_token
 
 # Runtime mode
 DATA_JOB_EXECUTION_MODE=inline
@@ -22,5 +27,4 @@ DATA_JOB_EXECUTION_MODE=inline
 # OpenAI / LLM optional
 LLM_PROVIDER=openai
 LLM_API_KEY=
-LLM_BASE_URL=https://api.deepseek.com
 LLM_MODEL=deepseek-v4-flash

--- a/.env.example
+++ b/.env.example
@@ -1,25 +1,20 @@
 # Flask
 DEBUG=True
-SECRET_KEY=change-me
+SECRET_KEY=change-this-secret
 
-# SQLite ORM default inside the container.
-# docker-compose.yml persists this file under ./instance on the host.
-SQLITE_DATABASE_PATH=/app/instance/stock_cursor.sqlite3
+# SQLite ORM default
+SQLITE_DATABASE_PATH=./instance/stock_cursor.sqlite3
 
-# Redis / Celery inside the Docker Compose network.
-# Use the service name "redis" instead of localhost from containers.
-REDIS_HOST=redis
+# Redis / Celery
+REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_DB=0
-CELERY_BROKER_URL=redis://redis:6379/0
-CELERY_RESULT_BACKEND=redis://redis:6379/0
+CELERY_BROKER_URL=redis://localhost:6379/0
+CELERY_RESULT_BACKEND=redis://localhost:6379/0
 
-# Data source.
-# docker-compose.yml mounts the host ./data directory to /app/data.
-# Put the downloaded Parquet data package contents in ./data on the host.
+# Data source
 DATA_SOURCE=parquet
-DATA_DIR=/app/data
-TUSHARE_TOKEN=your_token
+TUSHARE_TOKEN=your_tushare_token
 
 # Runtime mode
 DATA_JOB_EXECUTION_MODE=inline
@@ -27,4 +22,5 @@ DATA_JOB_EXECUTION_MODE=inline
 # OpenAI / LLM optional
 LLM_PROVIDER=openai
 LLM_API_KEY=
+LLM_BASE_URL=https://api.deepseek.com
 LLM_MODEL=deepseek-v4-flash

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt requirements_minimal.txt ./
-RUN pip install --no-cache-dir -r requirements_minimal.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt requirements_minimal.txt ./
+COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -38,12 +38,13 @@ class _LocalCelery:
 
 def make_celery(config_name: str = "default"):
     cfg = config[config_name]
-    broker = f"redis://{cfg.REDIS_HOST}:{cfg.REDIS_PORT}/{cfg.REDIS_DB}"
+    broker = cfg.CELERY_BROKER_URL
+    backend = cfg.CELERY_RESULT_BACKEND
 
     if Celery is None:
         return _LocalCelery()
 
-    celery = Celery("quant_data_jobs", broker=broker, backend=broker)
+    celery = Celery("quant_data_jobs", broker=broker, backend=backend)
     celery.conf.update(
         task_serializer="json",
         accept_content=["json"],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,43 +1,27 @@
+version: "3.9"
+
+x-app-common: &app-common
+  build: .
+  env_file:
+    - .env
+  volumes:
+    - ./data:/app/data
+    - ./instance:/app/instance
+    - ./logs:/app/logs
+  depends_on:
+    - redis
+  restart: unless-stopped
+
 services:
   web:
-    build: .
+    <<: *app-common
     command: python run.py
     ports:
       - "5000:5000"
-    env_file:
-      - .env
-    environment:
-      DATA_DIR: /app/data
-      SQLITE_DATABASE_PATH: /app/instance/stock_cursor.sqlite3
-      REDIS_HOST: redis
-      CELERY_BROKER_URL: redis://redis:6379/0
-      CELERY_RESULT_BACKEND: redis://redis:6379/0
-    volumes:
-      - ./data:/app/data
-      - ./instance:/app/instance
-      - ./logs:/app/logs
-    depends_on:
-      - redis
-    restart: unless-stopped
 
   worker:
-    build: .
+    <<: *app-common
     command: celery -A app.celery_app.celery worker -l info -P solo
-    env_file:
-      - .env
-    environment:
-      DATA_DIR: /app/data
-      SQLITE_DATABASE_PATH: /app/instance/stock_cursor.sqlite3
-      REDIS_HOST: redis
-      CELERY_BROKER_URL: redis://redis:6379/0
-      CELERY_RESULT_BACKEND: redis://redis:6379/0
-    volumes:
-      - ./data:/app/data
-      - ./instance:/app/instance
-      - ./logs:/app/logs
-    depends_on:
-      - redis
-    restart: unless-stopped
 
   redis:
     image: redis:7-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   web:
     build: .
@@ -8,18 +6,46 @@ services:
       - "5000:5000"
     env_file:
       - .env
+    environment:
+      DATA_DIR: /app/data
+      SQLITE_DATABASE_PATH: /app/instance/stock_cursor.sqlite3
+      REDIS_HOST: redis
+      CELERY_BROKER_URL: redis://redis:6379/0
+      CELERY_RESULT_BACKEND: redis://redis:6379/0
+    volumes:
+      - ./data:/app/data
+      - ./instance:/app/instance
+      - ./logs:/app/logs
     depends_on:
       - redis
+    restart: unless-stopped
 
   worker:
     build: .
     command: celery -A app.celery_app.celery worker -l info -P solo
     env_file:
       - .env
+    environment:
+      DATA_DIR: /app/data
+      SQLITE_DATABASE_PATH: /app/instance/stock_cursor.sqlite3
+      REDIS_HOST: redis
+      CELERY_BROKER_URL: redis://redis:6379/0
+      CELERY_RESULT_BACKEND: redis://redis:6379/0
+    volumes:
+      - ./data:/app/data
+      - ./instance:/app/instance
+      - ./logs:/app/logs
     depends_on:
       - redis
+    restart: unless-stopped
 
   redis:
     image: redis:7-alpine
     ports:
       - "6379:6379"
+    volumes:
+      - redis_data:/data
+    restart: unless-stopped
+
+volumes:
+  redis_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,3 +72,4 @@ cvxpy>=1.4.0
 #金融数据获取
 baostock>=0.8.9
 tushare>=1.3.0
+pytdx>=1.72


### PR DESCRIPTION
## Summary

This PR improves the default Docker deployment configuration so the project can be run directly with persistent application state, Parquet market data, Redis/Celery services, and minute-level data sync dependencies on a host machine or NAS/router environment.

Changes:

- Mount host `./data` to container `/app/data` for downloaded Parquet data packages.
- Mount host `./instance` to container `/app/instance` so the SQLite database survives container rebuilds/restarts.
- Mount host `./logs` to container `/app/logs` so logs are persisted outside the container.
- Use the Compose service name `redis` for Redis/Celery settings instead of `localhost`, which does not point to the Redis container from inside `web`/`worker` containers.
- Persist Redis data with a named volume.
- Add `restart: unless-stopped` for the app services and Redis.
- Update `.env.example` to match the Docker Compose paths and network settings.
- Install `requirements.txt` in the Docker image instead of `requirements_minimal.txt`, because the Compose setup starts Redis/Celery-backed services and the minimal dependency set does not include required packages such as `redis` and `celery`.
- Add `pytdx` to `requirements.txt`, because the Tongdaxin minute data sync imports `pytdx.hq.TdxHq_API`.

## Why

The README tells users to download the Parquet data package and use the Docker deployment, but the previous Compose file did not mount the host data directory into the container. In practice, users who unzip the data package on the host still get startup warnings that required assets are missing because the container cannot see the files.

The previous `.env.example` also used `localhost` for Redis. In Docker Compose, `localhost` inside the `web` or `worker` container refers to that same container, not the Redis service. Using `redis` matches the Compose service name and allows the containers to connect reliably.

Persisting `data`, `instance`, `logs`, and Redis storage also prevents data loss when containers are rebuilt or upgraded.

Additionally, the minute-level Tongdaxin sync path currently imports `pytdx`, but `pytdx` was not listed in `requirements.txt`. Without it, syncing data such as `5min` bars fails with `No module named 'pytdx'`.

## Validation

Validated on an iStoreOS Docker host with a downloaded `data.zip` package:

1. Extracted the archive so files such as `stock_basic.parquet`, `stock_trade_calendar.parquet`, `stock_business.parquet`, `daily_history/daily`, and `daily_basic/daily` exist under host `./data`.
2. Ran Docker Compose with the updated mounts and environment.
3. Verified all containers started:
   - `web`
   - `worker`
   - `redis`
4. Verified the app responded with `HTTP/1.1 200 OK` on port `5000`.
5. Verified startup logs changed from missing critical Parquet assets to:
   - `关键资产检查: 通过`
   - `✅ 大宽表: 宽表已是最新`
6. Verified `pytdx` can be imported inside the Docker container.
7. Verified syncing `5min` data no longer fails with `No module named 'pytdx'`.
