### PR TITLE
feat: 整合 fuyao/tickflow 数据源 + 市场页面焕新（看板/自选/龙虎榜/连板/概念/行业/热股）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,12 @@ SQLITE_DATABASE_PATH=./instance/stock_cursor.sqlite3
 DATA_SOURCE=parquet
 TUSHARE_TOKEN=your_tushare_token
 
+# 第三方行情数据源（与 tushare 相互独立，同一张 Parquet 表的可选生产者）
+# 扶摇（同花顺）：日线/财务/实时快照，daily_history_fuyao 等任务使用
+FUYAO_API_KEY=
+# TickFlow：free 档仅支持单标的日K/行情（约5rpm），仅作校验兜底，勿用于批量任务
+TICKFLOW_API_KEY=
+
 # Runtime mode
 DATA_JOB_EXECUTION_MODE=inline
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -54,6 +54,7 @@ def create_app(config_name='default'):
     from app.routes.heatmap import heatmap_routes
     from app.routes.pattern_screen import pattern_screen_bp
     from app.api.pattern_screen_api import pattern_screen_api
+    from app.api.market_api import market_bp, datasources_bp
     app.register_blueprint(api_bp, url_prefix='/api')
     app.register_blueprint(ml_factor_bp)
     app.register_blueprint(text2sql_bp)
@@ -71,6 +72,8 @@ def create_app(config_name='default'):
     app.register_blueprint(heatmap_routes)
     app.register_blueprint(pattern_screen_bp)
     app.register_blueprint(pattern_screen_api)
+    app.register_blueprint(market_bp)
+    app.register_blueprint(datasources_bp)
 
     from app.main import main_bp
     app.register_blueprint(main_bp)

--- a/app/api/market_api.py
+++ b/app/api/market_api.py
@@ -1,0 +1,93 @@
+"""行情与数据源 API（数据来自扶摇快照，降级见 market_snapshot_service）。"""
+
+from flask import Blueprint, jsonify, request
+from loguru import logger
+
+from app.services.market_snapshot_service import get_market_snapshot_service
+
+market_bp = Blueprint("market_api", __name__, url_prefix="/api/market")
+datasources_bp = Blueprint("datasources_api", __name__, url_prefix="/api/datasources")
+
+
+def _ok(data) -> "tuple":
+    return jsonify({"code": 200, "message": "成功", "data": data})
+
+
+def _error(message: str, status: int = 500) -> "tuple":
+    return jsonify({"code": status, "message": message, "data": None}), status
+
+
+def _parse_codes(raw: str, limit: int = 200) -> list:
+    codes = [code.strip() for code in (raw or "").split(",") if code.strip()]
+    return codes[:limit]
+
+
+@market_bp.route("/snapshot", methods=["GET"])
+def get_snapshot():
+    """按代码取实时快照（逗号分隔，≤200 只）。"""
+    codes = _parse_codes(request.args.get("codes", ""))
+    if not codes:
+        return _error("缺少 codes 参数（逗号分隔的 ts_code，≤200 只）", 400)
+    try:
+        quotes = get_market_snapshot_service().get_quotes(codes)
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"行情快照API错误: {exc}")
+        return _error(f"行情快照获取失败: {exc}")
+    return _ok({"quotes": quotes, "updated_at": None})
+
+
+@market_bp.route("/dashboard", methods=["GET"])
+def get_dashboard():
+    """市场看板聚合（实时；扶摇异常时降级本地最近交易日）。"""
+    try:
+        return _ok(get_market_snapshot_service().get_dashboard())
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"市场看板API错误: {exc}")
+        return _error(f"市场看板获取失败: {exc}")
+
+
+@market_bp.route("/indices", methods=["GET"])
+def get_indices():
+    """指数实时快照（可选 codes 参数，默认看板四指数）。"""
+    codes = _parse_codes(request.args.get("codes", "")) or None
+    try:
+        return _ok({"indices": get_market_snapshot_service().get_indices(codes)})
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"指数行情API错误: {exc}")
+        return _error(f"指数行情获取失败: {exc}")
+
+
+@market_bp.route("/dragon-tiger", methods=["GET"])
+def get_dragon_tiger():
+    """龙虎榜（board: all/org/hot_money；date 格式 YYYYMMDD，可空=最近发布日）。"""
+    board = request.args.get("board", "all")
+    if board not in ("all", "org", "hot_money"):
+        return _error("board 取值须为 all/org/hot_money", 400)
+    date = (request.args.get("date") or "").strip() or None
+    try:
+        return _ok(get_market_snapshot_service().get_dragon_tiger(board_type=board, date=date))
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"龙虎榜API错误: {exc}")
+        return _error(f"龙虎榜获取失败: {exc}")
+
+
+@market_bp.route("/auction-benchmark", methods=["GET"])
+def get_auction_benchmark():
+    """盘前竞价短线风向标（date 可空=当日；支持一年内历史）。"""
+    date = (request.args.get("date") or "").strip() or None
+    try:
+        return _ok(get_market_snapshot_service().get_auction_benchmark(date=date))
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"竞价风向标API错误: {exc}")
+        return _error(f"竞价风向标获取失败: {exc}")
+
+
+@datasources_bp.route("/status", methods=["GET"])
+def get_datasource_status():
+    """三数据源健康状态（探测结果缓存 5 分钟；?force=1 强制重探）。"""
+    force = (request.args.get("force") or "").lower() in ("1", "true", "yes")
+    try:
+        return _ok(get_market_snapshot_service().get_source_status(force=force))
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"数据源状态API错误: {exc}")
+        return _error(f"数据源状态获取失败: {exc}")

--- a/app/api/market_api.py
+++ b/app/api/market_api.py
@@ -87,10 +87,17 @@ def get_auction_benchmark():
         return _error(f"竞价风向标获取失败: {exc}")
 
 
-@market_bp.route("/limit-up/pool", methods=["GET"])
-def get_limit_up_pool():
-    """涨停池（date YYYYMMDD 可空=最近交易日；page/size 分页，连板数降序）。"""
-    service = get_board_market_service()
+@market_bp.route("/limit-up/ladder", methods=["GET"])
+def get_limit_up_ladder():
+    """连板天梯矩阵（近 30 个交易日，2 板~7 板+ 各档家数）。"""
+    try:
+        return _ok(get_board_market_service().get_limit_up_ladder())
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"连板天梯API错误: {exc}")
+        return _error(f"连板天梯获取失败: {exc}")
+
+
+def _pool_endpoint(fetch):
     date = (request.args.get("date") or "").strip() or None
     if date and not _DATE_RE.fullmatch(date):
         return _error("date 格式应为 YYYYMMDD", 400)
@@ -100,22 +107,63 @@ def get_limit_up_pool():
     except ValueError:
         return _error("page/size 须为整数", 400)
     try:
-        return _ok(service.get_limit_up_pool(date=date, page=page, size=size))
+        return _ok(fetch(date, page, size))
     except ValueError as exc:
         return _error(str(exc), 400)
     except Exception as exc:  # noqa: BLE001
-        logger.error(f"涨停池API错误: {exc}")
-        return _error(f"涨停池获取失败: {exc}")
+        logger.error(f"股票池API错误: {exc}")
+        return _error(f"股票池获取失败: {exc}")
 
 
-@market_bp.route("/limit-up/ladder", methods=["GET"])
-def get_limit_up_ladder():
-    """连板天梯矩阵（近 30 个交易日，2 板~7 板+ 各档家数）。"""
+@market_bp.route("/limit-up/pool", methods=["GET"])
+def get_limit_up_pool():
+    """涨停池（date YYYYMMDD 可空=最近交易日；page/size 分页，连板数降序）。"""
+    service = get_board_market_service()
+    return _pool_endpoint(service.get_limit_up_pool)
+
+
+@market_bp.route("/limit-down/pool", methods=["GET"])
+def get_limit_down_pool():
+    """跌停池（date 口径同涨停池）。"""
+    service = get_board_market_service()
+    return _pool_endpoint(service.get_limit_down_pool)
+
+
+@market_bp.route("/limit-break/pool", methods=["GET"])
+def get_limit_break_pool():
+    """炸板池（曾涨停后开板；date 口径同涨停池）。"""
+    service = get_board_market_service()
+    return _pool_endpoint(service.get_limit_break_pool)
+
+
+@market_bp.route("/hot-stocks", methods=["GET"])
+def get_hot_stocks():
+    """同花顺热股榜 + 飙升榜（period: day/hour，缓存 5 分钟）。"""
+    period = (request.args.get("period") or "day").strip()
+    if period not in ("day", "hour"):
+        return _error("period 取值须为 day/hour", 400)
     try:
-        return _ok(get_board_market_service().get_limit_up_ladder())
+        return _ok(get_board_market_service().get_hot_stocks(period))
     except Exception as exc:  # noqa: BLE001
-        logger.error(f"连板天梯API错误: {exc}")
-        return _error(f"连板天梯获取失败: {exc}")
+        logger.error(f"热股榜API错误: {exc}")
+        return _error(f"热股榜获取失败: {exc}")
+
+
+@market_bp.route("/ticker-search", methods=["GET"])
+def get_ticker_search():
+    """标的名称/代码模糊检索（自选添加联想，A 股）。"""
+    query = (request.args.get("q") or "").strip()
+    if len(query) < 2:
+        return _error("q 参数至少 2 个字符", 400)
+    try:
+        limit = min(20, max(1, int(request.args.get("limit", 10))))
+    except ValueError:
+        return _error("limit 须为整数", 400)
+    try:
+        return _ok(get_board_market_service().search_tickers(query, limit))
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"标的检索API错误: {exc}")
+        return _error(f"标的检索获取失败: {exc}")
 
 
 @market_bp.route("/boards", methods=["GET"])

--- a/app/api/market_api.py
+++ b/app/api/market_api.py
@@ -1,9 +1,14 @@
 """行情与数据源 API（数据来自扶摇快照，降级见 market_snapshot_service）。"""
 
+import re
+
 from flask import Blueprint, jsonify, request
 from loguru import logger
 
+from app.services.board_market_service import VALID_TAGS, get_board_market_service
 from app.services.market_snapshot_service import get_market_snapshot_service
+
+_DATE_RE = re.compile(r"\d{8}")
 
 market_bp = Blueprint("market_api", __name__, url_prefix="/api/market")
 datasources_bp = Blueprint("datasources_api", __name__, url_prefix="/api/datasources")
@@ -80,6 +85,63 @@ def get_auction_benchmark():
     except Exception as exc:  # noqa: BLE001
         logger.error(f"竞价风向标API错误: {exc}")
         return _error(f"竞价风向标获取失败: {exc}")
+
+
+@market_bp.route("/limit-up/pool", methods=["GET"])
+def get_limit_up_pool():
+    """涨停池（date YYYYMMDD 可空=最近交易日；page/size 分页，连板数降序）。"""
+    service = get_board_market_service()
+    date = (request.args.get("date") or "").strip() or None
+    if date and not _DATE_RE.fullmatch(date):
+        return _error("date 格式应为 YYYYMMDD", 400)
+    try:
+        page = max(1, int(request.args.get("page", 1)))
+        size = min(200, max(1, int(request.args.get("size", 100))))
+    except ValueError:
+        return _error("page/size 须为整数", 400)
+    try:
+        return _ok(service.get_limit_up_pool(date=date, page=page, size=size))
+    except ValueError as exc:
+        return _error(str(exc), 400)
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"涨停池API错误: {exc}")
+        return _error(f"涨停池获取失败: {exc}")
+
+
+@market_bp.route("/limit-up/ladder", methods=["GET"])
+def get_limit_up_ladder():
+    """连板天梯矩阵（近 30 个交易日，2 板~7 板+ 各档家数）。"""
+    try:
+        return _ok(get_board_market_service().get_limit_up_ladder())
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"连板天梯API错误: {exc}")
+        return _error(f"连板天梯获取失败: {exc}")
+
+
+@market_bp.route("/boards", methods=["GET"])
+def get_boards():
+    """同花顺板块涨跌排行（tag: industry=行业 / cn_concept=概念）。"""
+    tag = (request.args.get("tag") or "industry").strip()
+    if tag not in VALID_TAGS:
+        return _error(f"tag 取值须为 {'/'.join(VALID_TAGS)}", 400)
+    try:
+        return _ok(get_board_market_service().get_boards(tag))
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"板块排行API错误: {exc}")
+        return _error(f"板块排行获取失败: {exc}")
+
+
+@market_bp.route("/boards/constituents", methods=["GET"])
+def get_board_constituents():
+    """板块成分股 + 实时行情富化（code 为同花顺指数代码，如 881101.TI）。"""
+    code = (request.args.get("code") or "").strip()
+    if not code:
+        return _error("缺少 code 参数（同花顺指数代码）", 400)
+    try:
+        return _ok(get_board_market_service().get_board_constituents(code))
+    except Exception as exc:  # noqa: BLE001
+        logger.error(f"板块成分股API错误: {exc}")
+        return _error(f"板块成分股获取失败: {exc}")
 
 
 @datasources_bp.route("/status", methods=["GET"])

--- a/app/services/ai/tools.py
+++ b/app/services/ai/tools.py
@@ -58,6 +58,37 @@ def _tushare_token_configured() -> bool:
     return token not in ('', 'your_tushare_token')
 
 
+# 数据源 source_name → (环境变量, 未配置时的提示)
+# derived 等本地计算 source 不在映射内，无需凭证。
+_SOURCE_TOKEN_REQUIREMENTS = {
+    'tushare': (
+        'TUSHARE_TOKEN',
+        '该任务需要 Tushare 数据源，但尚未配置 TUSHARE_TOKEN。'
+        '请在项目根目录 .env 中设置 TUSHARE_TOKEN 后重启服务再试',
+    ),
+    'fuyao': (
+        'FUYAO_API_KEY',
+        '该任务需要扶摇数据源，但尚未配置 FUYAO_API_KEY。'
+        '请在项目根目录 .env 中设置 FUYAO_API_KEY 后重启服务再试',
+    ),
+    'tickflow': (
+        'TICKFLOW_API_KEY',
+        '该任务需要 TickFlow 数据源，但尚未配置 TICKFLOW_API_KEY。'
+        '请在项目根目录 .env 中设置 TICKFLOW_API_KEY 后重启服务再试',
+    ),
+}
+
+_TOKEN_PLACEHOLDERS = ('', 'your_tushare_token')
+
+
+def _source_token_configured(source_name: str) -> bool:
+    requirement = _SOURCE_TOKEN_REQUIREMENTS.get(source_name)
+    if requirement is None:
+        return True
+    value = (os.getenv(requirement[0]) or '').strip()
+    return value not in _TOKEN_PLACEHOLDERS
+
+
 # ----------------------------------------------------------------------
 # 惰性单例（避免模块导入期触发重资源初始化）
 # ----------------------------------------------------------------------
@@ -284,6 +315,7 @@ def _tool_list_data_jobs(_args: Dict[str, Any]) -> Dict[str, Any]:
                 'description': definition.description,
                 'dependencies': list(definition.dependencies or []),
                 'needs_tushare_token': definition.source_name == 'tushare',
+                'source_name': definition.source_name,
                 'dangerous': bool(definition.dangerous),
                 'visible': definition.job_type in JobRegistry()._visible_job_types,
             }
@@ -362,11 +394,10 @@ def _run_single_job(job_type: str, params: Dict[str, Any]) -> Dict[str, Any]:
     if definition.dangerous:
         raise ToolError(f'任务 {job_type} 被标记为危险任务，请在数据管理页面手动执行')
 
-    if definition.source_name == 'tushare' and not _tushare_token_configured():
-        raise ToolError(
-            '该任务需要 Tushare 数据源，但尚未配置 TUSHARE_TOKEN。'
-            '请在项目根目录 .env 中设置 TUSHARE_TOKEN 后重启服务再试'
-        )
+    if definition.source_name in _SOURCE_TOKEN_REQUIREMENTS and not _source_token_configured(
+        definition.source_name
+    ):
+        raise ToolError(_SOURCE_TOKEN_REQUIREMENTS[definition.source_name][1])
 
     if job_type == 'wide_table_builder':
         raise ToolError('大宽表构建请使用 build_wide_table 工具（含 18:00 校验）')

--- a/app/services/board_market_service.py
+++ b/app/services/board_market_service.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import copy
 import threading
 import time
 from datetime import datetime, timedelta, timezone
@@ -21,6 +22,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from loguru import logger
 
+from app.services.market_snapshot_service import evict_oldest
 from app.utils.data_sources.fuyao_client import BEIJING_TZ, FuyaoClient, FuyaoError
 
 POOL_FRESH_SECONDS = 60.0
@@ -32,6 +34,10 @@ TRADING_DAYS_FRESH_SECONDS = 6 * 3600.0
 HOT_FRESH_SECONDS = 300.0
 SEARCH_FRESH_SECONDS = 60.0
 STALE_SERVE_SECONDS = 3600.0
+#: 进程内缓存容量上限（按日期/检索词等键会随使用增长，防无界）
+POOL_CACHE_MAX_ENTRIES = 64
+SEARCH_CACHE_MAX_ENTRIES = 128
+CONSTITUENTS_CACHE_MAX_ENTRIES = 128
 
 #: 天梯矩阵的档位键 → 连板数
 LADDER_BOARD_KEYS = (
@@ -83,10 +89,14 @@ class BoardMarketService:
     def _serve_stale(
         cached: Optional[Tuple[float, Dict[str, Any]]], fresh_seconds: float, exc: Exception
     ) -> Optional[Dict[str, Any]]:
-        """新鲜期过期后 1 小时内回供旧值（标 stale），超出窗口返回 None。"""
+        """新鲜期过期后 1 小时内回供旧值（标 stale），超出窗口返回 None。
+
+        回供的是深拷贝：调用方可能就地改 payload（如覆盖 cached/stale 标记），
+        不能与缓存共享嵌套结构。
+        """
         if cached and time.monotonic() - cached[0] < fresh_seconds + STALE_SERVE_SECONDS:
             logger.warning(f"[board] 扶摇拉取失败，回供过期缓存: {exc}")
-            payload = dict(cached[1])
+            payload = copy.deepcopy(cached[1])
             payload.update({"cached": True, "stale": True})
             return payload
         return None
@@ -148,7 +158,7 @@ class BoardMarketService:
             cached = cache.get(key)
         fresh = self._pool_fresh_seconds(resolved)
         if cached and time.monotonic() - cached[0] < fresh:
-            payload = dict(cached[1])
+            payload = copy.deepcopy(cached[1])
             payload["cached"] = True
             return payload
 
@@ -163,7 +173,9 @@ class BoardMarketService:
                 "items": normalize(data.get("item") or []),
             }
             with self._lock:
-                cache[key] = (time.monotonic(), payload)
+                evict_oldest(cache, POOL_CACHE_MAX_ENTRIES)
+                # 写入侧深拷贝：缓存对象与首次返回给调用方的对象隔离
+                cache[key] = (time.monotonic(), copy.deepcopy(payload))
             return payload
         except FuyaoError as exc:
             stale = self._serve_stale(cached, fresh, exc)
@@ -269,7 +281,7 @@ class BoardMarketService:
         with self._lock:
             cached = self._ladder_cache
         if cached and time.monotonic() - cached[0] < LADDER_FRESH_SECONDS:
-            return cached[1]
+            return copy.deepcopy(cached[1])
         try:
             data = self.client.limit_up_ladder()
         except FuyaoError as exc:
@@ -297,7 +309,7 @@ class BoardMarketService:
             )
         payload = {"days": days}
         with self._lock:
-            self._ladder_cache = (time.monotonic(), payload)
+            self._ladder_cache = (time.monotonic(), copy.deepcopy(payload))
         return payload
 
     # ---- 同花顺热股榜 / 飙升榜 ----
@@ -312,7 +324,7 @@ class BoardMarketService:
         with self._lock:
             cached = self._hot_cache.get(period)
         if cached and time.monotonic() - cached[0] < HOT_FRESH_SECONDS:
-            payload = dict(cached[1])
+            payload = copy.deepcopy(cached[1])
             payload["cached"] = True
             return payload
 
@@ -327,7 +339,7 @@ class BoardMarketService:
             raise
 
         with self._lock:
-            self._hot_cache[period] = (time.monotonic(), payload)
+            self._hot_cache[period] = (time.monotonic(), copy.deepcopy(payload))
         return payload
 
     @staticmethod
@@ -362,7 +374,7 @@ class BoardMarketService:
         with self._lock:
             cached = self._search_cache.get(key)
         if cached and time.monotonic() - cached[0] < SEARCH_FRESH_SECONDS:
-            return cached[1]
+            return copy.deepcopy(cached[1])
         rows = self.client.ticker_search(text, asset_type="a-share", limit=key[1])
         payload = {
             "query": text,
@@ -377,7 +389,8 @@ class BoardMarketService:
             ],
         }
         with self._lock:
-            self._search_cache[key] = (time.monotonic(), payload)
+            evict_oldest(self._search_cache, SEARCH_CACHE_MAX_ENTRIES)
+            self._search_cache[key] = (time.monotonic(), copy.deepcopy(payload))
         return payload
 
     # ---- 同花顺行业 / 概念板块 ----
@@ -394,7 +407,7 @@ class BoardMarketService:
         with self._lock:
             cached = self._boards_cache.get(tag)
         if cached and time.monotonic() - cached[0] < BOARD_SNAPSHOT_FRESH_SECONDS:
-            payload = dict(cached[1])
+            payload = copy.deepcopy(cached[1])
             payload["cached"] = True
             return payload
 
@@ -444,7 +457,7 @@ class BoardMarketService:
             "server_ts": _now_ms(),
         }
         with self._lock:
-            self._boards_cache[tag] = (time.monotonic(), payload)
+            self._boards_cache[tag] = (time.monotonic(), copy.deepcopy(payload))
         return payload
 
     def _get_catalog(self, tag: str) -> List[Dict[str, Any]]:
@@ -472,7 +485,7 @@ class BoardMarketService:
         with self._lock:
             cached = self._constituents_cache.get(code)
         if cached and time.monotonic() - cached[0] < CONSTITUENTS_FRESH_SECONDS:
-            payload = dict(cached[1])
+            payload = copy.deepcopy(cached[1])
             payload["cached"] = True
             return payload
 
@@ -500,7 +513,8 @@ class BoardMarketService:
             )
         payload = {"code": code, "total": len(items), "items": items}
         with self._lock:
-            self._constituents_cache[code] = (time.monotonic(), payload)
+            evict_oldest(self._constituents_cache, CONSTITUENTS_CACHE_MAX_ENTRIES)
+            self._constituents_cache[code] = (time.monotonic(), copy.deepcopy(payload))
         return payload
 
     @staticmethod

--- a/app/services/board_market_service.py
+++ b/app/services/board_market_service.py
@@ -29,6 +29,8 @@ BOARD_SNAPSHOT_FRESH_SECONDS = 60.0
 CATALOG_FRESH_SECONDS = 6 * 3600.0
 CONSTITUENTS_FRESH_SECONDS = 3600.0
 TRADING_DAYS_FRESH_SECONDS = 6 * 3600.0
+HOT_FRESH_SECONDS = 300.0
+SEARCH_FRESH_SECONDS = 60.0
 STALE_SERVE_SECONDS = 3600.0
 
 #: 天梯矩阵的档位键 → 连板数
@@ -61,6 +63,10 @@ class BoardMarketService:
         self._client = client
         self._lock = threading.Lock()
         self._pool_cache: Dict[Tuple[str, int, int], Tuple[float, Dict[str, Any]]] = {}
+        self._down_pool_cache: Dict[Tuple[str, int, int], Tuple[float, Dict[str, Any]]] = {}
+        self._break_pool_cache: Dict[Tuple[str, int, int], Tuple[float, Dict[str, Any]]] = {}
+        self._hot_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
+        self._search_cache: Dict[Tuple[str, int], Tuple[float, Dict[str, Any]]] = {}
         self._ladder_cache: Optional[Tuple[float, Dict[str, Any]]] = None
         self._catalog_cache: Dict[str, Tuple[float, List[Dict[str, Any]]]] = {}
         self._boards_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
@@ -120,41 +126,46 @@ class BoardMarketService:
             day -= timedelta(days=1)
         return day.strftime("%Y%m%d")
 
-    # ---- 涨停池 / 连板天梯 ----
+    # ---- 涨停 / 跌停 / 炸板池 ----
 
-    def get_limit_up_pool(self, date: Optional[str] = None, page: int = 1, size: int = 100) -> Dict[str, Any]:
-        """涨停池（date YYYYMMDD 可空=最近交易日；连板数降序）。
+    def _get_special_pool(
+        self,
+        cache: Dict[Tuple[str, int, int], Tuple[float, Dict[str, Any]]],
+        fetch,
+        normalize,
+        date: Optional[str],
+        page: int,
+        size: int,
+    ) -> Dict[str, Any]:
+        """特色数据池通用获取：日期解析 + TTL 缓存 + 过期回供。
 
-        返回 {date,total,page,size,items:[...],stale?}；扶摇异常时回供
-        1 小时内的过期缓存。
+        fetch(date_ms, page, size) 返回 {pagination, item}；normalize 把
+        服务端字段映射为前端蛇形字段。历史日数据不再变化，缓存视为永久。
         """
         resolved = self._validate_date(date) or self.latest_trade_date()
         key = (resolved, page, min(int(size), 200))
         with self._lock:
-            cached = self._pool_cache.get(key)
-        if cached and time.monotonic() - cached[0] < self._pool_fresh_seconds(resolved):
+            cached = cache.get(key)
+        fresh = self._pool_fresh_seconds(resolved)
+        if cached and time.monotonic() - cached[0] < fresh:
             payload = dict(cached[1])
             payload["cached"] = True
             return payload
 
         try:
-            data = self.client.limit_up_pool(
-                date_ms=_ymd_to_beijing_ms(resolved), page=key[1], size=key[2]
-            )
+            data = fetch(_ymd_to_beijing_ms(resolved), key[1], key[2])
             pagination = data.get("pagination") or {}
-            items = self._normalize_pool_items(data.get("item") or [])
             payload = {
                 "date": resolved,
-                "total": int(pagination.get("total") or len(items)),
+                "total": int(pagination.get("total") or len(data.get("item") or [])),
                 "page": key[1],
                 "size": key[2],
-                "items": items,
+                "items": normalize(data.get("item") or []),
             }
             with self._lock:
-                self._pool_cache[key] = (time.monotonic(), payload)
+                cache[key] = (time.monotonic(), payload)
             return payload
         except FuyaoError as exc:
-            fresh = self._pool_fresh_seconds(resolved)
             stale = self._serve_stale(cached, fresh, exc)
             if stale is not None:
                 return stale
@@ -168,27 +179,90 @@ class BoardMarketService:
 
     @staticmethod
     def _normalize_pool_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """字段重命名为前端友好蛇形（保留原始含义，见 client docstring）。"""
-        normalized = []
-        for row in items:
-            normalized.append(
-                {
-                    "ts_code": row.get("thscode"),
-                    "ticker": row.get("ticker"),
-                    "name": row.get("name"),
-                    "is_st": bool(row.get("is_st")),
-                    "is_new": bool(row.get("is_new")),
-                    "last_price": row.get("last_price"),
-                    "pct_chg": row.get("price_change_ratio_pct"),
-                    "limit_up_time": row.get("limit_up_time"),
-                    "reason": row.get("limit_up_reason"),
-                    "continue_day_text": row.get("continue_day_text"),
-                    "continue_day_cnt": row.get("continue_day_cnt"),
-                    "seal_money": row.get("seal_money"),
-                    "max_seal_money": row.get("max_seal_money"),
-                }
-            )
-        return normalized
+        """涨停池字段重命名为前端友好蛇形（原始含义见 client docstring）。"""
+        return [
+            {
+                "ts_code": row.get("thscode"),
+                "ticker": row.get("ticker"),
+                "name": row.get("name"),
+                "is_st": bool(row.get("is_st")),
+                "is_new": bool(row.get("is_new")),
+                "last_price": row.get("last_price"),
+                "pct_chg": row.get("price_change_ratio_pct"),
+                "limit_up_time": row.get("limit_up_time"),
+                "reason": row.get("limit_up_reason"),
+                "continue_day_text": row.get("continue_day_text"),
+                "continue_day_cnt": row.get("continue_day_cnt"),
+                "seal_money": row.get("seal_money"),
+                "max_seal_money": row.get("max_seal_money"),
+            }
+            for row in items
+        ]
+
+    @staticmethod
+    def _normalize_down_pool_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        return [
+            {
+                "ts_code": row.get("thscode"),
+                "ticker": row.get("ticker"),
+                "name": row.get("name"),
+                "last_price": row.get("last_price"),
+                "pct_chg": row.get("price_change_ratio_pct"),
+                "first_limit_time": row.get("first_limit_time"),
+                "last_limit_time": row.get("last_limit_time"),
+                "turnover_ratio_pct": row.get("turnover_ratio_pct"),
+            }
+            for row in items
+        ]
+
+    @staticmethod
+    def _normalize_break_pool_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        return [
+            {
+                "ts_code": row.get("thscode"),
+                "ticker": row.get("ticker"),
+                "name": row.get("name"),
+                "last_price": row.get("last_price"),
+                "pct_chg": row.get("price_change_ratio_pct"),
+                "open_times": row.get("open_times"),
+                "turnover_ratio_pct": row.get("turnover_ratio_pct"),
+                "turnover": row.get("turnover"),
+            }
+            for row in items
+        ]
+
+    def get_limit_up_pool(self, date: Optional[str] = None, page: int = 1, size: int = 100) -> Dict[str, Any]:
+        """涨停池（date YYYYMMDD 可空=最近交易日；连板数降序）。"""
+        return self._get_special_pool(
+            self._pool_cache,
+            lambda ms, p, s: self.client.limit_up_pool(date_ms=ms, page=p, size=s),
+            self._normalize_pool_items,
+            date,
+            page,
+            size,
+        )
+
+    def get_limit_down_pool(self, date: Optional[str] = None, page: int = 1, size: int = 100) -> Dict[str, Any]:
+        """跌停池（date 口径同涨停池）。"""
+        return self._get_special_pool(
+            self._down_pool_cache,
+            lambda ms, p, s: self.client.limit_down_pool(date_ms=ms, page=p, size=s),
+            self._normalize_down_pool_items,
+            date,
+            page,
+            size,
+        )
+
+    def get_limit_break_pool(self, date: Optional[str] = None, page: int = 1, size: int = 100) -> Dict[str, Any]:
+        """炸板池（曾涨停后开板；date 口径同涨停池）。"""
+        return self._get_special_pool(
+            self._break_pool_cache,
+            lambda ms, p, s: self.client.limit_break_pool(date_ms=ms, page=p, size=s),
+            self._normalize_break_pool_items,
+            date,
+            page,
+            size,
+        )
 
     def get_limit_up_ladder(self) -> Dict[str, Any]:
         """连板天梯：30 个交易日的 {date, counts:{连板数:家数}, highest}。"""
@@ -224,6 +298,86 @@ class BoardMarketService:
         payload = {"days": days}
         with self._lock:
             self._ladder_cache = (time.monotonic(), payload)
+        return payload
+
+    # ---- 同花顺热股榜 / 飙升榜 ----
+
+    def get_hot_stocks(self, period: str = "day") -> Dict[str, Any]:
+        """热股榜 + 飙升榜（period: day/hour；缓存 5 分钟）。
+
+        heat 为字符串数值，统一转 float 便于前端排序展示。
+        """
+        if period not in ("day", "hour"):
+            raise ValueError("period 取值须为 day/hour")
+        with self._lock:
+            cached = self._hot_cache.get(period)
+        if cached and time.monotonic() - cached[0] < HOT_FRESH_SECONDS:
+            payload = dict(cached[1])
+            payload["cached"] = True
+            return payload
+
+        try:
+            hot = self._normalize_hot_items(self.client.hot_stock_list(period=period))
+            skyrocket = self._normalize_hot_items(self.client.skyrocket_list(period=period))
+            payload = {"period": period, "hot": hot, "skyrocket": skyrocket}
+        except FuyaoError as exc:
+            stale = self._serve_stale(cached, HOT_FRESH_SECONDS, exc)
+            if stale is not None:
+                return stale
+            raise
+
+        with self._lock:
+            self._hot_cache[period] = (time.monotonic(), payload)
+        return payload
+
+    @staticmethod
+    def _normalize_hot_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        normalized = []
+        for row in items:
+            try:
+                heat = float(row.get("heat"))
+            except (TypeError, ValueError):
+                heat = None
+            normalized.append(
+                {
+                    "ts_code": row.get("thscode"),
+                    "ticker": row.get("ticker"),
+                    "name": row.get("name"),
+                    "rank": row.get("rank"),
+                    "heat": heat,
+                    "rank_change": row.get("rank_change"),
+                    "rank_trend": row.get("rank_trend"),
+                }
+            )
+        return normalized
+
+    # ---- 标的检索 ----
+
+    def search_tickers(self, query: str, limit: int = 10) -> Dict[str, Any]:
+        """名称/代码模糊检索（自选添加联想；透传扶摇，短缓存 60s）。"""
+        text = (query or "").strip()
+        if len(text) < 2:
+            raise ValueError("检索关键字至少 2 个字符")
+        key = (text.lower(), min(int(limit), 20))
+        with self._lock:
+            cached = self._search_cache.get(key)
+        if cached and time.monotonic() - cached[0] < SEARCH_FRESH_SECONDS:
+            return cached[1]
+        rows = self.client.ticker_search(text, asset_type="a-share", limit=key[1])
+        payload = {
+            "query": text,
+            "items": [
+                {
+                    "ts_code": row.get("thscode"),
+                    "ticker": row.get("ticker"),
+                    "name": row.get("name"),
+                    "exchange": row.get("exchange"),
+                }
+                for row in rows
+            ],
+        }
+        with self._lock:
+            self._search_cache[key] = (time.monotonic(), payload)
         return payload
 
     # ---- 同花顺行业 / 概念板块 ----

--- a/app/services/board_market_service.py
+++ b/app/services/board_market_service.py
@@ -1,0 +1,415 @@
+"""板块与连板分析服务：涨停池 / 连板天梯 / 同花顺行业·概念板块。
+
+数据全部来自扶摇特色数据域：
+- 涨停池 ``limit-up-pool``：按交易日的涨停个股（连板数/封单额/涨停时间/原因）
+- 连板天梯 ``limit-up-ladder``：近 30 个交易日的 2 板~7 板+ 矩阵
+- 同花顺指数目录+快照：行业（320 个）/概念（390 个）板块的实时涨跌排行
+- 指数成分股：板块成分清单，用全市场快照帧富化个股行情
+
+缓存策略：
+- 涨停池按（日期,页）缓存，盘中 60s、历史日永久（当日数据不再变化）
+- 天梯/板块快照分别 5 分钟 / 60 秒；目录与成分股按小时~天缓存
+- 扶摇异常时优先回供过期缓存（stale 标记），无缓存才抛错
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from loguru import logger
+
+from app.utils.data_sources.fuyao_client import BEIJING_TZ, FuyaoClient, FuyaoError
+
+POOL_FRESH_SECONDS = 60.0
+LADDER_FRESH_SECONDS = 300.0
+BOARD_SNAPSHOT_FRESH_SECONDS = 60.0
+CATALOG_FRESH_SECONDS = 6 * 3600.0
+CONSTITUENTS_FRESH_SECONDS = 3600.0
+TRADING_DAYS_FRESH_SECONDS = 6 * 3600.0
+STALE_SERVE_SECONDS = 3600.0
+
+#: 天梯矩阵的档位键 → 连板数
+LADDER_BOARD_KEYS = (
+    ("two_board", 2),
+    ("three_board", 3),
+    ("four_board", 4),
+    ("five_board", 5),
+    ("six_board", 6),
+    ("seven_over", 7),
+)
+
+VALID_TAGS = ("industry", "cn_concept")
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _ymd_to_beijing_ms(ymd: str) -> int:
+    """YYYYMMDD → 北京时间当日零点 epoch ms（扶摇 date_ms 口径）。"""
+    dt = datetime.strptime(str(ymd), "%Y%m%d").replace(tzinfo=BEIJING_TZ)
+    return int(dt.timestamp() * 1000)
+
+
+class BoardMarketService:
+    """进程内单例（get_board_market_service），线程安全。"""
+
+    def __init__(self, client: Optional[FuyaoClient] = None):
+        self._client = client
+        self._lock = threading.Lock()
+        self._pool_cache: Dict[Tuple[str, int, int], Tuple[float, Dict[str, Any]]] = {}
+        self._ladder_cache: Optional[Tuple[float, Dict[str, Any]]] = None
+        self._catalog_cache: Dict[str, Tuple[float, List[Dict[str, Any]]]] = {}
+        self._boards_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
+        self._constituents_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
+        self._trade_days_cache: Optional[Tuple[float, List[str]]] = None
+
+    @property
+    def client(self) -> FuyaoClient:
+        if self._client is None:
+            self._client = FuyaoClient()
+        return self._client
+
+    @staticmethod
+    def _serve_stale(
+        cached: Optional[Tuple[float, Dict[str, Any]]], fresh_seconds: float, exc: Exception
+    ) -> Optional[Dict[str, Any]]:
+        """新鲜期过期后 1 小时内回供旧值（标 stale），超出窗口返回 None。"""
+        if cached and time.monotonic() - cached[0] < fresh_seconds + STALE_SERVE_SECONDS:
+            logger.warning(f"[board] 扶摇拉取失败，回供过期缓存: {exc}")
+            payload = dict(cached[1])
+            payload.update({"cached": True, "stale": True})
+            return payload
+        return None
+
+    # ---- 交易日辅助 ----
+
+    def latest_trade_date(self) -> str:
+        """最近交易日 YYYYMMDD（交易日历缓存 6 小时；异常回退自然日回退）。"""
+        with self._lock:
+            cached = self._trade_days_cache
+        if cached and time.monotonic() - cached[0] < TRADING_DAYS_FRESH_SECONDS:
+            return cached[1][-1]
+        try:
+            rows = self.client.trading_days()
+            days = sorted(
+                str(row.get("date") or "") for row in rows if row.get("date")
+            )
+            days = [d for d in days if len(d) == 8 and d <= self._today()]
+            if not days:
+                raise FuyaoError("empty", "交易日历为空")
+            with self._lock:
+                self._trade_days_cache = (time.monotonic(), days)
+            return days[-1]
+        except FuyaoError as exc:
+            logger.warning(f"[board] 交易日历获取失败，回退自然日: {exc}")
+            return self._fallback_trade_date()
+
+    @staticmethod
+    def _today() -> str:
+        return datetime.now(BEIJING_TZ).strftime("%Y%m%d")
+
+    @staticmethod
+    def _fallback_trade_date() -> str:
+        """无交易日历时按自然日回退（周末向前找周五），够用且不依赖网络。"""
+        day = datetime.now(BEIJING_TZ).date()
+        while day.weekday() >= 5:  # 5=周六 6=周日
+            day -= timedelta(days=1)
+        return day.strftime("%Y%m%d")
+
+    # ---- 涨停池 / 连板天梯 ----
+
+    def get_limit_up_pool(self, date: Optional[str] = None, page: int = 1, size: int = 100) -> Dict[str, Any]:
+        """涨停池（date YYYYMMDD 可空=最近交易日；连板数降序）。
+
+        返回 {date,total,page,size,items:[...],stale?}；扶摇异常时回供
+        1 小时内的过期缓存。
+        """
+        resolved = self._validate_date(date) or self.latest_trade_date()
+        key = (resolved, page, min(int(size), 200))
+        with self._lock:
+            cached = self._pool_cache.get(key)
+        if cached and time.monotonic() - cached[0] < self._pool_fresh_seconds(resolved):
+            payload = dict(cached[1])
+            payload["cached"] = True
+            return payload
+
+        try:
+            data = self.client.limit_up_pool(
+                date_ms=_ymd_to_beijing_ms(resolved), page=key[1], size=key[2]
+            )
+            pagination = data.get("pagination") or {}
+            items = self._normalize_pool_items(data.get("item") or [])
+            payload = {
+                "date": resolved,
+                "total": int(pagination.get("total") or len(items)),
+                "page": key[1],
+                "size": key[2],
+                "items": items,
+            }
+            with self._lock:
+                self._pool_cache[key] = (time.monotonic(), payload)
+            return payload
+        except FuyaoError as exc:
+            fresh = self._pool_fresh_seconds(resolved)
+            stale = self._serve_stale(cached, fresh, exc)
+            if stale is not None:
+                return stale
+            raise
+
+    @staticmethod
+    def _pool_fresh_seconds(date: str) -> float:
+        """历史日数据不再变化，缓存视为永久新鲜；仅当日短缓存。"""
+        today = datetime.now(BEIJING_TZ).strftime("%Y%m%d")
+        return POOL_FRESH_SECONDS if date >= today else 24 * 3600.0
+
+    @staticmethod
+    def _normalize_pool_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """字段重命名为前端友好蛇形（保留原始含义，见 client docstring）。"""
+        normalized = []
+        for row in items:
+            normalized.append(
+                {
+                    "ts_code": row.get("thscode"),
+                    "ticker": row.get("ticker"),
+                    "name": row.get("name"),
+                    "is_st": bool(row.get("is_st")),
+                    "is_new": bool(row.get("is_new")),
+                    "last_price": row.get("last_price"),
+                    "pct_chg": row.get("price_change_ratio_pct"),
+                    "limit_up_time": row.get("limit_up_time"),
+                    "reason": row.get("limit_up_reason"),
+                    "continue_day_text": row.get("continue_day_text"),
+                    "continue_day_cnt": row.get("continue_day_cnt"),
+                    "seal_money": row.get("seal_money"),
+                    "max_seal_money": row.get("max_seal_money"),
+                }
+            )
+        return normalized
+
+    def get_limit_up_ladder(self) -> Dict[str, Any]:
+        """连板天梯：30 个交易日的 {date, counts:{连板数:家数}, highest}。"""
+        with self._lock:
+            cached = self._ladder_cache
+        if cached and time.monotonic() - cached[0] < LADDER_FRESH_SECONDS:
+            return cached[1]
+        try:
+            data = self.client.limit_up_ladder()
+        except FuyaoError as exc:
+            stale = self._serve_stale(cached, LADDER_FRESH_SECONDS, exc)
+            if stale is not None:
+                return stale
+            raise
+        days = []
+        for day in data.get("item") or []:
+            boards = day.get("boards") or {}
+            counts = {
+                str(num): len(boards.get(key) or []) for key, num in LADDER_BOARD_KEYS
+            }
+            highest = max(
+                (int(num) for key, num in LADDER_BOARD_KEYS if boards.get(key)),
+                default=0,
+            )
+            days.append(
+                {
+                    "date": day.get("date"),
+                    "counts": counts,
+                    "highest": highest,
+                    "total": sum(counts.values()),
+                }
+            )
+        payload = {"days": days}
+        with self._lock:
+            self._ladder_cache = (time.monotonic(), payload)
+        return payload
+
+    # ---- 同花顺行业 / 概念板块 ----
+
+    def get_boards(self, tag: str) -> Dict[str, Any]:
+        """板块涨跌排行（tag: industry/cn_concept；按涨跌幅降序）。
+
+        目录缓存 6 小时，行情快照缓存 60 秒；快照失败的板块留在
+        unavailable 列表里而不是悄悄消失。
+        """
+        if tag not in VALID_TAGS:
+            raise ValueError(f"tag 取值须为 {'/'.join(VALID_TAGS)}")
+        catalog = self._get_catalog(tag)
+        with self._lock:
+            cached = self._boards_cache.get(tag)
+        if cached and time.monotonic() - cached[0] < BOARD_SNAPSHOT_FRESH_SECONDS:
+            payload = dict(cached[1])
+            payload["cached"] = True
+            return payload
+
+        codes = [str(row.get("thscode")) for row in catalog if row.get("thscode")]
+        quote_by_code: Dict[str, Dict[str, Any]] = {}
+        last_error: Optional[FuyaoError] = None
+        for start in range(0, len(codes), 100):
+            batch = codes[start:start + 100]
+            try:
+                rows, _ = self.client.index_snapshot(batch)
+            except FuyaoError as exc:
+                logger.warning(f"[board] 板块快照批次失败（{len(batch)} 只）: {exc}")
+                last_error = exc
+                continue
+            for row in rows:
+                quote_by_code[str(row.get("thscode"))] = row
+
+        if not quote_by_code:
+            stale = self._serve_stale(cached, BOARD_SNAPSHOT_FRESH_SECONDS, last_error)
+            if stale is not None:
+                return stale
+            raise last_error or FuyaoError("empty", "板块快照为空")
+
+        items: List[Dict[str, Any]] = []
+        unavailable: List[str] = []
+        for row in catalog:
+            code = str(row.get("thscode"))
+            quote = quote_by_code.get(code)
+            if quote is None:
+                unavailable.append(code)
+                continue
+            items.append(
+                {
+                    "thscode": code,
+                    "name": row.get("name"),
+                    "last_price": quote.get("last_price"),
+                    "pct_chg": quote.get("price_change_ratio_pct"),
+                    "turnover_yuan": quote.get("turnover"),
+                    "volume": quote.get("volume"),
+                }
+            )
+        items.sort(key=lambda x: (x["pct_chg"] is None, -(x["pct_chg"] or 0)))
+        payload = {
+            "tag": tag,
+            "items": items,
+            "unavailable": unavailable,
+            "server_ts": _now_ms(),
+        }
+        with self._lock:
+            self._boards_cache[tag] = (time.monotonic(), payload)
+        return payload
+
+    def _get_catalog(self, tag: str) -> List[Dict[str, Any]]:
+        with self._lock:
+            cached = self._catalog_cache.get(tag)
+        if cached and time.monotonic() - cached[0] < CATALOG_FRESH_SECONDS:
+            return cached[1]
+        catalog = self.client.ths_index_catalog(tag=tag)
+        if not catalog:
+            raise FuyaoError("empty", f"同花顺指数目录为空（tag={tag}）")
+        with self._lock:
+            self._catalog_cache[tag] = (time.monotonic(), catalog)
+        return catalog
+
+    # ---- 板块成分股 ----
+
+    def get_board_constituents(self, code: str) -> Dict[str, Any]:
+        """板块成分股 + 实时行情富化（行情来自全市场快照帧，无额外请求）。
+
+        快照帧取不到的成分股（停牌/新股/降级日无该股）行情字段为 null。
+        """
+        code = (code or "").strip().upper()
+        if not code:
+            raise ValueError("缺少板块代码")
+        with self._lock:
+            cached = self._constituents_cache.get(code)
+        if cached and time.monotonic() - cached[0] < CONSTITUENTS_FRESH_SECONDS:
+            payload = dict(cached[1])
+            payload["cached"] = True
+            return payload
+
+        try:
+            rows = self.client.ths_index_constituents(code)
+        except FuyaoError as exc:
+            stale = self._serve_stale(cached, CONSTITUENTS_FRESH_SECONDS, exc)
+            if stale is not None:
+                return stale
+            raise
+
+        quote_by_code = self._quote_frame_index()
+        items = []
+        for row in rows:
+            ts_code = str(row.get("thscode") or "")
+            quote = quote_by_code.get(ts_code) or {}
+            items.append(
+                {
+                    "ts_code": ts_code,
+                    "name": row.get("name") or quote.get("name"),
+                    "last_price": quote.get("last_price"),
+                    "pct_chg": quote.get("pct_chg"),
+                    "amount_yuan": quote.get("amount_yuan"),
+                }
+            )
+        payload = {"code": code, "total": len(items), "items": items}
+        with self._lock:
+            self._constituents_cache[code] = (time.monotonic(), payload)
+        return payload
+
+    @staticmethod
+    def _quote_frame_index() -> Dict[str, Dict[str, Any]]:
+        """全市场快照帧 → {ts_code: {last_price,pct_chg,amount_yuan,name}}。
+
+        兼容扶摇快照（last_price/turnover 元）与降级本地日线
+        （close/pre_close/amount 千元）两种 schema。
+        """
+        from app.services.market_snapshot_service import get_market_snapshot_service
+
+        frame = get_market_snapshot_service().get_quote_frame()
+        if frame is None or frame.empty:
+            return {}
+        index: Dict[str, Dict[str, Any]] = {}
+        if "last_price" in frame.columns:
+            records = frame.to_dict("records")
+            for record in records:
+                index[str(record.get("ts_code"))] = {
+                    "name": record.get("name"),
+                    "last_price": record.get("last_price"),
+                    "pct_chg": record.get("pct_chg"),
+                    "amount_yuan": record.get("turnover"),
+                }
+            return index
+        # 本地日线 schema
+        for record in frame.to_dict("records"):
+            pre = record.get("pre_close")
+            close = record.get("close")
+            pct = (
+                round((float(close) - float(pre)) / float(pre) * 100, 4)
+                if pre and close and float(pre) != 0
+                else None
+            )
+            index[str(record.get("ts_code"))] = {
+                "name": record.get("name"),
+                "last_price": close,
+                "pct_chg": pct,
+                "amount_yuan": (record.get("amount") or 0) * 1000.0,
+            }
+        return index
+
+    # ---- 参数校验 ----
+
+    @staticmethod
+    def _validate_date(date: Optional[str]) -> Optional[str]:
+        if date is None or str(date).strip() == "":
+            return None
+        text = str(date).strip()
+        try:
+            datetime.strptime(text, "%Y%m%d")
+        except ValueError as exc:
+            raise ValueError(f"date 格式应为 YYYYMMDD，收到: {date}") from exc
+        return text
+
+
+_service: Optional[BoardMarketService] = None
+_service_lock = threading.Lock()
+
+
+def get_board_market_service() -> BoardMarketService:
+    global _service
+    with _service_lock:
+        if _service is None:
+            _service = BoardMarketService()
+        return _service

--- a/app/services/data_jobs/registry.py
+++ b/app/services/data_jobs/registry.py
@@ -11,9 +11,11 @@ class JobRegistry:
         # 仅向页面暴露的任务（按用户确认保留）
         self._visible_job_types: Set[str] = {
             "stock_basic",            # 1
+            "stock_basic_fuyao",      # 1b（扶摇源股票清单刷新）
             "trade_calendar",         # 2
             "stock_company",          # 3
             "daily_history_by_date",  # 5
+            "daily_history_fuyao",    # 5b（扶摇源日线）
             "daily_basic",            # 6
             "moneyflow",              # 15
             "stk_factor",             # 17
@@ -36,6 +38,17 @@ class JobRegistry:
                 recommended_order=2,
                 source_name="tushare",
                 source_mode="full",
+            ),
+            "stock_basic_fuyao": JobDefinition(
+                "stock_basic_fuyao",
+                "基础资料",
+                "app/utils/stock_basic_fuyao.py",
+                display_name="股票清单（扶摇源）",
+                description="从扶摇快照刷新股票名称并追加新上市代码；行业/退市股等元数据仍由 tushare 版维护。",
+                recommended_order=2,
+                source_name="fuyao",
+                source_mode="incremental",
+                supports_incremental=True,
             ),
             "trade_calendar": JobDefinition(
                 "trade_calendar",
@@ -93,6 +106,18 @@ class JobRegistry:
                 source_mode="incremental",
                 supports_incremental=True,
             ),
+            "daily_history_fuyao": JobDefinition(
+                "daily_history_fuyao",
+                "日频行情与基本面",
+                "app/utils/daily_history_fuyao.py",
+                display_name="日线行情（扶摇源）",
+                description="从扶摇数据源下载全市场日线行情（dump 一次覆盖全市场），与 tushare 版写入同一张表。",
+                dependencies=["trade_calendar"],
+                recommended_order=5,
+                source_name="fuyao",
+                source_mode="incremental",
+                supports_incremental=True,
+            ),
             "income_statement": JobDefinition(
                 "income_statement", "财务三表", "app/utils/income_statement.py", display_name="利润表", description="下载上市公司利润表。", dependencies=["stock_basic"], source_name="tushare", source_mode="incremental", supports_incremental=True
             ),
@@ -101,6 +126,11 @@ class JobRegistry:
             ),
             "cash_flow": JobDefinition(
                 "cash_flow", "财务三表", "app/utils/cash_flow.py", display_name="现金流量表", description="下载上市公司现金流量表。", dependencies=["stock_basic"], source_name="tushare", source_mode="incremental", supports_incremental=True
+            ),
+            "financial_fuyao": JobDefinition(
+                "financial_fuyao", "财务三表", "app/utils/financial_fuyao.py", display_name="财务三表（扶摇源）",
+                description="从扶摇数据源下载利润表/资产负债表/现金流量表（单标的接口逐只拉取，免费 key 可用），与 tushare VIP 版写入同一组表。",
+                dependencies=["stock_basic"], source_name="fuyao", source_mode="incremental", supports_incremental=True
             ),
             "moneyflow": JobDefinition("moneyflow", "资金流与扩展因子", "app/utils/moneyflow.py", display_name="资金流向", description="下载主力、大单、中单和小单资金流数据。", recommended_order=7, source_name="tushare", source_mode="incremental", supports_incremental=True),
             "moneyflow_ths": JobDefinition("moneyflow_ths", "资金流与扩展因子", "app/utils/moneyflow_ths.py", display_name="同花顺资金流", description="下载同花顺口径资金流数据。", source_name="ths", source_mode="incremental", supports_incremental=True),

--- a/app/services/market_dashboard.py
+++ b/app/services/market_dashboard.py
@@ -1,0 +1,119 @@
+"""市场看板聚合：从统一列的行情帧计算市场宽度、涨跌分布与榜单。
+
+输入帧契约（由 market_snapshot_service._build_dashboard 统一）：
+    ts_code / name / price / pct_chg / prev_close / amount_yuan
+
+涨跌停为近似口径：按代码板块推断涨跌停幅度（北交所 30%、创/科 20%、
+其余 10%），不含 ST 5% 特例，仅用于市场宽度展示。
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pandas as pd
+
+DASHBOARD_TOP_N = 10
+
+DISTRIBUTION_BUCKETS = (
+    ("< -5%", None, -5.0),
+    ("-5% ~ -2%", -5.0, -2.0),
+    ("-2% ~ 0", -2.0, 0.0),
+    ("0 ~ 2%", 0.0, 2.0),
+    ("2% ~ 5%", 2.0, 5.0),
+    (">= 5%", 5.0, None),
+)
+
+
+def limit_ratio_for(ts_code: str) -> float:
+    """按代码板块推断涨跌停幅度（近似口径，见模块 docstring）。"""
+    code = str(ts_code).split(".")[0]
+    if str(ts_code).endswith(".BJ"):
+        return 0.30
+    if code.startswith(("300", "688", "689")):
+        return 0.20
+    return 0.10
+
+
+def _board_row(row: "pd.Series") -> Dict[str, Any]:
+    return {
+        "ts_code": row["ts_code"],
+        "name": row.get("name"),
+        "price": None if pd.isna(row["price"]) else round(float(row["price"]), 3),
+        "pct_chg": None if pd.isna(row["pct_chg"]) else round(float(row["pct_chg"]), 3),
+        "amount_yuan": None if pd.isna(row["amount_yuan"]) else float(row["amount_yuan"]),
+    }
+
+
+def build_dashboard_payload(frame: pd.DataFrame) -> Dict[str, Any]:
+    """聚合市场看板数据（不含 source/degraded 等调用方附加字段）。"""
+    empty_boards = {"top_gainers": [], "top_losers": [], "top_amount": []}
+    if frame is None or frame.empty:
+        return {
+            "breadth": {}, "distribution": [], "total_amount_yuan": 0.0,
+            **empty_boards,
+        }
+
+    pct = pd.to_numeric(frame["pct_chg"], errors="coerce")
+    valid = pct.dropna()
+
+    up = int((valid > 0).sum())
+    down = int((valid < 0).sum())
+    flat = int((valid == 0).sum())
+
+    # 涨跌停近似统计：price/prev_close 达到板块涨跌停幅度的 99.5% 视为触板
+    limit_up = 0
+    limit_down = 0
+    ratio_frame = frame
+    if {"price", "prev_close"}.issubset(ratio_frame.columns):
+        prev = pd.to_numeric(ratio_frame["prev_close"], errors="coerce")
+        price = pd.to_numeric(ratio_frame["price"], errors="coerce")
+        ratios = ratio_frame["ts_code"].map(limit_ratio_for).astype(float)
+        with_rel = prev > 0
+        change_ratio = (price / prev - 1.0).where(with_rel)
+        limit_up = int((change_ratio >= ratios * 0.995).sum())
+        limit_down = int((change_ratio <= -ratios * 0.995).sum())
+
+    distribution = []
+    for label, low, high in DISTRIBUTION_BUCKETS:
+        if low is None:
+            count = int((valid < high).sum())
+        elif high is None:
+            count = int((valid >= low).sum())
+        else:
+            count = int(((valid >= low) & (valid < high)).sum())
+        distribution.append({"bucket": label, "count": count})
+
+    ranked = frame.assign(_pct=pct)
+    top_gainers = [
+        _board_row(row)
+        for row in ranked.nlargest(DASHBOARD_TOP_N, "_pct").to_dict("records")
+        if row["_pct"] == row["_pct"]
+    ]
+    top_losers = [
+        _board_row(row)
+        for row in ranked.nsmallest(DASHBOARD_TOP_N, "_pct").to_dict("records")
+        if row["_pct"] == row["_pct"]
+    ]
+    amount = pd.to_numeric(frame["amount_yuan"], errors="coerce")
+    top_amount = [
+        _board_row(row)
+        for row in frame.assign(_amt=amount).nlargest(DASHBOARD_TOP_N, "_amt").to_dict("records")
+        if row["_amt"] == row["_amt"]
+    ]
+
+    return {
+        "breadth": {
+            "up": up,
+            "down": down,
+            "flat": flat,
+            "limit_up": limit_up,
+            "limit_down": limit_down,
+            "total": int(valid.shape[0]),
+        },
+        "distribution": distribution,
+        "total_amount_yuan": float(amount.dropna().sum()),
+        "top_gainers": top_gainers,
+        "top_losers": top_losers,
+        "top_amount": top_amount,
+    }

--- a/app/services/market_snapshot_service.py
+++ b/app/services/market_snapshot_service.py
@@ -1,0 +1,316 @@
+"""行情快照服务：扶摇实时数据的缓存聚合层。
+
+职责：
+- 对快照/看板/龙虎榜/风向标做 TTL 或按日缓存，避免多页面轮询打爆扶摇限频
+- 看板聚合：涨跌家数、涨跌停近似统计、涨跌分布、榜单（涨幅/跌幅/成交额）
+- 降级：扶摇异常时回退本地 Parquet 最近交易日的日线数据计算看板，
+  并标记 degraded=True（前端据此展示降级提示，而不是白屏）
+
+口径说明：
+- 涨跌停家数为近似统计：按代码板块推断涨跌停幅度（北交所 30%、创业板/
+  科创板 20%、其余 10%），不含 ST 的 5% 特例，也无法感知除权除息，
+  仅用于市场宽度展示，不作为交易依据
+- 快照无股票名称字段，name 由本地 stock_basic 关联补齐
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import pandas as pd
+from loguru import logger
+
+from app.utils.data_sources.fuyao_client import FuyaoClient, FuyaoError
+from app.utils.data_sources.fuyao_normalize import snapshot_rows_to_quote_frame
+
+DASHBOARD_CACHE_SECONDS = 30.0
+QUOTES_CACHE_SECONDS = 5.0
+STALE_SERVE_SECONDS = 600.0  # 扶摇异常时，最近一次成功数据在 10 分钟内继续供应
+SOURCE_STATUS_CACHE_SECONDS = 300.0
+
+#: 看板默认指数（上证指数/深证成指/创业板指/沪深300）
+DEFAULT_INDEX_CODES = ("000001.SH", "399001.SZ", "399006.SZ", "000300.SH")
+
+
+def _limit_ratio_for(ts_code: str) -> float:
+    """按代码板块推断涨跌停幅度（近似口径，见模块 docstring）。"""
+    code = ts_code.split(".")[0]
+    if ts_code.endswith(".BJ"):
+        return 0.30
+    if code.startswith(("300", "688", "689")):
+        return 0.20
+    return 0.10
+
+
+class MarketSnapshotService:
+    """进程内单例（get_market_snapshot_service），线程安全。"""
+
+    def __init__(self, client: Optional[FuyaoClient] = None):
+        self._client = client
+        self._lock = threading.Lock()
+        self._dashboard_cache: Optional[Tuple[float, Dict[str, Any]]] = None
+        self._quotes_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
+        self._dragon_cache: Dict[Tuple[str, Optional[str]], Tuple[float, Dict[str, Any]]] = {}
+        self._auction_cache: Dict[Optional[str], Tuple[float, Dict[str, Any]]] = {}
+        self._status_cache: Optional[Tuple[float, Dict[str, Any]]] = None
+
+    # ---- 基础 ----
+
+    @property
+    def client(self) -> FuyaoClient:
+        if self._client is None:
+            self._client = FuyaoClient()
+        return self._client
+
+    @staticmethod
+    def _now_ms() -> int:
+        return int(time.time() * 1000)
+
+    @staticmethod
+    def _merge_stock_names(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """快照无名称字段，用本地 stock_basic 关联补齐（失败静默跳过）。"""
+        try:
+            from app.utils.parquet_job_helpers import get_stock_codes  # noqa: F401
+            from app.services.data_reader import ParquetDataReader
+
+            basic = ParquetDataReader().get_stock_basic()
+            if basic.empty or "ts_code" not in basic.columns:
+                return rows
+            name_map = dict(zip(basic["ts_code"].astype(str), basic.get("name")))
+            for row in rows:
+                if row.get("name") is None:
+                    row["name"] = name_map.get(str(row.get("ts_code")))
+            return rows
+        except Exception as exc:  # noqa: BLE001 - 名称补齐失败不影响行情主数据
+            logger.debug(f"[market] 名称补齐跳过: {exc}")
+            return rows
+
+    # ---- 实时快照 ----
+
+    def get_quotes(self, ts_codes: List[str]) -> Dict[str, Dict[str, Any]]:
+        """按代码取实时快照（≤100 只/请求，自动分批；单只缓存 5s）。
+
+        返回 {ts_code: {ts_code,name,last_price,pct_chg,...}}；取不到的代码
+        不出现在结果里。扶摇异常时回退缓存中的旧值（10 分钟内）。
+        """
+        wanted = list(dict.fromkeys(ts_codes or []))[:200]
+        result: Dict[str, Dict[str, Any]] = {}
+        missing: List[str] = []
+        now = time.monotonic()
+        with self._lock:
+            for code in wanted:
+                cached = self._quotes_cache.get(code)
+                if cached and now - cached[0] < QUOTES_CACHE_SECONDS:
+                    result[code] = cached[1]
+                else:
+                    missing.append(code)
+
+        if missing:
+            fresh = self._fetch_quote_rows(missing)
+            with self._lock:
+                for row in fresh:
+                    code = str(row.get("ts_code"))
+                    self._quotes_cache[code] = (time.monotonic(), row)
+                    result[code] = row
+
+        return {code: result[code] for code in wanted if code in result}
+
+    def _fetch_quote_rows(self, ts_codes: List[str]) -> List[Dict[str, Any]]:
+        rows: List[Dict[str, Any]] = []
+        try:
+            for start in range(0, len(ts_codes), 100):
+                batch = ts_codes[start:start + 100]
+                data = self.client.snapshot_page(thscodes=batch)
+                rows.extend(data.get("item") or [])
+            frame = snapshot_rows_to_quote_frame(rows)
+        except FuyaoError as exc:
+            logger.warning(f"[market] 快照批量拉取失败，回退缓存: {exc}")
+            return self._stale_quotes(ts_codes)
+        return self._merge_stock_names(frame.to_dict("records"))
+
+    def _stale_quotes(self, ts_codes: List[str]) -> List[Dict[str, Any]]:
+        now = time.monotonic()
+        stale: List[Dict[str, Any]] = []
+        with self._lock:
+            for code in ts_codes:
+                cached = self._quotes_cache.get(code)
+                if cached and now - cached[0] < STALE_SERVE_SECONDS:
+                    stale.append(cached[1])
+        return stale
+
+    # ---- 看板 ----
+
+    def get_dashboard(self) -> Dict[str, Any]:
+        """市场看板聚合（缓存 30s；扶摇异常降级本地 Parquet 最近交易日）。"""
+        with self._lock:
+            cached = self._dashboard_cache
+        if cached and time.monotonic() - cached[0] < DASHBOARD_CACHE_SECONDS:
+            return cached[1]
+
+        try:
+            rows, server_ts = self.client.snapshot_all()
+            if not rows:
+                raise FuyaoError("empty", "快照为空")
+            frame = snapshot_rows_to_quote_frame(rows)
+            frame = self._merge_stock_names(frame.to_dict("records"))
+            frame = pd.DataFrame(frame)
+            payload = self._build_dashboard(frame, source="fuyao", as_of=None)
+            payload["server_ts"] = server_ts
+        except FuyaoError as exc:
+            logger.warning(f"[market] 看板实时数据失败，降级本地 Parquet: {exc}")
+            payload = self._dashboard_from_local()
+            payload["degraded_reason"] = str(exc)
+
+        with self._lock:
+            self._dashboard_cache = (time.monotonic(), payload)
+        return payload
+
+    def _dashboard_from_local(self) -> Dict[str, Any]:
+        """降级：用本地日线最近分区构建看板（标记 degraded + as_of）。"""
+        from app.utils.parquet_job_helpers import latest_partition_date
+
+        data_dir = None
+        latest = latest_partition_date("daily_history/daily", data_dir=data_dir)
+        if not latest:
+            return {
+                "degraded": True, "source": "none", "as_of": None,
+                "indices": [], "breadth": {}, "distribution": [],
+                "top_gainers": [], "top_losers": [], "top_amount": [],
+                "updated_at": self._now_ms(),
+            }
+        from app.services.data_reader import ParquetDataReader
+
+        df = ParquetDataReader().get_daily(start_date=latest, end_date=latest)
+        payload = self._build_dashboard(df, source="local_parquet", as_of=latest)
+        payload["degraded"] = True
+        return payload
+
+    @staticmethod
+    def _build_dashboard(frame: "pd.DataFrame", source: str, as_of: Optional[str]) -> Dict[str, Any]:
+        """把两套列名（扶摇快照 / 本地日线）统一成看板聚合的输入契约。"""
+        import pandas as pd
+
+        from app.services.market_dashboard import build_dashboard_payload
+
+        unified = pd.DataFrame({"ts_code": frame["ts_code"].astype(str)})
+        unified["name"] = frame["name"] if "name" in frame.columns else None
+        unified["price"] = frame["last_price"] if "last_price" in frame.columns else frame["close"]
+        unified["pct_chg"] = pd.to_numeric(frame["pct_chg"], errors="coerce")
+        unified["prev_close"] = (
+            frame["prev_close"] if "prev_close" in frame.columns else frame["pre_close"]
+        )
+        if "turnover" in frame.columns:  # 扶摇：元
+            unified["amount_yuan"] = pd.to_numeric(frame["turnover"], errors="coerce")
+        else:  # 本地日线：千元 → 元
+            unified["amount_yuan"] = pd.to_numeric(frame["amount"], errors="coerce") * 1000.0
+
+        payload = build_dashboard_payload(unified)
+        payload.update({"degraded": False, "source": source, "as_of": as_of})
+        return payload
+
+    # ---- 指数 ----
+
+    def get_indices(self, symbols: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+        """指数实时快照（默认看板四指数；北交所指数不支持，自动跳过）。"""
+        wanted = [s for s in (symbols or list(DEFAULT_INDEX_CODES)) if not s.upper().endswith(".BJ")]
+        try:
+            rows, _ = self.client.index_snapshot(wanted)
+        except FuyaoError as exc:
+            logger.warning(f"[market] 指数快照失败: {exc}")
+            return []
+        return [
+            {
+                "ts_code": row.get("thscode"),
+                "last_price": row.get("last_price"),
+                "pct_chg": row.get("price_change_ratio_pct"),
+            }
+            for row in rows
+        ]
+
+    # ---- 龙虎榜 / 竞价风向标（按日缓存，当日数据不变）----
+
+    def get_dragon_tiger(self, board_type: str = "all", date: Optional[str] = None) -> Dict[str, Any]:
+        key = (board_type, date)
+        with self._lock:
+            cached = self._dragon_cache.get(key)
+        if cached:
+            payload = dict(cached[1])
+            payload["cached"] = True
+            return payload
+        payload = self.client.dragon_tiger_list(board_type=board_type, date=date)
+        with self._lock:
+            self._dragon_cache[key] = (time.monotonic(), payload)
+        return payload
+
+    def get_auction_benchmark(self, date: Optional[str] = None) -> Dict[str, Any]:
+        with self._lock:
+            cached = self._auction_cache.get(date)
+        if cached:
+            payload = dict(cached[1])
+            payload["cached"] = True
+            return payload
+        payload = self.client.short_term_benchmark(date=date)
+        with self._lock:
+            self._auction_cache[date] = (time.monotonic(), payload)
+        return payload
+
+    # ---- 数据源状态 ----
+
+    def get_source_status(self, force: bool = False) -> Dict[str, Any]:
+        """三数据源健康状态（缓存 5 分钟）。
+
+        tushare 只做 token 配置检查（不 burn 积分）；fuyao/tickflow 发最小
+        探测请求。
+        """
+        with self._lock:
+            cached = self._status_cache
+        if cached and not force and time.monotonic() - cached[0] < SOURCE_STATUS_CACHE_SECONDS:
+            return cached[1]
+
+        status: Dict[str, Any] = {"checked_at": self._now_ms()}
+
+        tushare_token = (_env("TUSHARE_TOKEN") or "").strip()
+        status["tushare"] = {"configured": tushare_token not in ("", "your_tushare_token")}
+
+        fuyao_key = (_env("FUYAO_API_KEY") or "").strip()
+        fuyao_status: Dict[str, Any] = {"configured": bool(fuyao_key)}
+        if fuyao_key:
+            try:
+                self.client.snapshot_page(limit=1)
+                fuyao_status.update({"ok": True, "error": None})
+            except FuyaoError as exc:
+                fuyao_status.update({"ok": False, "error": str(exc)})
+        status["fuyao"] = fuyao_status
+
+        from app.utils.data_sources.tickflow_client import TickflowClient
+
+        tickflow_key = (_env("TICKFLOW_API_KEY") or "").strip()
+        tier = TickflowClient(api_key=tickflow_key).detect_tier() if tickflow_key else "none"
+        status["tickflow"] = {"configured": bool(tickflow_key), "tier": tier}
+
+        with self._lock:
+            self._status_cache = (time.monotonic(), status)
+        return status
+
+
+def _env(key: str) -> Optional[str]:
+    import os
+
+    from dotenv import load_dotenv
+
+    load_dotenv()
+    return os.getenv(key)
+
+
+_service: Optional[MarketSnapshotService] = None
+_service_lock = threading.Lock()
+
+
+def get_market_snapshot_service() -> MarketSnapshotService:
+    global _service
+    with _service_lock:
+        if _service is None:
+            _service = MarketSnapshotService()
+        return _service

--- a/app/services/market_snapshot_service.py
+++ b/app/services/market_snapshot_service.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import copy
 import threading
 import time
 from typing import Any, Dict, List, Optional, Tuple
@@ -29,6 +30,20 @@ DASHBOARD_CACHE_SECONDS = 30.0
 QUOTES_CACHE_SECONDS = 5.0
 STALE_SERVE_SECONDS = 600.0  # 扶摇异常时，最近一次成功数据在 10 分钟内继续供应
 SOURCE_STATUS_CACHE_SECONDS = 300.0
+INDICES_FRESH_SECONDS = 10.0
+#: 龙虎榜/竞价 date=None（"最近发布日"）的短缓存——发布时点未知，不能按日缓存
+LATEST_DAY_FRESH_SECONDS = 300.0
+#: 指定历史日的榜单是定稿数据，长缓存即可
+DAY_FINAL_TTL_SECONDS = 24 * 3600.0
+#: 按日缓存容量上限（防多日期轮询导致无界增长）
+DAY_CACHE_MAX_ENTRIES = 64
+
+
+def evict_oldest(cache: Dict[Any, Tuple[float, Any]], max_entries: int) -> None:
+    """按写入时间淘汰最旧条目，调用方须已持有锁。"""
+    while len(cache) >= max_entries:
+        oldest = min(cache.items(), key=lambda kv: kv[1][0])[0]
+        cache.pop(oldest)
 
 #: 看板默认指数（上证指数/深证成指/创业板指/沪深300）
 DEFAULT_INDEX_CODES = ("000001.SH", "399001.SZ", "399006.SZ", "000300.SH")
@@ -56,6 +71,7 @@ class MarketSnapshotService:
         self._auction_cache: Dict[Optional[str], Tuple[float, Dict[str, Any]]] = {}
         self._status_cache: Optional[Tuple[float, Dict[str, Any]]] = None
         self._frame_cache: Optional[Tuple[float, "pd.DataFrame"]] = None
+        self._indices_cache: Dict[Tuple[str, ...], Tuple[float, List[Dict[str, Any]]]] = {}
 
     # ---- 基础 ----
 
@@ -224,14 +240,25 @@ class MarketSnapshotService:
     # ---- 指数 ----
 
     def get_indices(self, symbols: Optional[List[str]] = None) -> List[Dict[str, Any]]:
-        """指数实时快照（默认看板四指数；北交所指数不支持，自动跳过）。"""
+        """指数实时快照（默认看板四指数；北交所指数不支持，自动跳过）。
+
+        缓存 10 秒；扶摇异常时回供 10 分钟内的旧值，再退返回 []。
+        """
         wanted = [s for s in (symbols or list(DEFAULT_INDEX_CODES)) if not s.upper().endswith(".BJ")]
+        key = tuple(wanted)
+        with self._lock:
+            cached = self._indices_cache.get(key)
+        if cached and time.monotonic() - cached[0] < INDICES_FRESH_SECONDS:
+            return copy.deepcopy(cached[1])
         try:
             rows, _ = self.client.index_snapshot(wanted)
         except FuyaoError as exc:
+            if cached and time.monotonic() - cached[0] < STALE_SERVE_SECONDS:
+                logger.warning(f"[market] 指数快照失败，回供过期缓存: {exc}")
+                return copy.deepcopy(cached[1])
             logger.warning(f"[market] 指数快照失败: {exc}")
             return []
-        return [
+        result = [
             {
                 "ts_code": row.get("thscode"),
                 "last_price": row.get("last_price"),
@@ -239,33 +266,64 @@ class MarketSnapshotService:
             }
             for row in rows
         ]
+        with self._lock:
+            evict_oldest(self._indices_cache, DAY_CACHE_MAX_ENTRIES)
+            self._indices_cache[key] = (time.monotonic(), result)
+        return result
 
-    # ---- 龙虎榜 / 竞价风向标（按日缓存，当日数据不变）----
+    # ---- 龙虎榜 / 竞价风向标 ----
+    # date=None 表示"最近发布日"，发布时点未知（龙虎榜收盘后才出），只做短缓存；
+    # 指定历史日的榜单是定稿数据，可长缓存；两种键都设容量上限防无界增长。
+
+    @staticmethod
+    def _day_data_fresh(date: Optional[str]) -> float:
+        return LATEST_DAY_FRESH_SECONDS if date is None else DAY_FINAL_TTL_SECONDS
+
+    def _fetch_day_payload(
+        self,
+        cache: Dict[Any, Tuple[float, Dict[str, Any]]],
+        key: Any,
+        date: Optional[str],
+        fetch,
+    ) -> Dict[str, Any]:
+        """按日数据通用获取：TTL 缓存 + 过期回供 + 容量上限。"""
+        fresh = self._day_data_fresh(date)
+        with self._lock:
+            cached = cache.get(key)
+        if cached and time.monotonic() - cached[0] < fresh:
+            payload = copy.deepcopy(cached[1])
+            payload["cached"] = True
+            return payload
+        try:
+            payload = fetch()
+        except FuyaoError as exc:
+            if cached and time.monotonic() - cached[0] < fresh + STALE_SERVE_SECONDS:
+                logger.warning(f"[market] 按日数据拉取失败，回供过期缓存: {exc}")
+                payload = copy.deepcopy(cached[1])
+                payload.update({"cached": True, "stale": True})
+                return payload
+            raise
+        with self._lock:
+            evict_oldest(cache, DAY_CACHE_MAX_ENTRIES)
+            # 写入侧也深拷贝：缓存中的对象与首次返回给调用方的对象必须隔离
+            cache[key] = (time.monotonic(), copy.deepcopy(payload))
+        return payload
 
     def get_dragon_tiger(self, board_type: str = "all", date: Optional[str] = None) -> Dict[str, Any]:
-        key = (board_type, date)
-        with self._lock:
-            cached = self._dragon_cache.get(key)
-        if cached:
-            payload = dict(cached[1])
-            payload["cached"] = True
-            return payload
-        payload = self.client.dragon_tiger_list(board_type=board_type, date=date)
-        with self._lock:
-            self._dragon_cache[key] = (time.monotonic(), payload)
-        return payload
+        return self._fetch_day_payload(
+            self._dragon_cache,
+            (board_type, date),
+            date,
+            lambda: self.client.dragon_tiger_list(board_type=board_type, date=date),
+        )
 
     def get_auction_benchmark(self, date: Optional[str] = None) -> Dict[str, Any]:
-        with self._lock:
-            cached = self._auction_cache.get(date)
-        if cached:
-            payload = dict(cached[1])
-            payload["cached"] = True
-            return payload
-        payload = self.client.short_term_benchmark(date=date)
-        with self._lock:
-            self._auction_cache[date] = (time.monotonic(), payload)
-        return payload
+        return self._fetch_day_payload(
+            self._auction_cache,
+            date,
+            date,
+            lambda: self.client.short_term_benchmark(date=date),
+        )
 
     # ---- 数据源状态 ----
 

--- a/app/services/market_snapshot_service.py
+++ b/app/services/market_snapshot_service.py
@@ -55,6 +55,7 @@ class MarketSnapshotService:
         self._dragon_cache: Dict[Tuple[str, Optional[str]], Tuple[float, Dict[str, Any]]] = {}
         self._auction_cache: Dict[Optional[str], Tuple[float, Dict[str, Any]]] = {}
         self._status_cache: Optional[Tuple[float, Dict[str, Any]]] = None
+        self._frame_cache: Optional[Tuple[float, "pd.DataFrame"]] = None
 
     # ---- 基础 ----
 
@@ -70,19 +71,11 @@ class MarketSnapshotService:
 
     @staticmethod
     def _merge_stock_names(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """快照无名称字段，用本地 stock_basic 关联补齐（失败静默跳过）。"""
+        """快照无名称字段，用名称注册表补齐（stock_basic + TickFlow 兜底）。"""
         try:
-            from app.utils.parquet_job_helpers import get_stock_codes  # noqa: F401
-            from app.services.data_reader import ParquetDataReader
+            from app.services.stock_name_registry import get_stock_name_registry
 
-            basic = ParquetDataReader().get_stock_basic()
-            if basic.empty or "ts_code" not in basic.columns:
-                return rows
-            name_map = dict(zip(basic["ts_code"].astype(str), basic.get("name")))
-            for row in rows:
-                if row.get("name") is None:
-                    row["name"] = name_map.get(str(row.get("ts_code")))
-            return rows
+            return get_stock_name_registry().merge_names(rows)
         except Exception as exc:  # noqa: BLE001 - 名称补齐失败不影响行情主数据
             logger.debug(f"[market] 名称补齐跳过: {exc}")
             return rows
@@ -156,6 +149,8 @@ class MarketSnapshotService:
             frame = snapshot_rows_to_quote_frame(rows)
             frame = self._merge_stock_names(frame.to_dict("records"))
             frame = pd.DataFrame(frame)
+            with self._lock:
+                self._frame_cache = (time.monotonic(), frame)
             payload = self._build_dashboard(frame, source="fuyao", as_of=None)
             payload["server_ts"] = server_ts
         except FuyaoError as exc:
@@ -166,6 +161,20 @@ class MarketSnapshotService:
         with self._lock:
             self._dashboard_cache = (time.monotonic(), payload)
         return payload
+
+    def get_quote_frame(self) -> Optional["pd.DataFrame"]:
+        """全市场实时快照 DataFrame（复用看板 30s 缓存；无数据返回 None）。
+
+        列为扶摇快照 schema（last_price/pct_chg/turnover 元）或降级时的
+        本地日线 schema（close/pre_close/amount 千元），调用方两种都要兼容。
+        """
+        try:
+            self.get_dashboard()
+        except Exception:  # noqa: BLE001 - 看板失败不阻断帧读取
+            pass
+        with self._lock:
+            cached = self._frame_cache
+        return cached[1] if cached else None
 
     def _dashboard_from_local(self) -> Dict[str, Any]:
         """降级：用本地日线最近分区构建看板（标记 degraded + as_of）。"""
@@ -183,6 +192,8 @@ class MarketSnapshotService:
         from app.services.data_reader import ParquetDataReader
 
         df = ParquetDataReader().get_daily(start_date=latest, end_date=latest)
+        with self._lock:
+            self._frame_cache = (time.monotonic(), df)
         payload = self._build_dashboard(df, source="local_parquet", as_of=latest)
         payload["degraded"] = True
         return payload

--- a/app/services/stock_name_registry.py
+++ b/app/services/stock_name_registry.py
@@ -1,0 +1,154 @@
+"""股票名称注册表：本地 stock_basic + TickFlow 标的维表合并。
+
+扶摇行情快照本身不带名称；stock_basic 由 tushare/fuyao job 离线维护，
+新股或存量数据陈旧时会缺名称。TickFlow free 档的交易所标的维表
+（``GET /v1/exchanges/{SH,SZ,BJ}/instruments``）带全量 A 股名称，
+拉一次落盘 parquet 缓存（默认 7 天刷新），与 stock_basic 合并后
+作为全站名称兜底：stock_basic 优先（与现有展示一致），缺失处用
+TickFlow 补齐。
+
+缓存路径：``{DATA_DIR}/cache/tickflow/instruments.parquet``，
+损坏/缺失/过期时后台重拉，拉取失败静默降级为仅 stock_basic。
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import pandas as pd
+from loguru import logger
+
+CACHE_TTL_SECONDS = 7 * 24 * 3600.0
+EXCHANGES = ("SH", "SZ", "BJ")
+
+
+def default_cache_dir() -> Path:
+    data_dir = os.getenv(
+        "DATA_DIR",
+        os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))), "data"),
+    )
+    return Path(data_dir) / "cache" / "tickflow"
+
+
+def _cache_path() -> Path:
+    return default_cache_dir() / "instruments.parquet"
+
+
+def fetch_tickflow_names(client=None) -> Dict[str, str]:
+    """从 TickFlow 拉三交易所标的维表，返回 {ts_code: name}（失败抛异常）。"""
+    from app.utils.data_sources.tickflow_client import TickflowClient
+
+    client = client or TickflowClient()
+    names: Dict[str, str] = {}
+    for exchange in EXCHANGES:
+        for item in client.instruments(exchange=exchange):
+            symbol = str(item.get("symbol") or "").strip()
+            name = str(item.get("name") or "").strip()
+            if symbol and name:
+                names[symbol] = name
+    if not names:
+        raise RuntimeError("TickFlow 标的维表为空")
+    return names
+
+
+def _read_cache(path: Path, max_age_seconds: float) -> Optional[Dict[str, str]]:
+    try:
+        if not path.exists():
+            return None
+        mtime = path.stat().st_mtime
+        if time.time() - mtime > max_age_seconds:
+            return None
+        frame = pd.read_parquet(path)
+        if frame.empty or "ts_code" not in frame.columns or "name" not in frame.columns:
+            return None
+        return dict(zip(frame["ts_code"].astype(str), frame["name"].astype(str)))
+    except Exception as exc:  # noqa: BLE001 - 缓存坏了等同于没有缓存
+        logger.debug(f"[names] tickflow 名称缓存读取失败: {exc}")
+        return None
+
+
+def _write_cache(path: Path, names: Dict[str, str]) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        frame = pd.DataFrame({"ts_code": list(names.keys()), "name": list(names.values())})
+        tmp = path.with_suffix(f".parquet.part.{os.getpid()}")
+        frame.to_parquet(tmp, index=False)
+        tmp.replace(path)
+    except Exception as exc:  # noqa: BLE001 - 缓存写失败不影响名称供应
+        logger.debug(f"[names] tickflow 名称缓存写入失败: {exc}")
+
+
+class StockNameRegistry:
+    """进程内单例（get_stock_name_registry）：名称合并 + TickFlow 兜底缓存。"""
+
+    def __init__(self, cache_path: Optional[Path] = None):
+        self._cache_path = Path(cache_path) if cache_path else _cache_path()
+        self._lock = threading.Lock()
+        self._names: Optional[Dict[str, str]] = None
+        self._fetched_monotonic: float = 0.0
+
+    def name_map(self, max_age_seconds: float = CACHE_TTL_SECONDS) -> Dict[str, str]:
+        """合并名称表（stock_basic 优先，TickFlow 补缺；带进程内缓存）。"""
+        with self._lock:
+            if self._names is not None and time.monotonic() - self._fetched_monotonic < 300.0:
+                return self._names
+
+        merged: Dict[str, str] = {}
+        tickflow_names = _read_cache(self._cache_path, max_age_seconds)
+        if tickflow_names is None:
+            try:
+                tickflow_names = fetch_tickflow_names()
+                _write_cache(self._cache_path, tickflow_names)
+            except Exception as exc:  # noqa: BLE001 - 兜底源失败降级 stock_basic
+                logger.debug(f"[names] tickflow 标的维表拉取失败: {exc}")
+                tickflow_names = {}
+        merged.update(tickflow_names)
+
+        try:
+            from app.services.data_reader import ParquetDataReader
+
+            basic = ParquetDataReader().get_stock_basic()
+            if not basic.empty and "ts_code" in basic.columns and "name" in basic.columns:
+                merged.update(
+                    dict(zip(basic["ts_code"].astype(str), basic["name"].astype(str)))
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(f"[names] stock_basic 名称读取失败: {exc}")
+
+        with self._lock:
+            self._names = merged
+            self._fetched_monotonic = time.monotonic()
+        return merged
+
+    def merge_names(self, rows: List[Dict]) -> List[Dict]:
+        """就地补齐 rows 里缺失的 name 字段（无名称表时原样返回）。"""
+        try:
+            name_map = self.name_map()
+        except Exception:  # noqa: BLE001
+            return rows
+        for row in rows:
+            if row.get("name") is None:
+                row["name"] = name_map.get(str(row.get("ts_code")))
+        return rows
+
+    def invalidate(self) -> None:
+        """清空进程内缓存（测试/手动刷新用；不影响落盘缓存）。"""
+        with self._lock:
+            self._names = None
+            self._fetched_monotonic = 0.0
+
+
+_registry: Optional[StockNameRegistry] = None
+_registry_lock = threading.Lock()
+
+
+def get_stock_name_registry() -> StockNameRegistry:
+    global _registry
+    with _registry_lock:
+        if _registry is None:
+            _registry = StockNameRegistry()
+        return _registry

--- a/app/utils/daily_history_fuyao.py
+++ b/app/utils/daily_history_fuyao.py
@@ -1,0 +1,59 @@
+"""扶摇全市场日线行情下载（daily_history/daily 表的 fuyao 生产者）。
+
+与 tushare 版（daily_history_by_date.py / daily_history_by_code.py）写入同一张
+Parquet 表、同一套 schema，两者是同表的可选生产者，读取侧无感知。
+
+取数走 FuyaoDailyFetcher 三档策略（近端 10d dump → 10 年 dump → 单标的兜底），
+见 app/utils/data_sources/fuyao_dump.py；单位/时区换算集中在 fuyao_normalize。
+
+前置依赖：trade_calendar（交易日解析）。冷启动可用显式参数：
+    DATA_JOB_TRADE_DATE=20260904 python app/utils/daily_history_fuyao.py
+"""
+
+import sys
+from pathlib import Path
+
+# 兼容直接运行（python app/utils/daily_history_fuyao.py）：
+# 此时 sys.path[0] 是 app/utils，需要把项目根加进去才能 import app.*
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from app.utils.data_sources.fuyao_dump import FuyaoDailyFetcher
+from app.utils.parquet_job_helpers import resolve_trade_dates_with_gap_fill
+from app.utils.parquet_writer import save_to_parquet
+
+REL_TABLE = "daily_history/daily"
+
+
+def main() -> int:
+    trade_dates, _ = resolve_trade_dates_with_gap_fill(REL_TABLE)
+    if not trade_dates:
+        print("[daily_history_fuyao] 没有需要拉取的交易日")
+        return 0
+
+    fetcher = FuyaoDailyFetcher()
+    frames = fetcher.fetch_dates(trade_dates)
+
+    total = 0
+    failed = []
+    for trade_date in trade_dates:
+        frame = frames.get(trade_date)
+        if frame is None or frame.empty:
+            failed.append(trade_date)
+            continue
+        total += save_to_parquet(frame, trade_date, REL_TABLE)
+
+    saved_days = len(trade_dates) - len(failed)
+    print(
+        f"[daily_history_fuyao] 完成，trade_days={len(trade_dates)}, "
+        f"saved_days={saved_days}, total_upsert={total}"
+    )
+    if failed:
+        print(f"[daily_history_fuyao] 以下交易日未取得数据（作业标记失败，可重试）: {failed}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/app/utils/data_sources/__init__.py
+++ b/app/utils/data_sources/__init__.py
@@ -1,0 +1,48 @@
+"""第三方数据源客户端（fuyao / tickflow）。
+
+与 tushare（app/utils/db_utils.DatabaseUtils）完全独立：
+- 凭证各自独立（FUYAO_API_KEY / TICKFLOW_API_KEY）
+- 归一化到与 tushare 相同的 Parquet 表口径（fuyao_normalize），
+  数据源只是同一张表的可替换生产者
+"""
+
+from app.utils.data_sources.fuyao_client import (
+    API_KEY_ENV as FUYAO_API_KEY_ENV,
+    BASE_URL as FUYAO_BASE_URL,
+    FuyaoClient,
+    FuyaoError,
+    beijing_ms_to_ymd,
+)
+from app.utils.data_sources.fuyao_dump import DumpStore, FuyaoDailyFetcher
+from app.utils.data_sources.fuyao_normalize import (
+    daily_frame_from_dump,
+    daily_frame_from_kline_rows,
+    financial_items_to_frame,
+    snapshot_rows_to_quote_frame,
+    snapshot_rows_to_stock_basic,
+)
+from app.utils.data_sources.tickflow_client import (
+    API_KEY_ENV as TICKFLOW_API_KEY_ENV,
+    BASE_URL as TICKFLOW_BASE_URL,
+    TickflowClient,
+    TickflowError,
+)
+
+__all__ = [
+    "FuyaoClient",
+    "FuyaoError",
+    "FUYAO_API_KEY_ENV",
+    "FUYAO_BASE_URL",
+    "beijing_ms_to_ymd",
+    "DumpStore",
+    "FuyaoDailyFetcher",
+    "daily_frame_from_dump",
+    "daily_frame_from_kline_rows",
+    "financial_items_to_frame",
+    "snapshot_rows_to_quote_frame",
+    "snapshot_rows_to_stock_basic",
+    "TickflowClient",
+    "TickflowError",
+    "TICKFLOW_API_KEY_ENV",
+    "TICKFLOW_BASE_URL",
+]

--- a/app/utils/data_sources/fuyao_client.py
+++ b/app/utils/data_sources/fuyao_client.py
@@ -324,6 +324,38 @@ class FuyaoClient:
             },
         ) or {}
 
+    def limit_down_pool(
+        self,
+        date_ms: Optional[int] = None,
+        page: int = 1,
+        size: int = 100,
+    ) -> Dict[str, Any]:
+        """A 股跌停股票池（date_ms 口径同涨停池）。
+
+        实测字段：thscode/ticker/name/last_price/price_change_ratio_pct/
+        first_limit_time/last_limit_time/turnover_ratio_pct。
+        """
+        return self._get(
+            "/api/a-share/special-data/limit-down-pool",
+            {"date_ms": date_ms, "page": page, "size": size},
+        ) or {}
+
+    def limit_break_pool(
+        self,
+        date_ms: Optional[int] = None,
+        page: int = 1,
+        size: int = 100,
+    ) -> Dict[str, Any]:
+        """A 股炸板股票池（曾涨停后开板；date_ms 口径同涨停池）。
+
+        实测字段：thscode/ticker/name/last_price/price_change_ratio_pct/
+        open_times(炸板次数)/turnover_ratio_pct/turnover。
+        """
+        return self._get(
+            "/api/a-share/special-data/limit-break-pool",
+            {"date_ms": date_ms, "page": page, "size": size},
+        ) or {}
+
     def limit_up_ladder(self) -> Dict[str, Any]:
         """连板天梯矩阵（近 30 个交易日）。
 
@@ -332,6 +364,39 @@ class FuyaoClient:
         （thscode/ticker/name/board_num/seal_nextday/sign_level）。
         """
         return self._get("/api/a-share/special-data/limit-up-ladder") or {}
+
+    def hot_stock_list(self, period: str = "day") -> List[Dict[str, Any]]:
+        """同花顺热股榜（period: day/hour；Top30）。
+
+        实测字段：thscode/ticker/name/rank/heat(字符串数值)/
+        rank_change/rank_trend(up/down/flat)。
+        """
+        data = self._get(
+            "/api/a-share/special-data/hot-stock-list",
+            {"period": period},
+        )
+        return data.get("item") or []
+
+    def skyrocket_list(self, period: str = "day") -> List[Dict[str, Any]]:
+        """同花顺热股飙升榜（热度飙升最快；period: day/hour；Top30）。"""
+        data = self._get(
+            "/api/a-share/special-data/skyrocket-list",
+            {"period": period},
+        )
+        return data.get("item") or []
+
+    def ticker_search(
+        self, query: str, asset_type: str = "a-share", limit: int = 10
+    ) -> List[Dict[str, Any]]:
+        """标的检索（名称/代码模糊匹配，用于搜索联想）。
+
+        实测字段：thscode/ticker/name/exchange/asset_type/currency。
+        """
+        data = self._get(
+            "/api/meta/tickers/search",
+            {"q": query, "asset_type": asset_type, "limit": limit},
+        )
+        return data.get("item") or []
 
     # ---- dump 下载 ----
 

--- a/app/utils/data_sources/fuyao_client.py
+++ b/app/utils/data_sources/fuyao_client.py
@@ -195,15 +195,32 @@ class FuyaoClient:
     def index_snapshot(self, thscodes: Sequence[str]) -> Tuple[List[Dict[str, Any]], Optional[int]]:
         """指数实时快照（沪深交易所指数 + 同花顺板块指数，无北交所）。
 
-        未知代码会导致整批 1002 连坐，调用方需先过滤 .BJ 等不支持代码。
+        未知代码会导致整批 1002 连坐，调用方需先过滤 .BJ 等不支持代码；
+        批量上限 100 只，超量由调用方分批。
         """
         data = self._get(
             "/api/a-share-index/prices/snapshot",
-            {"thscodes": ",".join(thscodes)},
+            {"thscodes": ",".join(thscodes[:BATCH_LIMIT])},
         )
         items = data.get("item") or []
         ts = data.get("timestamp")
         return items, int(ts) if isinstance(ts, (int, float)) else None
+
+    def ths_index_catalog(self, tag: Optional[str] = None) -> List[Dict[str, Any]]:
+        """同花顺指数目录（tag: industry=行业 / cn_concept=概念，可空=全部）。
+
+        实测 industry 320 条、cn_concept 390 条；item: {thscode, name}。
+        """
+        data = self._get("/api/a-share-index/catalog/ths-index-list", {"tag": tag})
+        return data.get("item") or []
+
+    def ths_index_constituents(self, thscode: str) -> List[Dict[str, Any]]:
+        """同花顺指数成分股（item: {thscode, ticker, name}）。"""
+        data = self._get(
+            "/api/a-share-index/constituents/ths-stock-list",
+            {"thscode": thscode},
+        )
+        return data.get("item") or []
 
     # ---- 历史日K ----
 
@@ -280,6 +297,41 @@ class FuyaoClient:
             "/api/a-share/auction/short-term-benchmark",
             {"date": date},
         ) or {}
+
+    def limit_up_pool(
+        self,
+        date_ms: Optional[int] = None,
+        page: int = 1,
+        size: int = 100,
+        sort_field: str = "continue_day_cnt",
+        sort_dir: str = "desc",
+    ) -> Dict[str, Any]:
+        """A 股涨停股票池（date_ms 为北京时间零点 epoch ms，可空=最近交易日）。
+
+        实测字段：thscode/ticker/name/is_st/is_new/last_price/
+        price_change_ratio_pct/limit_up_time/limit_up_reason/
+        continue_day_text("5连板")/continue_day_cnt/seal_money/max_seal_money。
+        非交易日不传 date_ms 会返回空列表（total=0），由调用方回退最近交易日。
+        """
+        return self._get(
+            "/api/a-share/special-data/limit-up-pool",
+            {
+                "date_ms": date_ms,
+                "page": page,
+                "size": size,
+                "sort_field": sort_field,
+                "sort_dir": sort_dir,
+            },
+        ) or {}
+
+    def limit_up_ladder(self) -> Dict[str, Any]:
+        """连板天梯矩阵（近 30 个交易日）。
+
+        data.item[].boards 键：two_board/three_board/four_board/five_board/
+        six_board/seven_over（2 板至 7 板及以上），每档为个股列表
+        （thscode/ticker/name/board_num/seal_nextday/sign_level）。
+        """
+        return self._get("/api/a-share/special-data/limit-up-ladder") or {}
 
     # ---- dump 下载 ----
 

--- a/app/utils/data_sources/fuyao_client.py
+++ b/app/utils/data_sources/fuyao_client.py
@@ -1,0 +1,315 @@
+"""扶摇（同花顺官方金融数据 API）REST 客户端。
+
+接口契约参考 tick-stock-panel 项目（MIT License, Copyright (c) 2026
+tickflow-stock-panel contributors）的 backend/app/plugins/fuyao/client.py，
+按本项目技术栈改写为 requests 同步实现。该项目不携带此注释之外的义务。
+
+契约要点：
+- 认证：请求头 ``X-api-key``；key 从环境变量 FUYAO_API_KEY 读取
+- 响应信封：``{code, message, data}``，code != 0 视为业务错误
+  （4001 限频 / 1002 无效代码或非交易日 / 1003 超批量 / 5003 未披露报告期）
+- 时间口径：所有 *ms 字段为北京时间零点的 epoch ms，统一用
+  beijing_ms_to_ymd 解析（按 UTC 解析会偏一天）
+- 字段双命名：快照接口实测返回 high_price/low_price/prev_price，
+  官方文档为 highest_price/lowest_price/prev_close_price，取值时两者都试
+- 节流：单请求间隔默认 0.12s（实测 200+ 连发未触发 4001）
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import requests
+from dotenv import load_dotenv
+
+BEIJING_TZ = timezone(timedelta(hours=8))
+
+BASE_URL = "https://fuyao.aicubes.cn"
+API_KEY_ENV = "FUYAO_API_KEY"
+DEFAULT_THROTTLE_SECONDS = 0.12
+DEFAULT_TIMEOUT_SECONDS = 30
+
+#: 快照单页条数（6000 覆盖全市场）
+SNAPSHOT_PAGE_SIZE = 6000
+#: thscodes 批量接口单次上限（快照批量/估值快照）
+BATCH_LIMIT = 100
+#: dump 下载分片大小（字节）
+DUMP_CHUNK_SIZE = 1 << 20
+
+FINANCIAL_STATEMENT_ENDPOINTS = {
+    "income": "income-statements",
+    "balance_sheet": "balance-sheets",
+    "cash_flow": "cash-flow-statements",
+}
+
+_DUMP_RELEASE_RE = re.compile(r"releases/(\d{8})/")
+
+
+def beijing_ms_to_ymd(value_ms: Optional[float]) -> Optional[str]:
+    """北京时间零点的 epoch ms → YYYYMMDD。
+
+    扶摇所有日期字段都是北京时间零点，按 UTC 解析会得到前一天。
+    """
+    if value_ms is None or value_ms != value_ms:  # NaN 防御
+        return None
+    try:
+        dt = datetime.fromtimestamp(float(value_ms) / 1000.0, tz=BEIJING_TZ)
+    except (OverflowError, OSError, ValueError):
+        return None
+    return dt.strftime("%Y%m%d")
+
+
+def now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def release_of(presigned_url: str) -> Optional[str]:
+    """从预签名 URL 的 releases/<date>/ 路径提取 dump release 版本号。"""
+    found = _DUMP_RELEASE_RE.search(presigned_url or "")
+    return found.group(1) if found else None
+
+
+class FuyaoError(RuntimeError):
+    """扶摇业务错误（响应信封 code != 0 或 HTTP 非 2xx）。"""
+
+    def __init__(self, code: Any, message: str):
+        super().__init__(f"fuyao error code={code}: {message}")
+        self.code = code
+        self.message = message
+
+    @property
+    def is_rate_limited(self) -> bool:
+        return str(self.code) == "4001"
+
+    @property
+    def is_invalid_code(self) -> bool:
+        return str(self.code) == "1002"
+
+
+class FuyaoClient:
+    """扶摇 REST 客户端：请求节流 + 信封解包 + 各数据端点封装。
+
+    客户端不做任何字段换算/归一化（那是 normalize 层的职责），
+    只负责把端点返回的 data 原样交给调用方。
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        throttle_seconds: Optional[float] = None,
+        session: Optional[requests.Session] = None,
+    ):
+        # 与 db_utils 一致：脚本直接运行/被 API 调用时都先加载 .env
+        load_dotenv()
+        self.api_key = (api_key if api_key is not None else os.getenv(API_KEY_ENV, "")).strip()
+        self.base_url = (base_url or BASE_URL).rstrip("/")
+        self.timeout = timeout
+        self.throttle_seconds = (
+            throttle_seconds if throttle_seconds is not None else DEFAULT_THROTTLE_SECONDS
+        )
+        self._session = session or requests.Session()
+        self._throttle_lock = threading.Lock()
+        self._last_request_monotonic = 0.0
+
+    # ---- 基础请求 ----
+
+    def _throttle(self) -> None:
+        if self.throttle_seconds <= 0:
+            return
+        with self._throttle_lock:
+            wait = self._last_request_monotonic + self.throttle_seconds - time.monotonic()
+            if wait > 0:
+                time.sleep(wait)
+            self._last_request_monotonic = time.monotonic()
+
+    def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        if not self.api_key:
+            raise FuyaoError("no_key", f"未配置 {API_KEY_ENV}，请在 .env 中设置后重试")
+        clean_params = {k: v for k, v in (params or {}).items() if v is not None}
+        self._throttle()
+        try:
+            resp = self._session.get(
+                f"{self.base_url}{path}",
+                headers={"X-api-key": self.api_key},
+                params=clean_params,
+                timeout=self.timeout,
+            )
+        except requests.RequestException as exc:
+            raise FuyaoError("network", f"扶摇请求失败: {exc}") from exc
+        if resp.status_code != 200:
+            raise FuyaoError(resp.status_code, f"扶摇 HTTP {resp.status_code}: {resp.text[:200]}")
+        try:
+            payload = resp.json()
+        except ValueError as exc:
+            raise FuyaoError("bad_json", f"扶摇响应不是 JSON: {resp.text[:200]}") from exc
+        code = payload.get("code")
+        if code != 0:
+            raise FuyaoError(code, payload.get("message", ""))
+        return payload.get("data")
+
+    # ---- 行情快照 ----
+
+    def snapshot_page(
+        self,
+        limit: int = SNAPSHOT_PAGE_SIZE,
+        offset: int = 0,
+        thscodes: Optional[Sequence[str]] = None,
+    ) -> Dict[str, Any]:
+        """A 股全市场实时快照，分页或按 thscodes 批量（≤100）。"""
+        params: Dict[str, Any] = {"limit": limit, "offset": offset}
+        if thscodes:
+            params["thscodes"] = ",".join(thscodes[:BATCH_LIMIT])
+            params.pop("limit")
+            params.pop("offset")
+        return self._get("/api/a-share/prices/snapshot", params) or {}
+
+    def snapshot_all(self, max_pages: int = 50) -> Tuple[List[Dict[str, Any]], Optional[int]]:
+        """分页拉全市场快照，返回 (rows, 服务端时间戳ms)。"""
+        rows: List[Dict[str, Any]] = []
+        server_ts: Optional[int] = None
+        for _ in range(max_pages):
+            data = self.snapshot_page(limit=SNAPSHOT_PAGE_SIZE, offset=len(rows))
+            items = data.get("item") or []
+            rows.extend(items)
+            ts = data.get("timestamp")
+            if isinstance(ts, (int, float)) and server_ts is None:
+                server_ts = int(ts)
+            total = data.get("total") or data.get("count")
+            if not items or (isinstance(total, (int, float)) and len(rows) >= int(total)):
+                break
+        return rows, server_ts
+
+    def price_snapshot_batch(self, thscodes: Sequence[str]) -> List[Dict[str, Any]]:
+        """按代码批量拉实时快照（单次 ≤100 只）。"""
+        data = self.snapshot_page(thscodes=thscodes)
+        return data.get("item") or []
+
+    def index_snapshot(self, thscodes: Sequence[str]) -> Tuple[List[Dict[str, Any]], Optional[int]]:
+        """指数实时快照（沪深交易所指数 + 同花顺板块指数，无北交所）。
+
+        未知代码会导致整批 1002 连坐，调用方需先过滤 .BJ 等不支持代码。
+        """
+        data = self._get(
+            "/api/a-share-index/prices/snapshot",
+            {"thscodes": ",".join(thscodes)},
+        )
+        items = data.get("item") or []
+        ts = data.get("timestamp")
+        return items, int(ts) if isinstance(ts, (int, float)) else None
+
+    # ---- 历史日K ----
+
+    def historical_kline(
+        self,
+        thscode: str,
+        start_ms: Optional[int] = None,
+        end_ms: Optional[int] = None,
+        interval: str = "1d",
+        adjust: str = "none",
+    ) -> List[Dict[str, Any]]:
+        """单标的历史K线。adjust 锁定 none（服务端前复权有逐日漂移，禁用）。
+
+        服务端单次窗口 ≤10 年，超长窗口由调用方分片。
+        """
+        data = self._get(
+            "/api/a-share/prices/historical",
+            {
+                "thscode": thscode,
+                "interval": interval,
+                "adjust": adjust,
+                "start": start_ms,
+                "end": end_ms,
+            },
+        )
+        return data.get("item") or []
+
+    # ---- 财务 ----
+
+    def financial_statement(
+        self,
+        table: str,
+        thscode: str,
+        limit: int = 20,
+        period: str = "quarterly",
+    ) -> List[Dict[str, Any]]:
+        """单标的财务报表（income/balance_sheet/cash_flow），单次 ≤20 期。"""
+        endpoint = FINANCIAL_STATEMENT_ENDPOINTS.get(table)
+        if not endpoint:
+            raise ValueError(f"未知财务表: {table}")
+        data = self._get(
+            f"/api/a-share/financials/{endpoint}",
+            {"thscode": thscode, "period": period, "limit": limit},
+        )
+        return data.get("item") or []
+
+    def valuations_snapshot(self, thscodes: Sequence[str]) -> List[Dict[str, Any]]:
+        """估值快照（pe_ttm/pe_mrq/pb_mrq/ps_ttm/pcf_ttm），单次 ≤100 只。"""
+        data = self._get(
+            "/api/a-share/valuations/snapshot",
+            {"thscodes": ",".join(thscodes[:BATCH_LIMIT])},
+        )
+        return data.get("item") or []
+
+    # ---- 日历与特色数据 ----
+
+    def trading_days(self) -> List[Dict[str, Any]]:
+        """交易日历（固定近一年窗口，item: {date_ms, date}）。"""
+        data = self._get("/api/a-share/calendar/trading-days")
+        return data.get("item") or []
+
+    def dragon_tiger_list(
+        self, board_type: str = "all", date: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """龙虎榜（board_type: all/org/hot_money；date 可空=最近发布日）。"""
+        return self._get(
+            "/api/a-share/special-data/dragon-tiger-list",
+            {"board_type": board_type, "date": date},
+        ) or {}
+
+    def short_term_benchmark(self, date: Optional[str] = None) -> Dict[str, Any]:
+        """盘前竞价短线风向标（date 可空；支持一年内历史）。"""
+        return self._get(
+            "/api/a-share/auction/short-term-benchmark",
+            {"date": date},
+        ) or {}
+
+    # ---- dump 下载 ----
+
+    def dump_download_url(self, kind: str) -> Dict[str, Any]:
+        """获取全市场 dump 的预签名下载地址（kind: adjustment-factors/daily-k-10d/daily-k）。"""
+        return self._get(f"/api/dump/market-dumps/{kind}/download-url") or {}
+
+    def download_dump(self, kind: str, dest_path: Path) -> Path:
+        """下载 dump parquet 到本地（.part 临时文件 + 原子改名）。
+
+        预签名 URL 的签名覆盖请求本身，不得携带 X-api-key 头，
+        否则对象存储会校验失败。
+        """
+        info = self.dump_download_url(kind)
+        url = info.get("presigned_url")
+        if not url:
+            raise FuyaoError("no_url", f"dump {kind} 未返回下载地址")
+        dest_path = Path(dest_path)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        part_path = dest_path.with_suffix(dest_path.suffix + f".part.{os.getpid()}")
+        try:
+            with self._session.get(url, stream=True, timeout=self.timeout) as resp:
+                if resp.status_code != 200:
+                    raise FuyaoError(resp.status_code, f"dump {kind} 下载失败 HTTP {resp.status_code}")
+                with open(part_path, "wb") as fh:
+                    for chunk in resp.iter_content(chunk_size=DUMP_CHUNK_SIZE):
+                        if chunk:
+                            fh.write(chunk)
+            part_path.replace(dest_path)
+        finally:
+            if part_path.exists():
+                part_path.unlink(missing_ok=True)
+        return dest_path

--- a/app/utils/data_sources/fuyao_dump.py
+++ b/app/utils/data_sources/fuyao_dump.py
@@ -1,0 +1,307 @@
+"""扶摇全市场日K dump 的缓存管理与三档取数策略。
+
+取数三档（逐级降级，参考 tick-stock-panel 同名实现的策略分层）：
+- 近端窗口（≤12 天）：daily-k-10d dump（约 1MB），一次下载覆盖全市场 10 个交易日
+- 深窗口：daily-k 10 年全量 dump（约 172MB），缓存覆盖起点即复用、不追新 release
+  （旧 release 的中段历史不会变，尾部新鲜度由 10d dump 补）
+- 兜底：单标的 historical 接口（仅当未覆盖交易日 ≤5 天时启用，
+  5567 只 × 0.12s 节流 ≈ 11 分钟/天，超过 5 天直接报错而不是烧两小时）
+
+dump 缓存目录：``{DATA_DIR}/cache/fuyao/``，文件名 ``{prefix}__{release}.parquet``。
+release 号取自预签名 URL 的 releases/<date>/ 路径；小 dump 下载新 release 后
+清理旧版；10 年大 dump 只要覆盖请求起点就继续复用。
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import pandas as pd
+from loguru import logger
+
+from app.utils.data_sources.fuyao_client import (
+    FuyaoClient,
+    FuyaoError,
+    beijing_ms_to_ymd,
+)
+from app.utils.data_sources.fuyao_normalize import (
+    DAILY_COLUMNS,
+    daily_frame_from_dump,
+    daily_frame_from_kline_rows,
+)
+
+RECENT_DUMP_KIND = "daily-k-10d"
+FULL_DUMP_KIND = "daily-k"
+
+#: 10 年 dump 单次可覆盖的最大年限（服务端约束）
+MAX_HISTORY_YEARS = 10
+#: 兜底单标的接口允许的最大未覆盖交易日数
+SYMBOL_FALLBACK_MAX_DATES = 5
+
+
+def default_cache_dir() -> Path:
+    data_dir = os.getenv(
+        "DATA_DIR",
+        os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))), "data"),
+    )
+    return Path(data_dir) / "cache" / "fuyao"
+
+
+def _ymd_to_date(ymd: str) -> date:
+    return datetime.strptime(str(ymd), "%Y%m%d").date()
+
+
+def _date_to_ms_end(ymd: str) -> int:
+    """YYYYMMDD → 当天（北京时间）23:59:59.999 的 epoch ms。"""
+    dt = datetime.strptime(str(ymd), "%Y%m%d").replace(hour=23, minute=59, second=59, tzinfo=None)
+    epoch = datetime(1970, 1, 1)
+    return int((dt - epoch).total_seconds() * 1000) - 8 * 3600 * 1000
+
+
+class DumpStore:
+    """dump 文件缓存：按 release 落盘、按需下载、内存 memo。"""
+
+    def __init__(self, client: FuyaoClient, cache_dir: Optional[Path] = None):
+        self.client = client
+        self.cache_dir = Path(cache_dir) if cache_dir else default_cache_dir()
+        self._path_memo: Dict[str, Path] = {}
+        self._frame_memo: Dict[str, pd.DataFrame] = {}
+
+    def _release_re(self) -> "re.Pattern[str]":
+        return re.compile(r"releases/(\d{8})/")
+
+    def ensure_path(self, kind: str, prefix: str, reuse_old_if_covers: Optional[str] = None) -> Path:
+        """确保 dump 已落盘并返回路径。
+
+        reuse_old_if_covers: YYYYMMDD。已有旧缓存覆盖该日期时直接复用，
+        不追新 release（避免深窗口高频触发时日日重下 172MB）。
+        """
+        memo = self._path_memo.get(kind)
+        if memo is not None and memo.exists():
+            return memo
+
+        if reuse_old_if_covers:
+            old = self._cached_covering(prefix, reuse_old_if_covers)
+            if old is not None:
+                self._path_memo[kind] = old
+                return old
+
+        info = self.client.dump_download_url(kind)
+        release = self._release_re().search(str(info.get("presigned_url") or ""))
+        release_tag = release.group(1) if release else "unknown"
+        dest = self.cache_dir / f"{prefix}__{release_tag}.parquet"
+        if not dest.exists():
+            logger.info(f"[fuyao] 下载 dump {kind} (release {release_tag}) -> {dest}")
+            self.client.download_dump(kind, dest)
+            for old_file in self.cache_dir.glob(f"{prefix}__*.parquet"):
+                if old_file.name != dest.name:
+                    old_file.unlink(missing_ok=True)
+        self._path_memo[kind] = dest
+        return dest
+
+    def _cached_covering(self, prefix: str, ymd: str) -> Optional[Path]:
+        """返回缓存中 date_ms 覆盖 ymd 的最新文件；坏文件跳过。"""
+        for path in sorted(self.cache_dir.glob(f"{prefix}__*.parquet"), reverse=True):
+            try:
+                dmin, _ = dump_date_range(path)
+            except Exception as exc:  # noqa: BLE001 - 缓存损坏不致命
+                logger.warning(f"[fuyao] 缓存文件不可读，跳过: {path} ({exc})")
+                continue
+            if dmin is not None and _ymd_to_date(ymd) >= dmin:
+                return path
+        return None
+
+    def load_frame(self, kind: str, prefix: str, reuse_old_if_covers: Optional[str] = None) -> pd.DataFrame:
+        """小 dump 整读 + 进程内 memo（10d dump/因子表体量小）。"""
+        memo = self._frame_memo.get(kind)
+        if memo is not None:
+            return memo
+        path = self.ensure_path(kind, prefix, reuse_old_if_covers=reuse_old_if_covers)
+        frame = pd.read_parquet(path)
+        self._frame_memo[kind] = frame
+        return frame
+
+
+def dump_date_range(path: Path) -> Tuple[Optional[date], Optional[date]]:
+    """读 dump 的 date_ms 边界（只读单列，避免整读大文件）。"""
+    series = pd.read_parquet(path, columns=["date_ms"])["date_ms"]
+    if series.empty:
+        return None, None
+    dmin = beijing_ms_to_ymd(series.min())
+    dmax = beijing_ms_to_ymd(series.max())
+    return (
+        datetime.strptime(dmin, "%Y%m%d").date() if dmin else None,
+        datetime.strptime(dmax, "%Y%m%d").date() if dmax else None,
+    )
+
+
+class FuyaoDailyFetcher:
+    """按交易日列表取全市场日K，三档策略自动降级。
+
+    返回 {trade_date: DataFrame(tushare 口径)}；无法覆盖的日期会抛
+    FuyaoError（调用方按作业失败处理，缺口由下一轮 gap_fill 回补）。
+    """
+
+    def __init__(
+        self,
+        client: Optional[FuyaoClient] = None,
+        store: Optional[DumpStore] = None,
+    ):
+        self.client = client or FuyaoClient()
+        self.store = store or DumpStore(self.client)
+
+    def fetch_dates(self, trade_dates: List[str]) -> Dict[str, pd.DataFrame]:
+        wanted = sorted({str(d) for d in trade_dates})
+        if not wanted:
+            return {}
+
+        result = self._fetch_from_recent_dump(wanted)
+        missing = [d for d in wanted if d not in result]
+        if missing:
+            result.update(self._fetch_from_full_dump(missing, result))
+        missing = [d for d in wanted if d not in result]
+        if missing:
+            self._fetch_from_symbol_api(missing, result)
+        return {d: result[d] for d in wanted if d in result}
+
+    # ---- 档 1：10d dump ----
+
+    def _fetch_from_recent_dump(self, wanted: List[str]) -> Dict[str, pd.DataFrame]:
+        span_days = (_ymd_to_date(wanted[-1]) - _ymd_to_date(wanted[0])).days
+        if span_days > 12:
+            return {}
+        try:
+            dump = self.store.load_frame(RECENT_DUMP_KIND, "daily_k_10d")
+        except FuyaoError as exc:
+            logger.warning(f"[fuyao] 10d dump 不可用，尝试 10 年 dump: {exc}")
+            return {}
+        dmin = beijing_ms_to_ymd(dump["date_ms"].min())
+        dmax = beijing_ms_to_ymd(dump["date_ms"].max())
+        if dmin is None or dmax is None or wanted[0] < dmin or wanted[-1] > dmax:
+            logger.info(f"[fuyao] 10d dump 覆盖 [{dmin}~{dmax}]，不满足窗口 [{wanted[0]}~{wanted[-1]}]")
+            return {}
+        frame = daily_frame_from_dump(dump, wanted)
+        return self._split_by_date(frame)
+
+    # ---- 档 2：10 年全量 dump（+ 10d dump 补尾）----
+
+    def _fetch_from_full_dump(
+        self, missing: List[str], already: Dict[str, pd.DataFrame]
+    ) -> Dict[str, pd.DataFrame]:
+        start_ymd = missing[0]
+        if (_ymd_to_date(missing[-1]) - _ymd_to_date(start_ymd)).days > MAX_HISTORY_YEARS * 365:
+            raise FuyaoError(
+                "window_too_long",
+                f"回补窗口早于扶摇 dump 覆盖范围（>10 年）: {start_ymd}~{missing[-1]}",
+            )
+        try:
+            path = self.store.ensure_path(
+                FULL_DUMP_KIND, "daily_k", reuse_old_if_covers=start_ymd
+            )
+        except FuyaoError as exc:
+            logger.warning(f"[fuyao] 10 年 dump 不可用: {exc}")
+            return {}
+
+        dmin, dmax = dump_date_range(path)
+        result: Dict[str, pd.DataFrame] = {}
+        covered = [d for d in missing if dmin and dmax and dmin <= _ymd_to_date(d) <= dmax]
+        if covered:
+            big = pd.read_parquet(path)
+            frame = daily_frame_from_dump(big, covered)
+            result = self._split_by_date(frame)
+
+        # 大 dump 末端之后的日期由 10d dump 补尾。10d dump 覆盖最近 10 个交易日，
+        # 其窗口起点即含大 dump 尾日，补尾日的 pre_close 在小 dump 内推导即为正确值。
+        dmax_ymd = dmax.strftime("%Y%m%d") if dmax else ""
+        tail = [d for d in missing if not dmax_ymd or d > dmax_ymd]
+        if tail:
+            try:
+                small = self.store.load_frame(RECENT_DUMP_KIND, "daily_k_10d")
+            except FuyaoError as exc:
+                logger.warning(f"[fuyao] 补尾失败，10d dump 不可用: {exc}")
+                return result
+            small_dmin = beijing_ms_to_ymd(small["date_ms"].min())
+            small_dmax = beijing_ms_to_ymd(small["date_ms"].max())
+            tail_ok = [
+                d for d in tail
+                if small_dmin and small_dmax and small_dmin <= d <= small_dmax
+            ]
+            if tail_ok:
+                tail_frame = daily_frame_from_dump(small, tail_ok)
+                result.update(self._split_by_date(tail_frame))
+        return result
+
+    # ---- 档 3：单标的接口兜底 ----
+
+    def _fetch_from_symbol_api(self, missing: List[str], result: Dict[str, pd.DataFrame]) -> None:
+        if len(missing) > SYMBOL_FALLBACK_MAX_DATES:
+            raise FuyaoError(
+                "dates_not_covered",
+                f"{len(missing)} 个交易日超出 dump 覆盖且超过兜底上限 "
+                f"{SYMBOL_FALLBACK_MAX_DATES} 天，请检查 dump 缓存或改用显式窗口: {missing[:5]}...",
+            )
+        symbols = _all_stock_codes()
+        if not symbols:
+            raise FuyaoError("no_symbols", "stock_basic 为空，无法执行单标的兜底拉取")
+        logger.warning(
+            f"[fuyao] {len(missing)} 个交易日 dump 未覆盖，走单标的接口兜底"
+            f"（{len(symbols)} 只 × {len(missing)} 天，预计约 "
+            f"{len(symbols) * len(missing) * 0.12 / 60:.0f} 分钟）"
+        )
+        start_ms = _window_start_ms(_backoff_ymd(missing[0], days=10))
+        end_ms = _date_to_ms_end(missing[-1])
+        total = len(symbols)
+        for index, ts_code in enumerate(symbols, start=1):
+            try:
+                rows = self.client.historical_kline(ts_code, start_ms=start_ms, end_ms=end_ms)
+            except FuyaoError as exc:
+                logger.warning(f"[fuyao] {ts_code} 日K拉取失败，跳过: {exc}")
+                continue
+            frame = daily_frame_from_kline_rows(rows, ts_code)
+            frame = frame[frame["trade_date"].isin(missing)]
+            for trade_date, group in frame.groupby("trade_date"):
+                existing = result.get(trade_date)
+                result[trade_date] = (
+                    pd.concat([existing, group], ignore_index=True) if existing is not None else group
+                )
+            if index % 500 == 0:
+                logger.info(f"[fuyao] 单标的兜底进度: {index}/{total}")
+        for trade_date in missing:
+            frame = result.get(trade_date)
+            if frame is not None:
+                result[trade_date] = frame[DAILY_COLUMNS].reset_index(drop=True)
+
+    @staticmethod
+    def _split_by_date(frame: pd.DataFrame) -> Dict[str, pd.DataFrame]:
+        if frame.empty:
+            return {}
+        return {
+            str(trade_date): group.reset_index(drop=True)
+            for trade_date, group in frame.groupby("trade_date", sort=True)
+        }
+
+
+def _backoff_ymd(ymd: str, days: int) -> str:
+    """回退若干自然日，给单标的接口的窗口留出前一交易日上下文（推导 pre_close）。"""
+    return (_ymd_to_date(ymd) - timedelta(days=days)).strftime("%Y%m%d")
+
+
+def _window_start_ms(ymd: str) -> int:
+    """YYYYMMDD → 当天（北京时间）00:00 的 epoch ms。"""
+    dt = datetime.strptime(str(ymd), "%Y%m%d")
+    epoch = datetime(1970, 1, 1)
+    return int((dt - epoch).total_seconds() * 1000) - 8 * 3600 * 1000
+
+
+def _all_stock_codes() -> List[str]:
+    """从本地 stock_basic 读全量代码（含退市股，兜底口径与 tushare 对齐）。"""
+    from app.services.data_reader import ParquetDataReader
+
+    df = ParquetDataReader().get_stock_basic()
+    if df.empty or "ts_code" not in df.columns:
+        return []
+    return df["ts_code"].dropna().astype(str).tolist()

--- a/app/utils/data_sources/fuyao_dump.py
+++ b/app/utils/data_sources/fuyao_dump.py
@@ -68,6 +68,9 @@ class DumpStore:
     def __init__(self, client: FuyaoClient, cache_dir: Optional[Path] = None):
         self.client = client
         self.cache_dir = Path(cache_dir) if cache_dir else default_cache_dir()
+        # memo 仅限单进程生命周期：当前数据作业均经 subprocess 执行，每次新进程
+        # 冷启动自然拿到新 release。若将来把 DumpStore 引入长驻服务，这里必须
+        # 改为按 release 失效（或加 TTL），否则会钉死在进程首次加载的版本。
         self._path_memo: Dict[str, Path] = {}
         self._frame_memo: Dict[str, pd.DataFrame] = {}
 

--- a/app/utils/data_sources/fuyao_normalize.py
+++ b/app/utils/data_sources/fuyao_normalize.py
@@ -226,8 +226,10 @@ def snapshot_rows_to_stock_basic(rows: List[Dict[str, Any]], existing: Optional[
         fresh["list_status"] = "L"
         return fresh.reset_index(drop=True)
 
-    keep_cols = [c for c in existing.columns if c not in ("name", "list_status")]
     base = existing.copy()
+    # existing 可能缺 name 列（旧版 stock_basic），补空列保证 merge 后赋值不炸
+    if "name" not in base.columns:
+        base["name"] = None
     base = base.merge(fresh[["ts_code", "name"]], on="ts_code", how="left", suffixes=("", "_fuyao"))
     base["name"] = base["name_fuyao"].fillna(base["name"])
     base = base.drop(columns=["name_fuyao"])

--- a/app/utils/data_sources/fuyao_normalize.py
+++ b/app/utils/data_sources/fuyao_normalize.py
@@ -1,0 +1,282 @@
+"""扶摇数据 → 本项目 Parquet 表（tushare 口径）的归一化层。
+
+所有单位/时区/字段换算集中在这里，下载脚本不做二次换算，
+保证 fuyao 与 tushare 产出的同一张表 schema 完全同构：
+读取侧（ParquetDataReader 及所有业务服务）对数据源无感知。
+
+对照表（daily 表）：
+- ts_code   ← thscode（同为 600000.SH 风格，直传）
+- trade_date← date_ms（北京时间零点 epoch ms，北京时区解析）
+- open/high/low/close ← open_price/high_price/low_price/close_price（直传）
+- vol       ← volume ÷ 100（股 → 手）
+- amount    ← turnover ÷ 1000（元 → 千元）
+- pre_close ← 按标的分组的前一交易日 close 推导（扶摇日K无此字段）
+- change/pct_chg ← close/pre_close 推导
+
+已知局限：pre_close 由前收盘价直接推导，遇除权除息日（前收盘价被交易所
+调整）该日 change/pct_chg 会反映原始价差而非真实涨跌幅。需要精确复权口径
+的消费者继续使用 tushare stk_factor（含 adj_factor/前复权价）。
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+
+from app.utils.data_sources.fuyao_client import beijing_ms_to_ymd
+
+#: daily 表标准列（与 ParquetDataReader.STANDARD_COLUMNS["daily"] 一致）
+DAILY_COLUMNS = [
+    "ts_code", "trade_date", "open", "high", "low", "close",
+    "pre_close", "change", "pct_chg", "vol", "amount",
+]
+
+# 扶摇快照字段双命名：实测 vs 官方文档
+_SNAPSHOT_NAME_CANDIDATES = {
+    "name": ["name"],
+    "open": ["open_price"],
+    "high": ["high_price", "highest_price"],
+    "low": ["low_price", "lowest_price"],
+    "prev_close": ["prev_price", "prev_close_price"],
+}
+_SNAPSHOT_NUMERIC = ("last_price", "open", "high", "low", "prev_close",
+                     "price_change", "price_change_ratio_pct", "volume", "turnover")
+
+# 财务三表：扶摇原始字段 → tushare 列名（映射之外的扶摇独有字段原名透传）
+INCOME_FIELD_MAP = {
+    "operating_income": "revenue",
+    "operating_costs": "oper_cost",
+    "sales_fee": "sell_exp",
+    "manage_fee": "admin_exp",
+    "research_and_development_expenses": "rd_exp",
+    "operating_profit": "operate_profit",
+    "interest_expenses": "fin_exp",
+    "profit_total": "total_profit",
+    "income_tax_expense": "income_tax",
+    "net_profit": "n_income",
+    "parent_holder_net_profit": "n_income_attr_p",
+    "basic_eps": "basic_eps",
+}
+BALANCE_FIELD_MAP = {
+    "assets_total": "total_assets",
+    "total_current_assets": "total_cur_assets",
+    "non_current_nets_total": "total_nca",
+    "cash": "cash_equivalents",
+    "accounts_receivable": "accounts_receiv",
+    "total_debt": "total_liab",
+    "holder_equity_total": "total_hldr_eqy_exc_min_int",
+}
+CASHFLOW_FIELD_MAP = {
+    "act_cash_flow_net": "n_cashflow_act",
+    "invest_cash_flow_net": "n_cashflow_inv_act",
+    "financing_cash_flow_net": "n_cash_flows_fnc_act",
+    "pay_fixed_assets_etc_cash": "construct_fix_asset",
+    "pay_dividends_profits_interest_cash": "assign_dividend_porfit_int",
+    "cash_equivalents_net_addition": "n_cash_inc_cash_equi",
+}
+
+_FINANCIAL_META_MAP = {
+    "thscode": "ts_code",
+    "report_date_ms": "ann_date",
+    "period_end_ms": "end_date",
+    "fiscal_year": "fiscal_year",
+    "fiscal_period": "fiscal_period",
+}
+
+FINANCIAL_FIELD_MAPS = {
+    "income": INCOME_FIELD_MAP,
+    "balance_sheet": BALANCE_FIELD_MAP,
+    "cash_flow": CASHFLOW_FIELD_MAP,
+}
+
+
+def _first_present(row: Dict[str, Any], names: Sequence[str]) -> Any:
+    for name in names:
+        if name in row and row[name] is not None:
+            return row[name]
+    return None
+
+
+def daily_frame_from_dump(dump_df: pd.DataFrame, trade_dates: Iterable[str]) -> pd.DataFrame:
+    """全市场日K dump（parquet 已读入）→ tushare 口径 daily DataFrame。
+
+    dump 列：thscode/date_ms/open_price/high_price/low_price/close_price/
+    volume/turnover（实测 2026-09，另有 currency/interval/adjusted 常量列）。
+
+    pre_close 在整个 dump 范围内按标的分组推导，再过滤目标交易日，
+    因此只要 dump 含目标日期的前一交易日，边界日 pre_close 就是正确的。
+    """
+    wanted = {str(d) for d in trade_dates}
+    if dump_df is None or dump_df.empty or not wanted:
+        return pd.DataFrame(columns=DAILY_COLUMNS)
+
+    df = dump_df.copy()
+    if "adjusted" in df.columns:
+        # 防御：dump 变为复权口径时拒绝落库，而不是静默混入复权价
+        df = df[df["adjusted"] == "none"]
+    df["trade_date"] = df["date_ms"].map(beijing_ms_to_ymd)
+    df = df.rename(columns={
+        "thscode": "ts_code",
+        "open_price": "open",
+        "high_price": "high",
+        "low_price": "low",
+        "close_price": "close",
+    })
+    # 先在整个 dump 范围推导 pre_close（目标日期的前一交易日也在 dump 内），
+    # 再过滤目标交易日——先过滤会让边界日的 pre_close 变成 NaN
+    frame = _finalize_daily(df)
+    frame = frame[frame["trade_date"].isin(wanted)]
+    if frame.empty:
+        return pd.DataFrame(columns=DAILY_COLUMNS)
+    return frame.reset_index(drop=True)
+
+
+def daily_frame_from_kline_rows(rows: List[Dict[str, Any]], ts_code: str) -> pd.DataFrame:
+    """单标的 historical 接口 rows → tushare 口径 daily DataFrame。"""
+    if not rows:
+        return pd.DataFrame(columns=DAILY_COLUMNS)
+    df = pd.DataFrame(rows)
+    df["ts_code"] = ts_code
+    df["trade_date"] = df["date_ms"].map(beijing_ms_to_ymd)
+    df = df.rename(columns={
+        "open_price": "open",
+        "high_price": "high",
+        "low_price": "low",
+        "close_price": "close",
+    })
+    return _finalize_daily(df)
+
+
+def _finalize_daily(df: pd.DataFrame) -> pd.DataFrame:
+    """列换算 + pre_close/change/pct_chg 推导 + 标准列输出。"""
+    df = df.copy()
+    for col in ("open", "high", "low", "close"):
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    # 股 → 手（向下取整，与 tick-stock-panel 口径一致）；元 → 千元
+    df["vol"] = np.floor(pd.to_numeric(df["volume"], errors="coerce") / 100.0)
+    df["amount"] = pd.to_numeric(df["turnover"], errors="coerce") / 1000.0
+
+    df = df.sort_values(["ts_code", "trade_date"], kind="mergesort")
+    df["pre_close"] = df.groupby("ts_code", sort=False)["close"].shift(1)
+    df["change"] = (df["close"] - df["pre_close"]).round(3)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        df["pct_chg"] = ((df["close"] / df["pre_close"] - 1.0) * 100.0).round(4)
+    df.loc[df["pre_close"].isna(), "change"] = np.nan
+    df.loc[df["pre_close"].isna(), "pct_chg"] = np.nan
+
+    # 停牌日（OHLC 全空）过滤，与 tushare daily 不返回停牌日一致
+    df = df.dropna(subset=["open", "high", "low", "close"], how="all")
+
+    df["trade_date"] = df["trade_date"].astype(str)
+    return df[DAILY_COLUMNS].reset_index(drop=True)
+
+
+def snapshot_rows_to_quote_frame(rows: List[Dict[str, Any]]) -> pd.DataFrame:
+    """全市场快照 rows → 行情 DataFrame（供看板/自选聚合）。
+
+    输出列：ts_code/name/last_price/open/high/low/prev_close/change/
+    pct_chg/volume(股)/turnover(元)。涨跌幅保持百分数原值。
+    """
+    records = []
+    for row in rows or []:
+        ts_code = row.get("thscode")
+        if not ts_code:
+            continue
+        record = {
+            "ts_code": ts_code,
+            "name": _first_present(row, _SNAPSHOT_NAME_CANDIDATES["name"]),
+            "last_price": row.get("last_price"),
+            "open": _first_present(row, _SNAPSHOT_NAME_CANDIDATES["open"]),
+            "high": _first_present(row, _SNAPSHOT_NAME_CANDIDATES["high"]),
+            "low": _first_present(row, _SNAPSHOT_NAME_CANDIDATES["low"]),
+            "prev_close": _first_present(row, _SNAPSHOT_NAME_CANDIDATES["prev_close"]),
+            "change": row.get("price_change"),
+            "pct_chg": row.get("price_change_ratio_pct"),
+            "volume": row.get("volume"),
+            "turnover": row.get("turnover"),
+        }
+        for col in _SNAPSHOT_NUMERIC:
+            value = record.get(col)
+            record[col] = float(value) if value is not None and value == value else None
+        records.append(record)
+    return pd.DataFrame(records)
+
+
+def snapshot_rows_to_stock_basic(rows: List[Dict[str, Any]], existing: Optional[pd.DataFrame] = None) -> pd.DataFrame:
+    """全市场快照 rows → stock_basic 表（代码清单全量对齐）。
+
+    快照没有股票名称字段（同花顺口径名称靠下游维表关联）：已有记录保留
+    原值（tushare 产出），仅追加快照中新出现的代码；new 代码 list_status
+    记为 L（快照只在市股），name 留空待 tushare 版补齐。
+    """
+    fresh = pd.DataFrame([
+        {
+            "ts_code": row.get("thscode"),
+            "symbol": str(row.get("thscode", "")).split(".")[0] if row.get("thscode") else None,
+            "name": _first_present(row, _SNAPSHOT_NAME_CANDIDATES["name"]),
+        }
+        for row in rows or []
+        if row.get("thscode")
+    ])
+    fresh = fresh.drop_duplicates(subset="ts_code")
+    if existing is None or existing.empty:
+        fresh["list_status"] = "L"
+        return fresh.reset_index(drop=True)
+
+    keep_cols = [c for c in existing.columns if c not in ("name", "list_status")]
+    base = existing.copy()
+    base = base.merge(fresh[["ts_code", "name"]], on="ts_code", how="left", suffixes=("", "_fuyao"))
+    base["name"] = base["name_fuyao"].fillna(base["name"])
+    base = base.drop(columns=["name_fuyao"])
+
+    known = set(base["ts_code"].astype(str))
+    additions = fresh[~fresh["ts_code"].astype(str).isin(known)].copy()
+    if not additions.empty:
+        for col in base.columns:
+            if col not in additions.columns:
+                additions[col] = "L" if col == "list_status" else None
+        base = pd.concat([base, additions[base.columns]], ignore_index=True)
+    return base.reset_index(drop=True)
+
+
+def financial_items_to_frame(
+    items: List[Dict[str, Any]],
+    table: str,
+    ts_code: str,
+) -> pd.DataFrame:
+    """单标的财务报表 items → tushare 兼容 DataFrame。
+
+    - 元数据：thscode→ts_code、report_date_ms→ann_date、period_end_ms→end_date
+      （ms 字段同样按北京时区解析）
+    - 字段映射表内的列改为 tushare 列名；映射表之外的扶摇独有字段原名透传
+    - null 保持 NaN（= 未披露），不伪造 0
+    """
+    field_map = FINANCIAL_FIELD_MAPS.get(table)
+    if field_map is None:
+        raise ValueError(f"未知财务表: {table}")
+    records: List[Dict[str, Any]] = []
+    for item in items or []:
+        record: Dict[str, Any] = {}
+        for src, dst in _FINANCIAL_META_MAP.items():
+            if src in item:
+                value = item[src]
+                if dst in ("ann_date", "end_date"):
+                    value = beijing_ms_to_ymd(value)
+                record[dst] = value
+        for src, dst in field_map.items():
+            if src in item:
+                record[dst] = item[src]
+        for src, value in item.items():
+            if src not in field_map and src not in _FINANCIAL_META_MAP:
+                record[src] = value
+        records.append(record)
+    frame = pd.DataFrame(records)
+    if not frame.empty:
+        frame["ts_code"] = ts_code
+        frame["end_date"] = frame["end_date"].astype(str)
+        if "ann_date" in frame.columns:
+            frame["ann_date"] = frame["ann_date"].astype(str)
+    return frame

--- a/app/utils/data_sources/tickflow_client.py
+++ b/app/utils/data_sources/tickflow_client.py
@@ -1,0 +1,152 @@
+"""TickFlow 轻量 REST 客户端（free 档兜底/校验源）。
+
+端点契约参考 tick-stock-panel 项目（MIT License, Copyright (c) 2026
+tickflow-stock-panel contributors）及其封装的官方 SDK。本项目不引入
+``tickflow[all]`` SDK（依赖过重），这里只封装 free 档用得到的两个 GET 接口。
+
+契约要点：
+- 认证：请求头 ``x-api-key``（注意与扶摇的 X-api-key 大小写不同，
+  HTTP 头本身不区分大小写，这里遵循各服务方的惯例拼写）
+- 端点：``https://api.tickflow.org``（免费档 key 也走付费端点，
+  free-api 忽略 key；tick-stock-panel 的探测逻辑即以此为准）
+- 档位：日K 全档可用；除权因子 starter+；分钟K pro+。
+  free 档 key 的限速约 5 rpm（单标的日K），
+  **不得用于全市场批量任务**——那是 tushare/fuyao job 的职责
+- 时间：K线响应 timestamp 数组为北京时间零点的 epoch ms
+
+不可用权限返回 HTTP 403 + ``{"code": "NO_XXX_PERMISSION"}``，
+本客户端原样抛 TickflowError(code=...)，由 detect_tier 据此判档。
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional, Sequence
+
+import requests
+from dotenv import load_dotenv
+
+BASE_URL = "https://api.tickflow.org"
+API_KEY_ENV = "TICKFLOW_API_KEY"
+DEFAULT_TIMEOUT_SECONDS = 30
+
+
+class TickflowError(RuntimeError):
+    """TickFlow 业务错误（权限不足/参数错误/网络异常）。"""
+
+    def __init__(self, code: Any, message: str):
+        super().__init__(f"tickflow error code={code}: {message}")
+        self.code = code
+        self.message = message
+
+    @property
+    def is_permission_denied(self) -> bool:
+        text = f"{self.code} {self.message}"
+        return "PERMISSION" in text or "权限" in text
+
+
+class TickflowClient:
+    """TickFlow REST 客户端：日K / 实时行情 / 档位探测。"""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        session: Optional[requests.Session] = None,
+    ):
+        # 与 db_utils 一致：脚本直接运行/被 API 调用时都先加载 .env
+        load_dotenv()
+        self.api_key = (api_key if api_key is not None else os.getenv(API_KEY_ENV, "")).strip()
+        self.base_url = (base_url or BASE_URL).rstrip("/")
+        self.timeout = timeout
+        self._session = session or requests.Session()
+
+    def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        if not self.api_key:
+            raise TickflowError("no_key", f"未配置 {API_KEY_ENV}，请在 .env 中设置后重试")
+        clean_params = {k: v for k, v in (params or {}).items() if v is not None}
+        try:
+            resp = self._session.get(
+                f"{self.base_url}{path}",
+                headers={"x-api-key": self.api_key},
+                params=clean_params,
+                timeout=self.timeout,
+            )
+        except requests.RequestException as exc:
+            raise TickflowError("network", f"tickflow 请求失败: {exc}") from exc
+        if resp.status_code != 200:
+            try:
+                payload = resp.json()
+            except ValueError:
+                payload = {}
+            raise TickflowError(
+                payload.get("code", resp.status_code),
+                payload.get("message", resp.text[:200]),
+            )
+        try:
+            payload = resp.json()
+        except ValueError as exc:
+            raise TickflowError("bad_json", f"tickflow 响应不是 JSON: {resp.text[:200]}") from exc
+        return payload.get("data")
+
+    def klines(
+        self,
+        symbol: str,
+        period: str = "1d",
+        count: Optional[int] = None,
+        adjust: str = "none",
+        start_time: Optional[int] = None,
+        end_time: Optional[int] = None,
+    ) -> Dict[str, List[Any]]:
+        """单标的K线（列数组紧凑格式）。返回含 timestamp/open/high/low/close/volume/amount。"""
+        data = self._get(
+            "/v1/klines",
+            {
+                "symbol": symbol,
+                "period": period,
+                "count": count,
+                "adjust": adjust,
+                "start_time": start_time,
+                "end_time": end_time,
+            },
+        )
+        return data or {}
+
+    def quotes(self, symbols: Sequence[str]) -> List[Dict[str, Any]]:
+        """实时行情（free 档单次 ≤5 只、10 rpm）。"""
+        data = self._get("/v1/quotes", {"symbols": ",".join(symbols)})
+        if isinstance(data, list):
+            return data
+        return (data or {}).get("quotes") or (data or {}).get("data") or []
+
+    def ex_factors(
+        self,
+        symbols: Sequence[str],
+        start_time: Optional[int] = None,
+        end_time: Optional[int] = None,
+    ) -> Dict[str, List[Dict[str, Any]]]:
+        """除权因子（starter+ 档；free 档返回 403 NO_EX_FACTORS_PERMISSION）。"""
+        data = self._get(
+            "/v1/klines/ex-factors",
+            {"symbols": ",".join(symbols), "start_time": start_time, "end_time": end_time},
+        )
+        return data or {}
+
+    def detect_tier(self) -> str:
+        """探测 key 档位：none（无效/未配置）/ free / starter+。
+
+        判据与 tick-stock-panel 的探测分水岭一致：
+        有单标的日K = key 有效；有除权因子 = 付费档，否则免费档。
+        """
+        if not self.api_key:
+            return "none"
+        try:
+            self.klines("600000.SH", period="1d", count=1, adjust="none")
+        except TickflowError:
+            return "none"
+        try:
+            self.ex_factors(["600000.SH"], start_time=0)
+        except TickflowError:
+            return "free"
+        return "paid"

--- a/app/utils/data_sources/tickflow_client.py
+++ b/app/utils/data_sources/tickflow_client.py
@@ -133,6 +133,26 @@ class TickflowClient:
         )
         return data or {}
 
+    def instruments(
+        self,
+        exchange: str = "SH",
+        instrument_type: str = "stock",
+        limit: int = 5000,
+    ) -> List[Dict[str, Any]]:
+        """交易所标的维表（free 档可用）。
+
+        exchange ∈ SH/SZ/BJ（美股港交所代码见服务端文档）；单次 limit 覆盖
+        全量即可，实测 SH 3660 只一次返回。item 含 symbol/name/ext，
+        ext 里有 listing_date/total_shares/float_shares/limit_up/limit_down。
+        """
+        data = self._get(
+            f"/v1/exchanges/{exchange}/instruments",
+            {"instrument_type": instrument_type, "limit": limit},
+        )
+        if isinstance(data, list):
+            return data
+        return (data or {}).get("data") or []
+
     def detect_tier(self) -> str:
         """探测 key 档位：none（无效/未配置）/ free / starter+。
 

--- a/app/utils/financial_fuyao.py
+++ b/app/utils/financial_fuyao.py
@@ -1,0 +1,222 @@
+"""扶摇财务三表下载（income_statement / balance_sheet / cash_flow 的 fuyao 生产者）。
+
+与 tushare VIP 版（financial_vip.py）写入同一组 Parquet 表，按 end_date 报告期
+分区。tushare 版按报告期一次拉全市场（需要 VIP 积分），扶摇是单标的接口
+（免费 key 即可），全市场一轮约 3 表 × 11 分钟（0.12s/请求节流）。
+
+增量策略：
+- expected = 最近一个已过披露截止日的报告期（Q1→4/30、H1→8/31、Q3→10/31、
+  FY→次年 4/30）
+- 本地最新分区已 >= expected：整表跳过
+- 否则逐标的拉最近 N 期（N = latest_local 到 expected 之间的期数 + 1，上限 20），
+  与已有分区按 (ts_code, end_date) 合并、保留最新 ann_date（财报更正覆盖旧值）
+- 每 500 个标的一次落盘（save_to_parquet 是整分区覆盖，必须先按报告期聚合），
+  中断后重跑至多重复 500 个标的的请求
+
+已知差异：字段映射见 fuyao_normalize.INCOME_FIELD_MAP 等，扶摇未披露的字段
+保持缺失（NaN），不做插补。
+"""
+
+import os
+import sys
+from collections import defaultdict
+from datetime import date, datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+# 兼容直接运行（python app/utils/financial_fuyao.py）
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+import pandas as pd
+from dotenv import load_dotenv
+from loguru import logger
+
+from app.utils.data_sources.fuyao_client import FuyaoClient
+from app.utils.data_sources.fuyao_normalize import financial_items_to_frame
+from app.utils.parquet_job_helpers import env_bool, latest_partition_date
+from app.utils.parquet_writer import save_to_parquet
+
+#: 扶摇表名 → 本地分区表名
+TABLES = {
+    "income": "income_statement",
+    "balance_sheet": "balance_sheet",
+    "cash_flow": "cash_flow",
+}
+
+#: 报告期（MMDD）→ 披露截止日（月, 日；FY 为次年）
+DISCLOSURE_DEADLINES = {
+    "0331": (4, 30),
+    "0630": (8, 31),
+    "0930": (10, 31),
+    "1231": (4, 30),
+}
+
+QUARTER_ENDS = ("0331", "0630", "0930", "1231")
+MAX_FETCH_PERIODS = 20
+#: 每批标的数：批内聚合、批末落盘（断点续跑粒度）
+SYMBOL_CHUNK_SIZE = 500
+SYMBOL_THROTTLE_NOTE = "0.12s/请求"
+
+
+def quarter_periods(start_ymd: str, end_ymd: str) -> List[str]:
+    """生成 [start, end] 之间的全部季度报告期（YYYYMMDD）。"""
+    periods = []
+    for year in range(int(start_ymd[:4]), int(end_ymd[:4]) + 1):
+        for month_day in QUARTER_ENDS:
+            period = f"{year}{month_day}"
+            if start_ymd <= period <= end_ymd:
+                periods.append(period)
+    return periods
+
+
+def expected_latest_period(today: Optional[date] = None) -> Optional[str]:
+    """最近一个已过披露截止日的报告期；一个都没有时返回 None。"""
+    today = today or date.today()
+    candidates: List[Tuple[date, str]] = []
+    for year in (today.year - 1, today.year):
+        for month_day, (month, day) in DISCLOSURE_DEADLINES.items():
+            deadline_year = year + 1 if month_day == "1231" else year
+            deadline = date(deadline_year, month, day)
+            if deadline <= today:
+                candidates.append((deadline, f"{year}{month_day}"))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda item: item[1])[1]
+
+
+def resolve_fetch_periods(latest_local: Optional[str], expected: str) -> List[str]:
+    """本次需要覆盖的报告期窗口（含更正重拉：从本地最新期（含）到 expected）。"""
+    start = latest_local or f"{int(expected[:4]) - 5}0101"
+    return quarter_periods(start, expected)
+
+
+def _read_existing_partition(table: str, end_date: str, data_dir: Optional[str]) -> Optional[pd.DataFrame]:
+    clean = str(end_date).replace("-", "")
+    partition = Path(data_dir or ".") / table / f"year={clean[:4]}" / f"month={clean[4:6]}" / f"day={clean[6:]}" / "data.parquet"
+    if not partition.exists():
+        return None
+    try:
+        return pd.read_parquet(partition)
+    except Exception as exc:  # noqa: BLE001 - 坏分区按空处理，靠新数据重建
+        logger.warning(f"[financial_fuyao] 分区读取失败，将重建: {partition} ({exc})")
+        return None
+
+
+def _merge_partition(existing: Optional[pd.DataFrame], new: pd.DataFrame) -> pd.DataFrame:
+    """同分区合并：(ts_code, end_date) 去重，保留最新 ann_date（更正覆盖旧值）。"""
+    if existing is None or existing.empty:
+        return new
+    combined = pd.concat([existing, new], ignore_index=True)
+    ann = pd.to_numeric(combined.get("ann_date"), errors="coerce")
+    combined = (
+        combined.assign(_ann=ann)
+        .sort_values("_ann", na_position="first", kind="mergesort")
+        .drop_duplicates(subset=["ts_code", "end_date"], keep="last")
+        .drop(columns=["_ann"])
+    )
+    return combined
+
+
+def all_stock_codes(client: Optional[FuyaoClient] = None) -> List[str]:
+    """标的清单：优先本地 stock_basic，冷启动时回退扶摇全市场快照。"""
+    from app.utils.parquet_job_helpers import get_stock_codes
+
+    codes = get_stock_codes()
+    if codes:
+        return codes
+    logger.warning("[financial_fuyao] 本地 stock_basic 为空，回退扶摇快照获取标的清单")
+    from app.utils.data_sources.fuyao_normalize import snapshot_rows_to_stock_basic
+
+    rows, _ = (client or FuyaoClient()).snapshot_all()
+    return snapshot_rows_to_stock_basic(rows)["ts_code"].tolist()
+
+
+def _sync_table(
+    client: FuyaoClient,
+    table: str,
+    partition_table: str,
+    symbols: List[str],
+    limit: int,
+    data_dir: Optional[str],
+) -> Tuple[int, int, int]:
+    """同步一张财务表，返回 (拉取成功标的数, 写入报告期数, 写入行数)。"""
+    rows_by_period: Dict[str, List[pd.DataFrame]] = defaultdict(list)
+    written_periods = 0
+    written_rows = 0
+    fetched_ok = 0
+
+    def flush():
+        nonlocal written_periods, written_rows
+        for end_date in sorted(rows_by_period):
+            new = pd.concat(rows_by_period[end_date], ignore_index=True)
+            existing = _read_existing_partition(partition_table, end_date, data_dir)
+            merged = _merge_partition(existing, new)
+            written_rows += save_to_parquet(merged, end_date, partition_table, data_dir=data_dir)
+            written_periods += 1
+        rows_by_period.clear()
+
+    fetched = 0
+    for symbol in symbols:
+        try:
+            items = client.financial_statement(table, symbol, limit=limit)
+        except Exception as exc:  # noqa: BLE001 - 单标的失败不阻断全市场任务
+            logger.warning(f"[financial_fuyao] {table} {symbol} 拉取失败，跳过: {exc}")
+            continue
+        frame = financial_items_to_frame(items, table, symbol)
+        fetched_ok += 1
+        for end_date, group in frame.groupby("end_date"):
+            rows_by_period[str(end_date)].append(group)
+        if fetched_ok % SYMBOL_CHUNK_SIZE == 0:
+            flush()
+            logger.info(f"[financial_fuyao] {table} 进度: {fetched_ok}/{len(symbols)}")
+    flush()
+    return fetched_ok, written_periods, written_rows
+
+
+def main() -> int:
+    load_dotenv()
+    data_dir = os.getenv("DATA_DIR")
+    full_refresh = env_bool("DATA_JOB_FULL_REFRESH", default=False)
+    today = date.today()
+    client = FuyaoClient()
+
+    symbols = all_stock_codes(client)
+    if not symbols:
+        print("[financial_fuyao] 无可用标的清单（stock_basic 与快照均为空）")
+        return 1
+
+    overall_exit = 0
+    for table, partition_table in TABLES.items():
+        latest_local = latest_partition_date(partition_table, data_dir=data_dir)
+        expected = expected_latest_period(today)
+        if expected is None:
+            print(f"[financial_fuyao] {partition_table}: 尚无过披露截止日的报告期，跳过")
+            continue
+        if latest_local is not None and latest_local >= expected and not full_refresh:
+            print(f"[financial_fuyao] {partition_table}: 本地 {latest_local} 已覆盖 {expected}，跳过")
+            continue
+
+        periods = resolve_fetch_periods(latest_local, expected)
+        limit = min(MAX_FETCH_PERIODS, max(2, len(periods) + (0 if full_refresh else 1)))
+        print(
+            f"[financial_fuyao] {partition_table}: local={latest_local or '无'} expected={expected} "
+            f"periods={len(periods)} limit={limit} symbols={len(symbols)} "
+            f"(预计约 {len(symbols) * 0.12 / 60:.0f} 分钟)"
+        )
+        fetched_ok, written_periods, written_rows = _sync_table(
+            client, table, partition_table, symbols, limit, data_dir
+        )
+        print(
+            f"[financial_fuyao] {partition_table} 完成: periods={written_periods}, "
+            f"total_upsert={written_rows}"
+        )
+        if fetched_ok == 0:
+            print(f"[financial_fuyao] {partition_table}: 全部标的拉取失败，作业标记失败")
+            overall_exit = 1
+    return overall_exit
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/app/utils/financial_fuyao.py
+++ b/app/utils/financial_fuyao.py
@@ -72,8 +72,13 @@ def quarter_periods(start_ymd: str, end_ymd: str) -> List[str]:
 
 
 def expected_latest_period(today: Optional[date] = None) -> Optional[str]:
-    """最近一个已过披露截止日的报告期；一个都没有时返回 None。"""
-    today = today or date.today()
+    """最近一个已过披露截止日的报告期；一个都没有时返回 None。
+
+    默认取北京时间今天：非东八区部署时，本地日期会让披露截止判断偏一天。
+    """
+    from app.utils.data_sources.fuyao_client import BEIJING_TZ
+
+    today = today or datetime.now(BEIJING_TZ).date()
     candidates: List[Tuple[date, str]] = []
     for year in (today.year - 1, today.year):
         for month_day, (month, day) in DISCLOSURE_DEADLINES.items():
@@ -94,7 +99,18 @@ def resolve_fetch_periods(latest_local: Optional[str], expected: str) -> List[st
 
 def _read_existing_partition(table: str, end_date: str, data_dir: Optional[str]) -> Optional[pd.DataFrame]:
     clean = str(end_date).replace("-", "")
-    partition = Path(data_dir or ".") / table / f"year={clean[:4]}" / f"month={clean[4:6]}" / f"day={clean[6:]}" / "data.parquet"
+    # 回退口径必须与 save_to_parquet/latest_partition_date 一致（DATA_DIR 或项目 data/），
+    # 否则 DATA_DIR 未设置时读不到已有分区，分块 flush 会互相覆盖丢数据
+    from app.utils.parquet_job_helpers import _default_data_root
+
+    partition = (
+        Path(data_dir or _default_data_root())
+        / table
+        / f"year={clean[:4]}"
+        / f"month={clean[4:6]}"
+        / f"day={clean[6:]}"
+        / "data.parquet"
+    )
     if not partition.exists():
         return None
     try:

--- a/app/utils/stock_basic_fuyao.py
+++ b/app/utils/stock_basic_fuyao.py
@@ -1,0 +1,67 @@
+"""扶摇股票清单刷新（stock_basic.parquet 的 fuyao 生产者）。
+
+与 tushare 版（stock_basic.py）写入同一个 stock_basic.parquet。定位差异：
+- 扶摇全市场快照一次拉齐（免费 key），适合日常刷新代码清单/发现新上市代码
+- 快照没有股票名称字段（名称靠下游维表关联），也没有退市股（D/P 状态）
+  和行业/地域/上市日期等元数据
+
+合并策略：已有记录整体保留（tushare 元数据与退市记录不动），快照中新出现
+的代码追加（list_status=L，名称待 tushare 版补齐）。名称刷新与完整元数据
+仍以 tushare 版为准。
+"""
+
+import sys
+from pathlib import Path
+
+# 兼容直接运行（python app/utils/stock_basic_fuyao.py）
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+import pandas as pd
+from dotenv import load_dotenv
+from loguru import logger
+
+from app.utils.data_sources.fuyao_client import FuyaoClient
+from app.utils.data_sources.fuyao_normalize import snapshot_rows_to_stock_basic
+from app.utils.parquet_writer import save_single_parquet
+
+REL_FILENAME = "stock_basic.parquet"
+
+
+def _read_existing(data_dir) -> pd.DataFrame:
+    from app.utils.parquet_job_helpers import _default_data_root
+
+    path = Path(data_dir or _default_data_root()) / REL_FILENAME
+    if not path.exists():
+        return pd.DataFrame()
+    try:
+        return pd.read_parquet(path)
+    except Exception as exc:  # noqa: BLE001 - 坏文件按空处理重建
+        logger.warning(f"[stock_basic_fuyao] 现有文件读取失败，将重建: {exc}")
+        return pd.DataFrame()
+
+
+def main() -> int:
+    load_dotenv()
+    import os
+
+    data_dir = os.getenv("DATA_DIR")
+
+    rows, _ = FuyaoClient().snapshot_all()
+    if not rows:
+        print("[stock_basic_fuyao] 快照为空，作业标记失败")
+        return 1
+
+    existing = _read_existing(data_dir)
+    merged = snapshot_rows_to_stock_basic(rows, existing)
+    saved = save_single_parquet(merged, REL_FILENAME, data_dir=data_dir)
+    print(
+        f"[stock_basic_fuyao] 完成: total={saved} (此前 {len(existing)}, "
+        f"新增 {max(saved - len(existing), 0)})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/plans/2026-09-05-fuyao-tickflow-datasource-and-frontend-design.md
+++ b/docs/plans/2026-09-05-fuyao-tickflow-datasource-and-frontend-design.md
@@ -1,0 +1,179 @@
+# 数据源整合（fuyao / tickflow）与前端焕新 设计方案
+
+Date: 2026-09-05
+
+## 一、背景（Context）
+
+参考项目 `tick-stock-panel`（MIT 协议，代码可合法借鉴）内置了两个数据源，经实测 key 均有效：
+
+| 数据源 | 实测结论 | 能力 |
+|---|---|---|
+| **fuyao**（同花顺扶摇，`https://fuyao.aicubes.cn`） | key 有效，全部接口实测通过 | 全市场实时快照（5567 只）、单标的 10 年历史日K、**全市场日K dump（172MB parquet 一次下载）**、财务三表、估值快照、龙虎榜、竞价风向标、交易日历（近一年）、除权因子 dump |
+| **tickflow**（`https://api.tickflow.org`） | key 有效，但为 **free 档**：除权因子与分钟K均返回 403 | 仅单标的日K（约 5 次/分钟限速）+ 小批量实时行情，无法承担全市场批量任务 |
+
+本项目现状：
+
+- 日频数据全部依赖 tushare：17 个 data job 中 15 个 `source_name="tushare"`，经 `DatabaseUtils.init_tushare_api()`（`app/utils/db_utils.py`）取数；无 provider 抽象层，**真正的系统契约是 Parquet 表结构**（`ParquetDataReader.TABLE_DIRS/STANDARD_COLUMNS`）。
+- 前端为 React 19 + Bootstrap 5.3 CSS + 手写 `theme.css`（886 行），无 Tailwind、无组件库、emoji 图标、无代码分割、无 query 缓存层，视觉上偏粗糙。
+- tick-stock-panel 前端为 Tailwind 3.4 + HSL 语义色 CSS 变量 + 自研薄组件层（无 shadcn/radix 依赖），暗色默认、1px 边框分层、等宽数字、信息密度高，观感明显更好。
+
+## 二、目标（Goals）
+
+1. **数据源整合**：将 fuyao、tickflow 作为独立于 tushare 的数据源接入，复用现有 data job / Parquet 架构，读取侧零改动。
+2. **前端焕新**：参考 tick-stock-panel 的设计风格（不照抄），建立新的设计 token 与组件层，新开发的页面全部采用新风格。
+3. 围绕 fuyao 独有能力（实时快照、龙虎榜、竞价风向标）新增有实际价值的页面。
+
+## 三、非目标（Non-Goals）
+
+- 不引入 tick-stock-panel 的插件体系 / 按数据集路由 / 能力探测引擎（对本项目过重）。
+- 不替换、不下线 tushare：`trade_calendar`（历史）、`daily_basic`（历史估值）、`stk_factor`、`moneyflow`、`cyq_perf`、`stock_company` 等任务继续走 tushare（fuyao/tickflow free 档不覆盖）。
+- 不整体重写存量 30 个旧页面（仅做基础设施打通，旧页面迁移作为可选后续阶段）。
+- 不引入 tickflow 官方 SDK（`tickflow[all]` 依赖过重，free 档只用到日K/行情两个 GET 接口，纯 REST 封装即可）。
+- 不新增定时调度器（数据更新仍由数据管理页手动触发）。
+
+## 四、Part 1：数据源整合设计
+
+### 4.1 与 tushare 区分的原则
+
+| 维度 | tushare（现状） | fuyao / tickflow（新增） |
+|---|---|---|
+| 凭证 | `TUSHARE_TOKEN` | 独立的 `FUYAO_API_KEY` / `TICKFLOW_API_KEY`（`.env`） |
+| 取数入口 | `DatabaseUtils.init_tushare_api()` | `app/utils/data_sources/` 下各自 client，互不引用 |
+| job 标识 | `source_name="tushare"` | `source_name="fuyao"` / `"tickflow"` |
+| 落盘 | 同一套 Parquet 表、同一套 schema | **相同**（数据源只是同一张表的可替换生产者） |
+| 依赖包 | `tushare` | 零新增（复用 `requests`） |
+
+核心思路：**数据源只在"写入侧"区分，读取侧契约不变**。不跑 fuyao job 即自动退回 tushare job，回退路径天然存在。
+
+### 4.2 新增模块结构
+
+```
+app/utils/data_sources/
+├── __init__.py
+├── fuyao_client.py      # fuyao REST 客户端（借鉴 tick-stock-panel backend/app/plugins/fuyao/client.py，MIT，改 httpx→requests）
+│                        #   含：X-api-key 认证、{code,message,data} 信封解包、错误码处理（4001限频/1002无效代码）、
+│                        #   请求节流（页间 0.15s / 单标的 0.12s）、dump 预签名 URL 下载（不得带 api-key 头）
+├── tickflow_client.py   # tickflow 轻量 REST 客户端（约 120 行：日K GET /v1/klines + 实时 GET/POST /v1/quotes）
+└── fuyao_dump.py        # 日K dump 三档取数策略（借鉴 tick-stock-panel provider.py 的 get_daily 分层）：
+                         #   ① 近端窗口(≤12天)→daily-k-10d dump（约1MB 一次覆盖全市场）
+                         #   ② 深回填→daily-k 10年全量 dump（172MB，按 release 版本缓存于 data/cache/fuyao/）
+                         #   ③ 兜底→单标的 historical 接口（10年自动分片）
+```
+
+下载脚本（沿用现有"脚本即 job"模式）：
+
+```
+app/utils/daily_history_fuyao.py     # 日线行情 → daily_history/daily/ 分区（核心，优先做）
+app/utils/financial_fuyao.py         # 财务三表 → income_statement/ balance_sheet/ cash_flow/（按 end_date 分区）
+app/utils/stock_basic_fuyao.py       # 股票列表 → stock_basic.parquet（可选，无退市股是其短板）
+```
+
+复用 `DailyFetchJob` 骨架（`app/utils/parquet_job_helpers.py:188`）与 `parquet_writer` 的原子写/锁机制。
+
+### 4.3 schema 对齐（风险控制重点）
+
+落盘必须与 tushare 产出完全同构，单位/口径换算如下：
+
+| 字段 | tushare 契约 | fuyao 原始 | 换算 |
+|---|---|---|---|
+| 代码 | `ts_code`（600000.SH） | `thscode`（同格式） | 直传 |
+| 日期 | `trade_date`（YYYYMMDD） | `date_ms` | **按北京时区解析**（date_ms 为北京时间零点 epoch ms，按 UTC 解析会偏一天） |
+| 开高低收 | `open/high/low/close` | `*_price` | 直传 |
+| 成交量 | `vol`（**手**） | `volume`（**股**） | `÷100` 取整 |
+| 成交额 | `amount`（**千元**） | `turnover`（**元**） | `÷1000` |
+| 前收盘 | `pre_close` | 无 | 从前一日 close 推导（首个交易日从 dump 元数据/快照 `prev_price` 补） |
+| 涨跌/涨跌幅 | `change` / `pct_chg`（百分数） | 无 / `price_change_ratio_pct`（百分数） | 推导 / 直传（注意：tickflow 的 `ext.change_pct` 是**小数制**，若接 tickflow 需 ×100） |
+
+快照接口字段双命名兼容（`high_price` / `highest_price`）在 client 层统一处理。财务三表按 tick-stock-panel `provider.py:757-799` 的映射思路改为映射到 tushare 列名（如 `operating_income→revenue`、`parent_holder_net_profit→n_income_attr_pid`），fuyao 独有字段作为扩展列透传，两源数据按（ts_code, end_date）合并取最新非空。
+
+### 4.4 job 注册与配套改动
+
+- `app/services/data_jobs/registry.py`：注册 `daily_history_fuyao`、`income_fuyao`、`balance_sheet_fuyao`、`cash_flow_fuyao`（合并为一个 `financial_fuyao` 亦可，实现时定），`source_name="fuyao"`；页面可见白名单 `_visible_job_types` 增加。tushare 对应 job 保留，两者是同一张表的两个可选生产者。
+- `app/services/ai/tools.py:365`：token 检查条件从 `source_name == 'tushare'` 扩展为按 source→env 映射（tushare→TUSHARE_TOKEN、fuyao→FUYAO_API_KEY、tickflow→TICKFLOW_API_KEY）。
+- `.env.example`：新增 `FUYAO_API_KEY=`、`TICKFLOW_API_KEY=`。key 不入库、不硬编码。
+- 借鉴代码文件头保留 MIT 版权注释（协议要求）。
+
+### 4.5 数据源状态 API（为前端页面服务）
+
+新增 `app/api/market_api.py`（Blueprint）：
+
+| 端点 | 数据来源 | 用途 |
+|---|---|---|
+| `GET /api/market/snapshot?codes=` | fuyao 快照（≤100/批） | 自选实时行情 |
+| `GET /api/market/dashboard` | fuyao 指数快照 + 全市场快照聚合（涨跌家数/分布/榜单，内存缓存 30~60s） | 市场看板 |
+| `GET /api/market/indices` | fuyao 指数接口 | 指数行情 |
+| `GET /api/market/dragon-tiger?date=` | fuyao 龙虎榜（按日缓存落 parquet） | 龙虎榜页 |
+| `GET /api/market/auction-benchmark?date=` | fuyao 竞价风向标（按日缓存） | 竞价风向标页 |
+| `GET /api/datasources/status` | 探测 fuyao/tickflow/tushare key 有效性与档位（tickflow 档位探测：日K成功+除权因子403⇒free） | 数据源状态展示 |
+
+后端服务层新建 `app/services/market_snapshot_service.py` 统一做缓存与降级（fuyao 失败时看板降级为本地 Parquet 最近交易日数据）。
+
+### 4.6 分阶段实施
+
+- **M1 客户端与配置**（~0.5 天）：`data_sources/` 三模块 + `.env` + 单元测试（mock 响应，覆盖信封错误码/单位换算/时区解析）。
+- **M2 日线链路**（~1 天）：`daily_history_fuyao.py` + registry 注册 + 合约测试（与 tushare 同日数据抽样比对 OHLC 一致、vol/amount 换算正确）。跑通全市场一天增量（10d dump 路径）。
+- **M3 财务三表**（~1 天）：字段映射表 + 三表 job + 合约测试。
+- **M4 行情 API**（~1 天）：`market_api.py` + 缓存服务 + 龙虎榜/风向标按日落盘。
+
+验收标准：数据管理页可见并成功执行 fuyao 任务；`ParquetDataReader` 读取 fuyao 产出的分区无感知差异（列白名单全通过）；fuyao job 失败不影响任何现有 tushare 任务。
+
+## 五、Part 2：前端焕新设计
+
+### 5.1 总体策略
+
+**新页面走新体系，旧页面不动，基础设施共存**：
+
+- 引入 Tailwind 3.4（**关闭 preflight**，避免与 Bootstrap reset 冲突），旧页面继续用 bootstrap 类，新页面用 tailwind 语义类。
+- 设计 token 借鉴 tick-stock-panel 的架构但**换掉其品牌色**：采用其锌灰中性底（`--base 240 5% 5%`、`--surface 240 7% 10%`、暗色靠 1px 边框分层不靠阴影、卡片圆角 8px）+ 本项目现有靛蓝 `#6366f1` 作为 accent（保留本项目品牌识别，即"参考风格不照抄"）。红涨绿跌（`--bull #F04438` / `--bear #12B76A`）与数字排版规范（JetBrains Mono + tabular-nums）直接采纳。
+- 暗色模式沿用现有 `data-theme` 属性（Tailwind 配 `darkMode: ['[data-theme="dark"]']`），补上 localStorage 持久化与 `index.html` 内联防闪白脚本（现刷新会闪回暗色）。
+- 图标从 emoji 换为 `lucide-react`；新页面数据获取用 `@tanstack/react-query`（旧页面不迁移）。
+
+### 5.2 基础设施改造（一次性）
+
+| 事项 | 内容 |
+|---|---|
+| 依赖 | `tailwindcss@3 postcss autoprefixer`（dev）+ `clsx tailwind-merge lucide-react @tanstack/react-query`（runtime）；React 19 下 Tailwind 3.4 兼容 |
+| `tailwind.config.ts` | 语义色映射 HSL 变量（base/surface/elevated/border/fg 三级/accent/bull/bear/warning）、圆角 token（card 8px/btn 6px/input 4px/dialog 12px）、`preflight: false` |
+| `src/styles/tsp.css` | `@tailwind` 指令 + 双主题 CSS 变量段（暗色默认）+ 等宽数字工具类；`main.tsx` 中与 bootstrap css 共存 |
+| 组件层 `src/components/ui/` | 从 tick-stock-panel 搬零依赖件并适配：`cn.ts`、`PageHeader`（细线下边框页头）、`EmptyState`、`Modal`（焦点陷阱/ESC/aria）、`Toast`、`SectionTitle`（accent 竖条+图标）；新增 `KpiCard`、`QuoteBadge`（半透明同色 pill：`bg-x/12 border-x/25 text-x`）、`DataTable`（轻表格：列自定义、mono 数字列、板块彩色徽章） |
+| 路由 | 新页面在 `App.tsx` 单独 `lazy()`（不影响旧页同步加载现状） |
+| QueryClient | `main.tsx` 挂 Provider，新页面独享 |
+
+### 5.3 新增页面（4 个，全部新风格）
+
+均参考 tick-stock-panel 对应页面的**布局模式与信息密度**，视觉与交互按本项目 token 重做：
+
+1. **市场看板 `MarketDashboardPage`**（参考 Dashboard.tsx 的结构）
+   指数 ticker 行（grid-cols-4）→ 市场宽度 KPI 行（涨跌家数/涨停跌停/成交额/振幅中位数）→ 主体两栏：左侧涨跌分布柱阵 + 领涨/领跌/成交额/换手 TOP 榜卡，右侧龙虎榜/风向标摘要 aside。数据：`/api/market/dashboard`，30s 轮询。点击个股弹出日K预览 Dialog（数据走本地 Parquet 已有接口）。
+2. **自选行情 `WatchlistPage`**（参考 Watchlist.tsx 模式）
+   分组卡片 + 实时快照表（fuyao 快照 5~10s 轮询，限 100 只/批），涨跌幅 bull/bear 着色、mono 数字、板块徽章；支持添加/删除自选（localStorage 起步，不建后端表）。
+3. **龙虎榜与竞价风向标 `DragonTigerPage`**（fuyao 独有数据，tick-stock-panel 无此页，自由发挥）
+   日期选择 + 三榜 Tab（机构/游资/全部）榜单表 + 当日风向标卡片组（每日约 5~6 只，含 auction_pct 与标签）。
+4. **数据源中心 `DataSourceCenterPage`**（参考 Settings/DataSources.tsx 的能力矩阵思路）
+   三个数据源卡片（tushare/fuyao/tickflow）：key 配置状态（脱敏显示）、实测档位/可用接口、近期 job 成功率；每数据集的当前生产者标注（daily: fuyao / stk_factor: tushare…）。与现有 `DataManagementPage` 互补（该页管任务执行，新页管数据源健康）。
+
+侧栏导航新增"市场"分组（市场看板/自选行情/龙虎榜）+ "数据源中心"入口，新分组用新组件渲染。
+
+### 5.4 分阶段实施
+
+- **F1 基础设施**（~1 天）：Tailwind/token/组件层/QueryClient/防闪白，产出 1 个演示性骨架页验收视觉方向。
+- **F2 市场看板 + 数据源中心**（~1.5 天）：依赖 M4 的 API。
+- **F3 自选行情 + 龙虎榜**（~1.5 天）。
+- **F4（可选后续）旧页面渐进迁移**：按访问频率逐页改造（HomePage → StocksPage → DataManagementPage…），不在本期承诺。
+
+验收标准：新旧页面共存无样式互相污染（preflight 关闭验证点）；暗/亮主题切换新页面正常；Lighthouse 新页面无 console 报错；行情页在 fuyao 接口异常时显示降级提示而非白屏。
+
+## 六、风险与对策
+
+| 风险 | 对策 |
+|---|---|
+| 单位/时区换算错误导致脏数据进 Parquet | M2 合约测试与 tushare 同日数据抽样比对；换算集中在 client 层一处，脚本不做二次换算 |
+| fuyao 限频（4001）/服务不可用 | client 内置节流与退避；行情 API 降级到本地 Parquet；下载 job 失败不影响 tushare 任务 |
+| tickflow free 档 5rpm 误用于批量任务 | tickflow 定位为校验/兜底源，不注册批量 job；文档与代码注释注明档位限制 |
+| Tailwind 与 Bootstrap 样式冲突 | 关闭 preflight；新页面不用 bootstrap 类；CI/lint 层面约定新页面目录禁引 bootstrap |
+| fuyao 财务单标的接口全市场耗时（约 11 分钟） | job 内进度落 Parquet 状态库可断点续跑；报告期增量只拉新披露 |
+| key 泄露 | 仅 `.env`，`.env.example` 留空占位；日志与前端脱敏 |
+
+## 七、工期汇总
+
+M1–M4 后端约 3.5 天，F1–F3 前端约 4 天，联调验收 0.5 天，合计约 **8 个工作日**。建议顺序：M1→M2→F1（尽早锁定视觉方向）→M3→M4→F2→F3。

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,16 @@
       href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='9' fill='%236366f1'/%3E%3Ctext x='16' y='22' font-size='18' font-weight='800' fill='white' text-anchor='middle' font-family='sans-serif'%3EQ%3C/text%3E%3C/svg%3E"
     />
     <title>量化分析系统 · React 版</title>
+    <script>
+      // 防主题闪白：渲染前读取持久化主题（ThemeContext 亦以 dark 为缺省）
+      try {
+        var _mode = localStorage.getItem('qa-theme')
+        if (_mode === 'light') {
+          document.documentElement.setAttribute('data-theme', 'light')
+          document.documentElement.setAttribute('data-bs-theme', 'light')
+        }
+      } catch (e) {}
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,27 +8,47 @@
       "name": "quant-frontend-react",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.102.8",
         "axios": "^1.7.9",
         "bootstrap": "^5.3.3",
+        "clsx": "^2.1.1",
         "echarts": "^6.1.0",
         "lightweight-charts": "^5.2.1",
+        "lucide-react": "^1.41.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.1.0",
-        "socket.io-client": "^4.8.3"
+        "socket.io-client": "^4.8.3",
+        "tailwind-merge": "^3.6.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.35.0",
         "@types/react": "^19.1.0",
         "@types/react-dom": "^19.1.0",
         "@vitejs/plugin-react": "^5.0.0",
+        "autoprefixer": "^10.5.5",
         "eslint": "^9.35.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.4.0",
+        "postcss": "^8.5.28",
+        "tailwindcss": "^3.4.17",
         "typescript": "~5.8.0",
         "typescript-eslint": "^8.42.0",
         "vite": "^7.0.0"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.3.0.tgz",
+      "integrity": "sha512-U4+70Pc5ZS9osnCBCE5Jha/ciHM+Yp+CNMNC/7HvYbNRk1Ldd+f7qO65W5qfhu/TCv+/ozljlXXe9Nj8419DMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1048,6 +1068,44 @@
         "node": "^22.20 || ^24.12 || >=25"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmmirror.com/@popperjs/core/-/core-2.11.8.tgz",
@@ -1460,6 +1518,32 @@
       "resolved": "https://registry.npmmirror.com/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.102.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.102.8.tgz",
+      "integrity": "sha512-ZNjkJ33CqvPNec/6lZBnHqLc3EVGPZ9ySLhYahU9TcuRFdmwXewuj0c4hwSWcGHqEUwcSrKeZ+oGcvPBqXcQcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.102.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.102.8.tgz",
+      "integrity": "sha512-TYBea4OuXWD7MhaSHq069TWbFe7rcwWN6kzT7JF0OKi1K6c1gTv2IzD6A6ExJsCMozdkqBWeuIUZmu4KQg0O5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.102.8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1924,6 +2008,47 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/argparse/-/argparse-2.0.1.tgz",
@@ -1936,6 +2061,43 @@
       "resolved": "https://registry.npmmirror.com/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.5.tgz",
+      "integrity": "sha512-uiRYvQYe/nNSzBJ7OUnd2/TZVsAdob3blml44teEpee9Cc1f4rGZFewO+JT3Wo8mgFOSzNqes4FHZn/Qz8WOuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.9",
+        "caniuse-lite": "^1.0.30001810",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
     },
     "node_modules/axios": {
       "version": "1.20.0",
@@ -1969,6 +2131,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bootstrap": {
       "version": "5.3.8",
       "resolved": "https://registry.npmmirror.com/bootstrap/-/bootstrap-5.3.8.tgz",
@@ -1999,10 +2174,23 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/browserslist": {
-      "version": "4.28.8",
-      "resolved": "https://registry.npmmirror.com/browserslist/-/browserslist-4.28.8.tgz",
-      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "dev": true,
       "funding": [
         {
@@ -2020,11 +2208,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.11.12",
-        "caniuse-lite": "^1.0.30001809",
-        "electron-to-chromium": "^1.5.402",
-        "node-releases": "^2.0.53",
-        "update-browserslist-db": "^1.3.0"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2054,6 +2242,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2094,6 +2292,53 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/color-convert/-/color-convert-2.0.1.tgz",
@@ -2124,6 +2369,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/concat-map": {
@@ -2168,6 +2423,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.2.3.tgz",
@@ -2207,6 +2475,20 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2574,6 +2856,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmmirror.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2587,6 +2899,16 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.3.tgz",
+      "integrity": "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2617,6 +2939,19 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/find-up": {
@@ -2691,6 +3026,20 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fsevents": {
@@ -2901,6 +3250,35 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmmirror.com/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2924,12 +3302,32 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmmirror.com/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3041,6 +3439,26 @@
         "fancy-canvas": "2.1.0"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmmirror.com/locate-path/-/locate-path-6.0.0.tgz",
@@ -3074,6 +3492,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.41.0.tgz",
+      "integrity": "sha512-6lksP35l6KszDKUeRTi4LV7i6DEe0Yzl2ALJm9j4c5xEYN91GdW1xGsawGMOg2mgjF5GHBVX8pKX9kP+cWsP3Q==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmmirror.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3081,6 +3508,43 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime-db": {
@@ -3123,6 +3587,18 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.18.tgz",
@@ -3157,6 +3633,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/optionator": {
@@ -3242,6 +3748,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmmirror.com/picocolors/-/picocolors-1.1.1.tgz",
@@ -3262,10 +3775,20 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/postcss": {
-      "version": "8.5.26",
-      "resolved": "https://registry.npmmirror.com/postcss/-/postcss-8.5.26.tgz",
-      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
       "dev": true,
       "funding": [
         {
@@ -3283,13 +3806,140 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.17",
+        "nanoid": "^3.3.18",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.0.0",
+        "yaml": "^2.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.9",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -3319,6 +3969,27 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.2.8",
@@ -3389,6 +4060,61 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/read-cache": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.2.tgz",
+      "integrity": "sha512-/peqiBB/n07gQGLsWaHho3WfvUyRscw0gYTsEFMhrIe/nWLkYaf5SbKYjGYqtRV3aPwykJgF2VEMo1ac4bnsGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3397,6 +4123,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rollup": {
@@ -3443,6 +4180,30 @@
         "@rollup/rollup-win32-x64-gnu": "4.63.1",
         "@rollup/rollup-win32-x64-msvc": "4.63.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/scheduler": {
@@ -3541,6 +4302,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmmirror.com/supports-color/-/supports-color-7.2.0.tgz",
@@ -3552,6 +4336,90 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.17",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
+      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.6",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/tinyglobby": {
@@ -3571,6 +4439,19 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmmirror.com/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -3583,6 +4464,13 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/tslib": {
       "version": "2.3.0",
@@ -3681,6 +4569,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.6",
@@ -3818,6 +4713,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,24 +10,31 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.102.8",
     "axios": "^1.7.9",
     "bootstrap": "^5.3.3",
+    "clsx": "^2.1.1",
     "echarts": "^6.1.0",
     "lightweight-charts": "^5.2.1",
+    "lucide-react": "^1.41.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.1.0",
-    "socket.io-client": "^4.8.3"
+    "socket.io-client": "^4.8.3",
+    "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "@vitejs/plugin-react": "^5.0.0",
+    "autoprefixer": "^10.5.5",
     "eslint": "^9.35.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.4.0",
+    "postcss": "^8.5.28",
+    "tailwindcss": "^3.4.17",
     "typescript": "~5.8.0",
     "typescript-eslint": "^8.42.0",
     "vite": "^7.0.0"

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { NavLink, Route, Routes } from 'react-router-dom'
+import { lazy, Suspense } from 'react'
 import { ThemeProvider, useTheme } from './theme/ThemeContext'
 import StocksPage from './pages/StocksPage'
 import AnalysisPage from './pages/AnalysisPage'
@@ -29,6 +30,12 @@ import RtReportsPage from './pages/RtReportsPage'
 import RtWebsocketPage from './pages/RtWebsocketPage'
 import AiWorkbenchPage from './pages/AiWorkbenchPage'
 import Text2SqlPage from './pages/Text2SqlPage'
+
+// 新版设计体系页面（tailwind token 体系），lazy 分割不增加旧页面首屏
+const MarketDashboardPage = lazy(() => import('./pages/MarketDashboardPage'))
+const WatchlistPage = lazy(() => import('./pages/WatchlistPage'))
+const DragonTigerPage = lazy(() => import('./pages/DragonTigerPage'))
+const DataSourceCenterPage = lazy(() => import('./pages/DataSourceCenterPage'))
 
 /** 旧版 Flask 前端地址：开发态 Vite 与 Flask 不同端口，直接指向 5000；构建产物由 Flask 同源托管时为空串 */
 export const OLD_SITE_BASE = import.meta.env.DEV ? 'http://127.0.0.1:5000' : ''
@@ -82,8 +89,19 @@ const NAV_GROUPS: NavGroup[] = [
     ],
   },
   {
+    label: '市场',
+    items: [
+      { to: '/market/dashboard', label: '市场看板', icon: '📊' },
+      { to: '/market/watchlist', label: '自选行情', icon: '⭐' },
+      { to: '/market/dragon-tiger', label: '龙虎榜', icon: '🐉' },
+    ],
+  },
+  {
     label: '数据',
-    items: [{ to: '/data-management', label: '数据管理', icon: '🗄️' }],
+    items: [
+      { to: '/data-management', label: '数据管理', icon: '🗄️' },
+      { to: '/datasources', label: '数据源中心', icon: '🧭' },
+    ],
   },
   {
     label: '试用工具',
@@ -160,6 +178,38 @@ function Shell() {
             <Route path="/stock-panorama" element={<StockPanoramaPage />} />
             <Route path="/feature-intro" element={<FeatureIntroPage />} />
             <Route path="/data-management" element={<DataManagementPage />} />
+            <Route
+              path="/market/dashboard"
+              element={
+                <Suspense fallback={null}>
+                  <MarketDashboardPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/market/watchlist"
+              element={
+                <Suspense fallback={null}>
+                  <WatchlistPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/market/dragon-tiger"
+              element={
+                <Suspense fallback={null}>
+                  <DragonTigerPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/datasources"
+              element={
+                <Suspense fallback={null}>
+                  <DataSourceCenterPage />
+                </Suspense>
+              }
+            />
             <Route path="/ml-factor" element={<MlFactorIndexPage />} />
             <Route path="/ml-factor/models" element={<MlModelsPage />} />
             <Route path="/ml-factor/scoring" element={<MlScoringPage />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,9 @@ import Text2SqlPage from './pages/Text2SqlPage'
 const MarketDashboardPage = lazy(() => import('./pages/MarketDashboardPage'))
 const WatchlistPage = lazy(() => import('./pages/WatchlistPage'))
 const DragonTigerPage = lazy(() => import('./pages/DragonTigerPage'))
+const LimitUpLadderPage = lazy(() => import('./pages/LimitUpLadderPage'))
+const ConceptAnalysisPage = lazy(() => import('./pages/ConceptAnalysisPage'))
+const IndustryAnalysisPage = lazy(() => import('./pages/IndustryAnalysisPage'))
 const DataSourceCenterPage = lazy(() => import('./pages/DataSourceCenterPage'))
 
 /** 旧版 Flask 前端地址：开发态 Vite 与 Flask 不同端口，直接指向 5000；构建产物由 Flask 同源托管时为空串 */
@@ -93,6 +96,9 @@ const NAV_GROUPS: NavGroup[] = [
     items: [
       { to: '/market/dashboard', label: '市场看板', icon: '📊' },
       { to: '/market/watchlist', label: '自选行情', icon: '⭐' },
+      { to: '/market/limit-up', label: '连板天梯', icon: '🔥' },
+      { to: '/market/concepts', label: '概念分析', icon: '💡' },
+      { to: '/market/industries', label: '行业分析', icon: '🏭' },
       { to: '/market/dragon-tiger', label: '龙虎榜', icon: '🐉' },
     ],
   },
@@ -199,6 +205,30 @@ function Shell() {
               element={
                 <Suspense fallback={null}>
                   <DragonTigerPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/market/limit-up"
+              element={
+                <Suspense fallback={null}>
+                  <LimitUpLadderPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/market/concepts"
+              element={
+                <Suspense fallback={null}>
+                  <ConceptAnalysisPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/market/industries"
+              element={
+                <Suspense fallback={null}>
+                  <IndustryAnalysisPage />
                 </Suspense>
               }
             />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,7 @@ const MarketDashboardPage = lazy(() => import('./pages/MarketDashboardPage'))
 const WatchlistPage = lazy(() => import('./pages/WatchlistPage'))
 const DragonTigerPage = lazy(() => import('./pages/DragonTigerPage'))
 const LimitUpLadderPage = lazy(() => import('./pages/LimitUpLadderPage'))
+const HotStocksPage = lazy(() => import('./pages/HotStocksPage'))
 const ConceptAnalysisPage = lazy(() => import('./pages/ConceptAnalysisPage'))
 const IndustryAnalysisPage = lazy(() => import('./pages/IndustryAnalysisPage'))
 const DataSourceCenterPage = lazy(() => import('./pages/DataSourceCenterPage'))
@@ -97,6 +98,7 @@ const NAV_GROUPS: NavGroup[] = [
       { to: '/market/dashboard', label: '市场看板', icon: '📊' },
       { to: '/market/watchlist', label: '自选行情', icon: '⭐' },
       { to: '/market/limit-up', label: '连板天梯', icon: '🔥' },
+      { to: '/market/hot', label: '热股榜单', icon: '📈' },
       { to: '/market/concepts', label: '概念分析', icon: '💡' },
       { to: '/market/industries', label: '行业分析', icon: '🏭' },
       { to: '/market/dragon-tiger', label: '龙虎榜', icon: '🐉' },
@@ -213,6 +215,14 @@ function Shell() {
               element={
                 <Suspense fallback={null}>
                   <LimitUpLadderPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/market/hot"
+              element={
+                <Suspense fallback={null}>
+                  <HotStocksPage />
                 </Suspense>
               }
             />

--- a/frontend/src/api/market.ts
+++ b/frontend/src/api/market.ts
@@ -1,0 +1,128 @@
+import { apiGet } from './client'
+
+// ================= 行情与数据源 /api/market、/api/datasources（信封 {code,message,data}） =================
+
+export interface QuoteRow {
+  ts_code: string
+  name: string | null
+  last_price: number | null
+  open: number | null
+  high: number | null
+  low: number | null
+  prev_close: number | null
+  change: number | null
+  pct_chg: number | null
+  volume: number | null
+  turnover: number | null
+}
+
+export interface IndexQuote {
+  ts_code: string
+  last_price: number | null
+  pct_chg: number | null
+}
+
+export interface BoardRow {
+  ts_code: string
+  name: string | null
+  price: number | null
+  pct_chg: number | null
+  amount_yuan: number | null
+}
+
+export interface MarketDashboard {
+  breadth: {
+    up: number
+    down: number
+    flat: number
+    limit_up: number
+    limit_down: number
+    total: number
+  }
+  distribution: { bucket: string; count: number }[]
+  total_amount_yuan: number
+  top_gainers: BoardRow[]
+  top_losers: BoardRow[]
+  top_amount: BoardRow[]
+  degraded: boolean
+  degraded_reason?: string
+  source: 'fuyao' | 'local_parquet' | 'none'
+  as_of: string | null
+  server_ts?: number | null
+}
+
+/** 龙虎榜个股（实测字段 2026-09；change 为小数比例 0.0875=8.75%） */
+export interface DragonTigerStock {
+  thscode: string
+  ticker?: string
+  name?: string
+  concept_list?: { name: string }[]
+  change?: number
+  net_value?: number
+  net_rate?: number
+  hot_rank?: number
+  buy_value?: number
+  sell_value?: number
+  limit_reason?: string
+  range_days?: number
+  org_net_value?: number
+  org_buy_num?: number
+  org_sell_num?: number
+  hot_money_net_value?: number
+  [key: string]: unknown
+}
+
+export interface DragonTigerPayload {
+  trade_date?: string
+  count?: number
+  stock_count?: number
+  stock_items?: DragonTigerStock[]
+  org_items?: DragonTigerStock[]
+  hot_money_items?: DragonTigerStock[]
+  [key: string]: unknown
+}
+
+export interface AuctionBenchmarkItem {
+  thscode: string
+  ticker?: string
+  name?: string
+  auction_pct?: number
+  tags?: string[]
+  [key: string]: unknown
+}
+
+export interface SourceStatus {
+  checked_at: number
+  tushare: { configured: boolean }
+  fuyao: { configured: boolean; ok?: boolean; error?: string | null }
+  tickflow: { configured: boolean; tier: 'none' | 'free' | 'paid' }
+}
+
+export function fetchDashboard() {
+  return apiGet<MarketDashboard>('/market/dashboard', undefined, 30_000)
+}
+
+export function fetchQuotes(codes: string[]) {
+  return apiGet<{ quotes: Record<string, QuoteRow> }>('/market/snapshot', {
+    codes: codes.join(','),
+  })
+}
+
+export function fetchIndices(codes?: string[]) {
+  return apiGet<{ indices: IndexQuote[] }>('/market/indices', codes ? { codes: codes.join(',') } : undefined)
+}
+
+export function fetchDragonTiger(board: 'all' | 'org' | 'hot_money' = 'all', date?: string) {
+  return apiGet<DragonTigerPayload>('/market/dragon-tiger', { board, date: date || undefined })
+}
+
+export function fetchAuctionBenchmark(date?: string) {
+  return apiGet<{ date?: string; date_ms?: number; item: AuctionBenchmarkItem[] }>(
+    '/market/auction-benchmark',
+    { date: date || undefined },
+  )
+}
+
+export function fetchSourceStatus(force = false) {
+  return apiGet<SourceStatus>('/datasources/status', force ? { force: 1 } : undefined)
+}

--- a/frontend/src/api/market.ts
+++ b/frontend/src/api/market.ts
@@ -208,3 +208,84 @@ export function fetchBoardConstituents(code: string) {
     { code },
   )
 }
+
+// ================= 跌停池 / 炸板池 / 热股榜 / 标的检索 =================
+
+/** 跌停池个股（实测字段 2026-09） */
+export interface LimitDownStock {
+  ts_code: string
+  ticker?: string
+  name?: string
+  last_price?: number
+  pct_chg?: number
+  first_limit_time?: string
+  last_limit_time?: string
+  turnover_ratio_pct?: number
+  [key: string]: unknown
+}
+
+/** 炸板池个股（曾涨停后开板） */
+export interface LimitBreakStock {
+  ts_code: string
+  ticker?: string
+  name?: string
+  last_price?: number
+  pct_chg?: number
+  open_times?: number
+  turnover_ratio_pct?: number
+  turnover?: number
+  [key: string]: unknown
+}
+
+export type HotPeriod = 'day' | 'hour'
+
+/** 热股榜/飙升榜个股 */
+export interface HotStock {
+  ts_code: string
+  ticker?: string
+  name?: string
+  rank?: number
+  heat?: number | null
+  rank_change?: number
+  rank_trend?: 'up' | 'down' | 'flat' | string
+  [key: string]: unknown
+}
+
+export interface TickerSearchItem {
+  ts_code: string
+  ticker?: string
+  name?: string
+  exchange?: string
+}
+
+function poolParams(date?: string, page = 1, size = 100) {
+  return { date: date || undefined, page, size }
+}
+
+export function fetchLimitDownPool(date?: string, page = 1, size = 100) {
+  return apiGet<LimitUpPoolPayload & { items: LimitDownStock[] }>(
+    '/market/limit-down/pool',
+    poolParams(date, page, size),
+  )
+}
+
+export function fetchLimitBreakPool(date?: string, page = 1, size = 100) {
+  return apiGet<LimitUpPoolPayload & { items: LimitBreakStock[] }>(
+    '/market/limit-break/pool',
+    poolParams(date, page, size),
+  )
+}
+
+export function fetchHotStocks(period: HotPeriod = 'day') {
+  return apiGet<{ period: HotPeriod; hot: HotStock[]; skyrocket: HotStock[] }>(
+    '/market/hot-stocks',
+    { period },
+  )
+}
+
+export function fetchTickerSearch(q: string, limit = 8) {
+  return apiGet<{ query: string; items: TickerSearchItem[] }>('/market/ticker-search', {
+    q,
+    limit,
+  })
+}

--- a/frontend/src/api/market.ts
+++ b/frontend/src/api/market.ts
@@ -126,3 +126,85 @@ export function fetchAuctionBenchmark(date?: string) {
 export function fetchSourceStatus(force = false) {
   return apiGet<SourceStatus>('/datasources/status', force ? { force: 1 } : undefined)
 }
+
+// ================= 涨停池 / 连板天梯 / 同花顺板块 =================
+
+/** 涨停池个股（实测字段 2026-09；seal_money 单位为元） */
+export interface LimitUpStock {
+  ts_code: string
+  ticker?: string
+  name?: string
+  is_st?: boolean
+  is_new?: boolean
+  last_price?: number
+  pct_chg?: number
+  limit_up_time?: string
+  reason?: string
+  continue_day_text?: string
+  continue_day_cnt?: number
+  seal_money?: number
+  max_seal_money?: number
+  [key: string]: unknown
+}
+
+export interface LimitUpPoolPayload {
+  date: string
+  total: number
+  page: number
+  size: number
+  items: LimitUpStock[]
+  cached?: boolean
+  stale?: boolean
+}
+
+/** 连板天梯单日（counts 键为连板数字符串，"7" 即 7 板及以上） */
+export interface LadderDay {
+  date: string | null
+  counts: Record<string, number>
+  highest: number
+  total: number
+}
+
+/** 同花顺板块（行业/概念）排行行 */
+export interface ThsBoardRow {
+  thscode: string
+  name?: string
+  last_price?: number
+  pct_chg?: number
+  turnover_yuan?: number
+  volume?: number
+}
+
+export interface BoardConstituent {
+  ts_code: string
+  name?: string | null
+  last_price?: number | null
+  pct_chg?: number | null
+  amount_yuan?: number | null
+}
+
+export function fetchLimitUpPool(date?: string, page = 1, size = 100) {
+  return apiGet<LimitUpPoolPayload>('/market/limit-up/pool', {
+    date: date || undefined,
+    page,
+    size,
+  })
+}
+
+export function fetchLimitUpLadder() {
+  return apiGet<{ days: LadderDay[] }>('/market/limit-up/ladder')
+}
+
+export function fetchBoards(tag: 'industry' | 'cn_concept') {
+  return apiGet<{ tag: string; items: ThsBoardRow[]; unavailable: string[] }>(
+    '/market/boards',
+    { tag },
+  )
+}
+
+export function fetchBoardConstituents(code: string) {
+  return apiGet<{ code: string; total: number; items: BoardConstituent[] }>(
+    '/market/boards/constituents',
+    { code },
+  )
+}

--- a/frontend/src/components/stock/StockLink.tsx
+++ b/frontend/src/components/stock/StockLink.tsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom'
+import { cn } from '../../lib/cn'
+
+interface StockLinkProps {
+  /** ts_code 形式（600000.SH）或同花顺 thscode */
+  code: string
+  name?: string | null
+  /** 显示的文本；默认 `名称 代码`，传 showCode=false 只显示名称 */
+  showCode?: boolean
+  className?: string
+}
+
+/** 个股链接：跳转到既有详情页 /stock/:tsCode（悬停显主题色，下划线由下划线偏移衬托） */
+export function StockLink({ code, name, showCode = true, className }: StockLinkProps) {
+  const label = name || code
+  return (
+    <Link
+      to={`/stock/${encodeURIComponent(code)}`}
+      title={`查看 ${label} 详情`}
+      className={cn(
+        'group inline-flex items-baseline gap-1.5 rounded-sm transition-colors hover:text-accent',
+        className,
+      )}
+    >
+      {showCode ? <span className="num text-fg-muted group-hover:text-accent/80">{code}</span> : null}
+      <span className={cn(showCode && 'text-fg-secondary')}>{name ?? ''}</span>
+      {!showCode && !name ? <span className="num">{code}</span> : null}
+    </Link>
+  )
+}

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react'
+import { cn } from '../../lib/cn'
+
+/** 空态：图标 + 标题 + 引导文案（+ 可选动作） */
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  className,
+}: {
+  icon?: ReactNode
+  title: ReactNode
+  description?: ReactNode
+  action?: ReactNode
+  className?: string
+}) {
+  return (
+    <div className={cn('flex flex-col items-center justify-center gap-1.5 px-6 py-10 text-center', className)}>
+      {icon ? <div className="text-fg-muted opacity-70">{icon}</div> : null}
+      <div className="text-sm font-medium">{title}</div>
+      {description ? <div className="max-w-sm text-xs leading-5 text-fg-muted">{description}</div> : null}
+      {action ? <div className="mt-2">{action}</div> : null}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+import { X } from 'lucide-react'
+import { cn } from '../../lib/cn'
+
+/**
+ * 无依赖模态原语（参考 tick-stock-panel Modal 模式）：
+ * ESC 关闭、点击遮罩关闭、焦点陷阱、aria 属性。
+ */
+export function Modal({
+  open,
+  onClose,
+  title,
+  children,
+  width = 'max-w-2xl',
+}: {
+  open: boolean
+  onClose: () => void
+  title: ReactNode
+  children: ReactNode
+  width?: string
+}) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation()
+        onClose()
+        return
+      }
+      if (event.key === 'Tab' && panelRef.current) {
+        // 简易焦点陷阱：Tab 循环限制在面板内
+        const focusables = panelRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        )
+        if (focusables.length === 0) return
+        const first = focusables[0]
+        const last = focusables[focusables.length - 1]
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault()
+          last.focus()
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault()
+          first.focus()
+        }
+      }
+    }
+    document.addEventListener('keydown', onKey, true)
+    return () => document.removeEventListener('keydown', onKey, true)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/60 p-4 pt-[8vh]"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose()
+      }}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        className={cn(
+          'w-full rounded-dialog border border-line bg-surface shadow-xl',
+          'animate-[modal-in_.16s_ease-smooth]',
+          width,
+        )}
+      >
+        <div className="flex items-center justify-between border-b border-line px-4 py-2.5">
+          <div className="text-sm font-semibold">{title}</div>
+          <button
+            type="button"
+            aria-label="关闭"
+            onClick={onClose}
+            className="rounded-btn p-1 text-fg-muted transition-colors hover:bg-elevated hover:text-fg-primary"
+          >
+            <X size={15} />
+          </button>
+        </div>
+        <div className="max-h-[72vh] overflow-y-auto p-4">{children}</div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,0 +1,3 @@
+export { Card, SectionTitle, PageHeader, Badge, Delta, KpiCell, SkeletonRows } from './primitives'
+export { Modal } from './Modal'
+export { EmptyState } from './EmptyState'

--- a/frontend/src/components/ui/primitives.tsx
+++ b/frontend/src/components/ui/primitives.tsx
@@ -1,0 +1,170 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+import { cn } from '../../lib/cn'
+
+/**
+ * 新版卡片（1px 边框分层，暗色不用阴影）。
+ * 统一公式：rounded-card border bg-surface + hover 微亮。
+ */
+export function Card({ className, children, ...rest }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        'rounded-card border border-line bg-surface/80 backdrop-blur-sm',
+        'transition-colors duration-150 ease-smooth hover:bg-surface',
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </div>
+  )
+}
+
+/** 区块标题：accent 渐变竖条 + 图标 + 右侧提示 */
+export function SectionTitle({
+  icon,
+  title,
+  hint,
+  right,
+  className,
+}: {
+  icon?: ReactNode
+  title: ReactNode
+  hint?: ReactNode
+  right?: ReactNode
+  className?: string
+}) {
+  return (
+    <div className={cn('flex items-center justify-between gap-2 px-3 py-2', className)}>
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="h-3.5 w-[3px] shrink-0 rounded-full bg-gradient-to-b from-accent to-accent/30" />
+        {icon ? <span className="text-fg-muted">{icon}</span> : null}
+        <span className="truncate text-sm font-semibold">{title}</span>
+        {hint ? <span className="num text-2xs text-fg-muted">{hint}</span> : null}
+      </div>
+      {right ? <div className="shrink-0 text-xs text-fg-muted">{right}</div> : null}
+    </div>
+  )
+}
+
+/** 页头：细线下边框 + 标题 + 副标题 + 右侧操作槽 */
+export function PageHeader({
+  title,
+  subtitle,
+  right,
+}: {
+  title: ReactNode
+  subtitle?: ReactNode
+  right?: ReactNode
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-line px-4 py-2.5">
+      <div className="min-w-0">
+        <h1 className="truncate text-lg font-semibold leading-tight">{title}</h1>
+        {subtitle ? <div className="mt-0.5 truncate text-xs text-fg-muted">{subtitle}</div> : null}
+      </div>
+      {right ? <div className="flex shrink-0 items-center gap-2">{right}</div> : null}
+    </div>
+  )
+}
+
+/** 半透明同色 pill 徽章 */
+export function Badge({
+  tone = 'neutral',
+  className,
+  children,
+}: {
+  tone?: 'neutral' | 'accent' | 'bull' | 'bear' | 'warning' | 'danger'
+  className?: string
+  children: ReactNode
+}) {
+  const tones: Record<string, string> = {
+    neutral: 'bg-elevated text-fg-secondary border-line',
+    accent: 'bg-accent/12 text-accent border-accent/25',
+    bull: 'bg-bull/12 text-bull border-bull/25',
+    bear: 'bg-bear/12 text-bear border-bear/25',
+    warning: 'bg-warning/12 text-warning border-warning/25',
+    danger: 'bg-danger/12 text-danger border-danger/25',
+  }
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full border px-1.5 py-px text-2xs leading-4',
+        tones[tone],
+        className,
+      )}
+    >
+      {children}
+    </span>
+  )
+}
+
+/** 涨跌着色数字（A 股口径：红涨绿跌），接受百分数数值；带箭头时省略负号 */
+export function Delta({
+  value,
+  suffix = '%',
+  digits = 2,
+  arrow = true,
+  className,
+}: {
+  value: number | null | undefined
+  suffix?: string
+  digits?: number
+  arrow?: boolean
+  className?: string
+}) {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return <span className={cn('num text-fg-muted', className)}>--</span>
+  }
+  const tone = value > 0 ? 'text-bull' : value < 0 ? 'text-bear' : 'text-fg-muted'
+  const sign = value > 0 ? '+' : ''
+  const prefix = arrow ? (value > 0 ? '▲' : value < 0 ? '▼' : '') : sign
+  const magnitude = arrow && value < 0 ? Math.abs(value) : value
+  return (
+    <span className={cn('num', tone, className)}>
+      {prefix}
+      {magnitude.toFixed(digits)}
+      {suffix}
+    </span>
+  )
+}
+
+/** KPI 统计格：11px 标签 + mono 数值 + 副标 */
+export function KpiCell({
+  label,
+  value,
+  sub,
+  tone,
+}: {
+  label: ReactNode
+  value: ReactNode
+  sub?: ReactNode
+  tone?: 'bull' | 'bear' | 'accent' | 'neutral'
+}) {
+  const toneClass =
+    tone === 'bull'
+      ? 'text-bull'
+      : tone === 'bear'
+        ? 'text-bear'
+        : tone === 'accent'
+          ? 'text-accent'
+          : 'text-fg-primary'
+  return (
+    <div className="rounded-card border border-line bg-elevated/50 px-2.5 py-2">
+      <div className="text-2xs text-fg-muted">{label}</div>
+      <div className={cn('num mt-0.5 text-lg font-semibold leading-6', toneClass)}>{value}</div>
+      {sub ? <div className="num text-2xs text-fg-muted">{sub}</div> : null}
+    </div>
+  )
+}
+
+/** 加载骨架行 */
+export function SkeletonRows({ rows = 6, className }: { rows?: number; className?: string }) {
+  return (
+    <div className={cn('space-y-1.5 p-3', className)}>
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="h-4 animate-pulse rounded-sm bg-elevated" style={{ opacity: 1 - i * 0.12 }} />
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/lib/cn.ts
+++ b/frontend/src/lib/cn.ts
@@ -1,0 +1,7 @@
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+/** 合并 className（条件类 + tailwind 类冲突消解） */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,14 +1,28 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import './styles/theme.css'
+import './styles/tsp.css'
 import App from './App'
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5_000,
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+  },
+})
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
   </React.StrictMode>,
 )

--- a/frontend/src/pages/BoardAnalysisPage.tsx
+++ b/frontend/src/pages/BoardAnalysisPage.tsx
@@ -1,0 +1,208 @@
+import { useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Layers, RefreshCw, Search } from 'lucide-react'
+import {
+  fetchBoardConstituents,
+  fetchBoards,
+  type ThsBoardRow,
+} from '../api/market'
+import { StockLink } from '../components/stock/StockLink'
+import { Card, Delta, EmptyState, PageHeader, SectionTitle, SkeletonRows } from '../components/ui'
+import { cn } from '../lib/cn'
+
+function yi(amount: number | null | undefined): string {
+  if (amount === null || amount === undefined) return '--'
+  const value = amount / 1e8
+  return value >= 100 ? `${value.toFixed(0)}亿` : `${value.toFixed(2)}亿`
+}
+
+interface BoardAnalysisPageProps {
+  tag: 'industry' | 'cn_concept'
+  title: string
+  subtitle: string
+}
+
+/** 行业/概念分析共用页：板块涨跌排行 + 选中板块的成分股行情 */
+export default function BoardAnalysisPage({ tag, title, subtitle }: BoardAnalysisPageProps) {
+  const [keyword, setKeyword] = useState('')
+  const [selected, setSelected] = useState<ThsBoardRow | null>(null)
+
+  const boardsQuery = useQuery({
+    queryKey: ['market', 'boards', tag],
+    queryFn: () => fetchBoards(tag),
+    refetchInterval: 60_000,
+  })
+
+  const constituentsQuery = useQuery({
+    queryKey: ['market', 'board-constituents', selected?.thscode],
+    queryFn: () => fetchBoardConstituents(selected!.thscode),
+    enabled: Boolean(selected?.thscode),
+  })
+
+  const items = boardsQuery.data?.items ?? []
+  const filtered = useMemo(() => {
+    const text = keyword.trim().toLowerCase()
+    if (!text) return items
+    return items.filter(
+      (row) =>
+        (row.name ?? '').toLowerCase().includes(text) ||
+        row.thscode.toLowerCase().includes(text),
+    )
+  }, [items, keyword])
+
+  return (
+    <div className="tsp-root min-h-full">
+      <PageHeader
+        title={title}
+        subtitle={subtitle}
+        right={
+          <button
+            type="button"
+            onClick={() => boardsQuery.refetch()}
+            className="inline-flex items-center gap-1.5 rounded-btn border border-line px-2.5 py-1 text-xs text-fg-secondary transition-colors hover:bg-elevated hover:text-fg-primary"
+          >
+            <RefreshCw size={12} className={boardsQuery.isFetching ? 'animate-spin' : ''} /> 刷新
+          </button>
+        }
+      />
+
+      <div className="grid grid-cols-1 gap-1.5 p-1.5 xl:grid-cols-[26rem_1fr]">
+        {/* 左列：板块排行 */}
+        <Card className="p-0">
+          <SectionTitle
+            icon={<Layers size={13} />}
+            title="板块涨跌排行"
+            hint={`${filtered.length}/${items.length} 个板块`}
+            right={
+              <div className="flex items-center gap-1 rounded-input border border-line bg-elevated/50 px-1.5 py-0.5">
+                <Search size={11} className="text-fg-muted" />
+                <input
+                  value={keyword}
+                  onChange={(event) => setKeyword(event.target.value)}
+                  placeholder="搜索板块"
+                  className="w-24 bg-transparent text-2xs outline-none placeholder:text-fg-muted"
+                />
+              </div>
+            }
+          />
+          {boardsQuery.isLoading ? (
+            <SkeletonRows rows={10} />
+          ) : boardsQuery.isError ? (
+            <EmptyState
+              title="板块数据加载失败"
+              description={(boardsQuery.error as Error)?.message}
+              action={
+                <button
+                  type="button"
+                  className="rounded-btn border border-line px-2.5 py-1 text-xs text-fg-secondary hover:bg-elevated"
+                  onClick={() => boardsQuery.refetch()}
+                >
+                  重试
+                </button>
+              }
+            />
+          ) : filtered.length === 0 ? (
+            <EmptyState title="没有匹配的板块" description="换个关键词试试。" />
+          ) : (
+            <div className="max-h-[calc(100vh-12rem)] overflow-y-auto">
+              <table className="w-full border-collapse text-xs">
+                <thead className="sticky top-0 z-10 bg-surface">
+                  <tr className="border-b border-line text-left text-2xs text-fg-muted">
+                    <th className="w-8 px-2 py-1.5 text-center font-medium">#</th>
+                    <th className="px-2 py-1.5 font-medium">板块</th>
+                    <th className="px-2 py-1.5 text-right font-medium">涨跌幅</th>
+                    <th className="px-2 py-1.5 text-right font-medium">成交额</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtered.map((row, index) => (
+                    <tr
+                      key={row.thscode}
+                      onClick={() => setSelected(row)}
+                      className={cn(
+                        'cursor-pointer border-t border-line/60 transition-colors hover:bg-elevated/60',
+                        selected?.thscode === row.thscode && 'bg-accent/8',
+                      )}
+                    >
+                      <td className="num px-2 py-1.5 text-center text-2xs text-fg-muted">{index + 1}</td>
+                      <td className="px-2 py-1.5">
+                        <div className="font-medium">{row.name ?? row.thscode}</div>
+                        <div className="num text-2xs text-fg-muted">{row.thscode}</div>
+                      </td>
+                      <td className="px-2 py-1.5 text-right">
+                        <Delta value={row.pct_chg} />
+                      </td>
+                      <td className="num px-2 py-1.5 text-right text-fg-secondary">{yi(row.turnover_yuan)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </Card>
+
+        {/* 右列：选中板块成分股 */}
+        <Card className="p-0">
+          <SectionTitle
+            title={selected ? `${selected.name ?? selected.thscode} · 成分股` : '成分股'}
+            hint={
+              constituentsQuery.data?.total != null
+                ? `${constituentsQuery.data.total} 只 · 点击板块查看`
+                : '点击左侧板块查看成分股'
+            }
+          />
+          {!selected ? (
+            <EmptyState
+              icon={<Layers size={22} />}
+              title="选择一个板块"
+              description="在左侧点击任意板块，查看其成分股与实时行情。"
+            />
+          ) : constituentsQuery.isLoading ? (
+            <SkeletonRows rows={10} />
+          ) : constituentsQuery.isError ? (
+            <EmptyState
+              title="成分股加载失败"
+              description={(constituentsQuery.error as Error)?.message}
+              action={
+                <button
+                  type="button"
+                  className="rounded-btn border border-line px-2.5 py-1 text-xs text-fg-secondary hover:bg-elevated"
+                  onClick={() => constituentsQuery.refetch()}
+                >
+                  重试
+                </button>
+              }
+            />
+          ) : (
+            <div className="max-h-[calc(100vh-12rem)] overflow-y-auto px-0.5 pb-0.5">
+              <table className="w-full border-collapse text-xs">
+                <thead className="sticky top-0 z-10 bg-surface">
+                  <tr className="border-b border-line text-left text-2xs text-fg-muted">
+                    <th className="px-3 py-1.5 font-medium">个股</th>
+                    <th className="px-3 py-1.5 text-right font-medium">现价</th>
+                    <th className="px-3 py-1.5 text-right font-medium">涨跌幅</th>
+                    <th className="px-3 py-1.5 text-right font-medium">成交额</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(constituentsQuery.data?.items ?? []).map((row, index) => (
+                    <tr key={`${row.ts_code}-${index}`} className="border-t border-line/60 hover:bg-elevated/50">
+                      <td className="px-3 py-1.5">
+                        <StockLink code={row.ts_code} name={row.name} />
+                      </td>
+                      <td className="num px-3 py-1.5 text-right">{row.last_price ?? '--'}</td>
+                      <td className="px-3 py-1.5 text-right">
+                        <Delta value={row.pct_chg} />
+                      </td>
+                      <td className="num px-3 py-1.5 text-right text-fg-secondary">{yi(row.amount_yuan)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/ConceptAnalysisPage.tsx
+++ b/frontend/src/pages/ConceptAnalysisPage.tsx
@@ -1,0 +1,11 @@
+import BoardAnalysisPage from './BoardAnalysisPage'
+
+export default function ConceptAnalysisPage() {
+  return (
+    <BoardAnalysisPage
+      tag="cn_concept"
+      title="概念分析"
+      subtitle="同花顺概念板块实时涨跌排行 · 60s 自动刷新 · 点击板块查看成分股"
+    />
+  )
+}

--- a/frontend/src/pages/DataSourceCenterPage.tsx
+++ b/frontend/src/pages/DataSourceCenterPage.tsx
@@ -1,0 +1,166 @@
+import { useQuery } from '@tanstack/react-query'
+import { CircleCheck, CircleX, Database, KeyRound, RefreshCw } from 'lucide-react'
+import { fetchSourceStatus, type SourceStatus } from '../api/market'
+import { Badge, Card, PageHeader, SectionTitle, SkeletonRows } from '../components/ui'
+import { cn } from '../lib/cn'
+
+interface SourceMeta {
+  key: keyof Omit<SourceStatus, 'checked_at'>
+  name: string
+  description: string
+  roles: string[]
+}
+
+const SOURCES: SourceMeta[] = [
+  {
+    key: 'tushare',
+    name: 'Tushare',
+    description: '历史估值、技术因子、资金流、筹码分布等日频数据的既有主干源。',
+    roles: ['daily_basic', 'stk_factor', 'moneyflow', 'cyq_perf', 'trade_calendar', '股票元数据'],
+  },
+  {
+    key: 'fuyao',
+    name: '扶摇（同花顺）',
+    description: '全市场日K dump、实时快照、财务三表、龙虎榜与竞价风向标；免费 key 可用。',
+    roles: ['daily_history（可选）', 'financial（可选）', '实时行情', '龙虎榜/风向标'],
+  },
+  {
+    key: 'tickflow',
+    name: 'TickFlow',
+    description: 'free 档仅支持单标的日K与少量实时行情（约 5rpm），定位为校验兜底源，勿用于批量任务。',
+    roles: ['校验兜底'],
+  },
+]
+
+function StatusBadge({ status }: { status: SourceStatus['fuyao'] & Partial<SourceStatus['tickflow']> }) {
+  if ('tier' in status && status.configured) {
+    if (status.tier === 'paid') return <Badge tone="accent">付费档</Badge>
+    if (status.tier === 'free') return <Badge tone="warning">免费档</Badge>
+  }
+  if (status.configured) {
+    if ('ok' in status) {
+      return status.ok ? (
+        <Badge tone="bull">
+          <CircleCheck size={10} /> 可用
+        </Badge>
+      ) : (
+        <Badge tone="danger">
+          <CircleX size={10} /> 异常
+        </Badge>
+      )
+    }
+    return (
+      <Badge tone="bull">
+        <CircleCheck size={10} /> 已配置
+      </Badge>
+    )
+  }
+  return <Badge tone="neutral">未配置</Badge>
+}
+
+export default function DataSourceCenterPage() {
+  const statusQuery = useQuery({
+    queryKey: ['datasources', 'status'],
+    queryFn: () => fetchSourceStatus(),
+    refetchInterval: 300_000,
+  })
+  const status = statusQuery.data
+
+  return (
+    <div className="tsp-root min-h-full">
+      <PageHeader
+        title="数据源中心"
+        subtitle="三个数据源的配置状态与健康探测 · 与数据管理页（任务执行）互补"
+        right={
+          <button
+            type="button"
+            onClick={() => statusQuery.refetch()}
+            className="inline-flex items-center gap-1.5 rounded-btn border border-line px-2.5 py-1 text-xs text-fg-secondary transition-colors hover:bg-elevated hover:text-fg-primary"
+          >
+            <RefreshCw size={12} className={statusQuery.isFetching ? 'animate-spin' : ''} /> 重新探测
+          </button>
+        }
+      />
+
+      <div className="space-y-1.5 p-1.5">
+        <div className="grid grid-cols-1 gap-1.5 lg:grid-cols-3">
+          {SOURCES.map((source) => {
+            const sourceStatus = status?.[source.key]
+            return (
+              <Card key={source.key} className="p-0">
+                <SectionTitle
+                  icon={<Database size={13} />}
+                  title={source.name}
+                  right={
+                    sourceStatus ? (
+                      <StatusBadge status={sourceStatus as SourceStatus['fuyao']} />
+                    ) : (
+                      <span className="text-2xs text-fg-muted">探测中…</span>
+                    )
+                  }
+                />
+                <div className="space-y-2 px-3 pb-3">
+                  <p className="text-xs leading-5 text-fg-secondary">{source.description}</p>
+                  <div className="flex flex-wrap gap-1">
+                    {source.roles.map((role) => (
+                      <span key={role} className="rounded-full border border-line bg-elevated/60 px-1.5 py-px text-2xs text-fg-secondary">
+                        {role}
+                      </span>
+                    ))}
+                  </div>
+                  {'error' in (sourceStatus ?? {}) && (sourceStatus as SourceStatus['fuyao']).error ? (
+                    <div className="rounded-input border border-danger/25 bg-danger/8 px-2 py-1.5 text-2xs leading-4 text-danger">
+                      {(sourceStatus as SourceStatus['fuyao']).error}
+                    </div>
+                  ) : null}
+                </div>
+              </Card>
+            )
+          })}
+        </div>
+
+        <Card className="p-0">
+          <SectionTitle
+            icon={<KeyRound size={13} />}
+            title="数据集 → 生产者"
+            hint="同一张 Parquet 表可有多个可选生产者"
+          />
+          {statusQuery.isLoading ? (
+            <SkeletonRows rows={5} />
+          ) : (
+            <table className="w-full border-collapse text-xs">
+              <thead>
+                <tr className="border-b border-line text-left text-2xs text-fg-muted">
+                  <th className="px-3 py-1.5 font-medium">数据集</th>
+                  <th className="px-3 py-1.5 font-medium">可用生产者</th>
+                  <th className="px-3 py-1.5 font-medium">说明</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[
+                  ['日线行情 daily_history', 'tushare / fuyao', '扶摇走全市场 dump，适合初始化与快速回补'],
+                  ['财务三表', 'tushare(VIP) / fuyao', '两源按报告期合并共存，互不覆盖'],
+                  ['股票清单 stock_basic', 'tushare / fuyao', '行业与退市股元数据以 tushare 为准'],
+                  ['日线指标 daily_basic', 'tushare', '扶摇估值仅有当日快照，无历史'],
+                  ['技术因子 / 资金流 / 筹码', 'tushare', '扶摇与 TickFlow 不提供'],
+                  ['实时行情 / 龙虎榜 / 风向标', 'fuyao', '免费 key 即可用'],
+                ].map(([dataset, producers, note]) => (
+                  <tr key={dataset} className={cn('border-t border-line/60 hover:bg-elevated/50')}>
+                    <td className="px-3 py-1.5">{dataset}</td>
+                    <td className="px-3 py-1.5 text-fg-secondary">{producers}</td>
+                    <td className="px-3 py-1.5 text-fg-muted">{note}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </Card>
+
+        <Card className="px-3 py-2 text-2xs leading-5 text-fg-muted">
+          凭证通过项目根目录 .env 管理：TUSHARE_TOKEN / FUYAO_API_KEY / TICKFLOW_API_KEY，互不影响；
+          任一数据源不可用不影响其余数据源的下载作业。
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/DragonTigerPage.tsx
+++ b/frontend/src/pages/DragonTigerPage.tsx
@@ -1,0 +1,211 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Flame, Ticket } from 'lucide-react'
+import { fetchAuctionBenchmark, fetchDragonTiger, type DragonTigerStock } from '../api/market'
+import { Badge, Card, Delta, EmptyState, PageHeader, SectionTitle, SkeletonRows } from '../components/ui'
+import { cn } from '../lib/cn'
+
+const BOARDS = [
+  { key: 'all', label: '全部' },
+  { key: 'org', label: '机构榜' },
+  { key: 'hot_money', label: '游资榜' },
+] as const
+
+type BoardKey = (typeof BOARDS)[number]['key']
+
+function fmtWan(value: unknown): string {
+  const num = typeof value === 'number' || typeof value === 'string' ? Number(value) : NaN
+  if (Number.isNaN(num)) return '--'
+  const yi = num / 1e8
+  if (Math.abs(yi) >= 1) return `${yi.toFixed(2)}亿`
+  const wan = num / 1e4
+  return `${wan.toFixed(0)}万`
+}
+
+function pickStockItems(payload: Record<string, unknown> | undefined, board: BoardKey): DragonTigerStock[] {
+  if (!payload) return []
+  if (board === 'org') return (payload.org_items as DragonTigerStock[]) ?? []
+  if (board === 'hot_money') return (payload.hot_money_items as DragonTigerStock[]) ?? []
+  return (payload.stock_items as DragonTigerStock[]) ?? []
+}
+
+function reasonOf(row: DragonTigerStock): string {
+  if (row.limit_reason) return String(row.limit_reason)
+  const concepts = (row.concept_list ?? []).map((item) => item?.name).filter(Boolean)
+  return concepts.join(' / ')
+}
+
+export default function DragonTigerPage() {
+  const [board, setBoard] = useState<BoardKey>('all')
+  const [date, setDate] = useState('')
+
+  const dragonQuery = useQuery({
+    queryKey: ['market', 'dragon-tiger', board, date],
+    queryFn: () => fetchDragonTiger(board, date || undefined),
+  })
+  const auctionQuery = useQuery({
+    queryKey: ['market', 'auction', date],
+    queryFn: () => fetchAuctionBenchmark(date || undefined),
+  })
+
+  const payload = dragonQuery.data as Record<string, unknown> | undefined
+  const stocks = pickStockItems(payload, board)
+  const tradeDate = (payload?.trade_date as string) ?? ''
+  const auctionItems = auctionQuery.data?.item ?? []
+
+  return (
+    <div className="tsp-root min-h-full">
+      <PageHeader
+        title="龙虎榜与竞价风向标"
+        subtitle={
+          tradeDate
+            ? `榜单日期 ${tradeDate} · 扶摇特色数据（当日数据缓存）`
+            : '扶摇特色数据 · 当日数据缓存'
+        }
+        right={
+          <input
+            type="date"
+            value={date}
+            max={new Date().toISOString().slice(0, 10)}
+            onChange={(event) => setDate(event.target.value)}
+            className="num rounded-input border border-line bg-elevated/50 px-2 py-1 text-xs outline-none focus:border-accent/60"
+          />
+        }
+      />
+
+      <div className="space-y-1.5 p-1.5">
+        {/* 榜单卡 */}
+        <Card className="p-0">
+          <SectionTitle
+            icon={<Flame size={13} />}
+            title="龙虎榜"
+            right={
+              <div className="flex items-center gap-1">
+                {BOARDS.map((item) => (
+                  <button
+                    key={item.key}
+                    type="button"
+                    onClick={() => setBoard(item.key)}
+                    className={cn(
+                      'rounded-btn px-2 py-0.5 text-xs transition-colors',
+                      board === item.key
+                        ? 'bg-accent/15 text-accent'
+                        : 'text-fg-muted hover:bg-elevated hover:text-fg-secondary',
+                    )}
+                  >
+                    {item.label}
+                  </button>
+                ))}
+              </div>
+            }
+          />
+
+          {dragonQuery.isLoading ? (
+            <SkeletonRows rows={8} />
+          ) : dragonQuery.isError ? (
+            <EmptyState
+              title="榜单加载失败"
+              description={(dragonQuery.error as Error)?.message}
+              action={
+                <button
+                  type="button"
+                  className="rounded-btn border border-line px-2.5 py-1 text-xs text-fg-secondary hover:bg-elevated"
+                  onClick={() => dragonQuery.refetch()}
+                >
+                  重试
+                </button>
+              }
+            />
+          ) : stocks.length === 0 ? (
+            <EmptyState
+              icon={<Flame size={22} />}
+              title="暂无榜单数据"
+              description="当日龙虎榜尚未发布，或所选日期无上榜个股。"
+            />
+          ) : (
+            <table className="w-full border-collapse text-xs">
+              <thead>
+                <tr className="border-b border-line text-left text-2xs text-fg-muted">
+                  <th className="px-3 py-1.5 font-medium">代码</th>
+                  <th className="px-3 py-1.5 font-medium">名称</th>
+                  <th className="px-3 py-1.5 text-right font-medium">涨跌幅</th>
+                  <th className="px-3 py-1.5 text-right font-medium">龙虎榜净买</th>
+                  <th className="px-3 py-1.5 text-right font-medium">买入额</th>
+                  <th className="px-3 py-1.5 text-right font-medium">卖出额</th>
+                  <th className="px-3 py-1.5 font-medium">上榜原因 / 概念</th>
+                </tr>
+              </thead>
+              <tbody>
+                {stocks.map((row, index) => (
+                  <tr key={`${row.thscode}-${index}`} className="border-t border-line/60 hover:bg-elevated/50">
+                    <td className="num px-3 py-1.5">{row.thscode || '--'}</td>
+                    <td className="px-3 py-1.5 text-fg-secondary">{row.name ?? '--'}</td>
+                    <td className="px-3 py-1.5 text-right">
+                      <Delta value={typeof row.change === 'number' ? row.change * 100 : null} />
+                    </td>
+                    <td className="num px-3 py-1.5 text-right">
+                      <span
+                        className={cn(
+                          'num',
+                          (row.net_value ?? 0) > 0 ? 'text-bull' : (row.net_value ?? 0) < 0 ? 'text-bear' : 'text-fg-muted',
+                        )}
+                      >
+                        {fmtWan(row.net_value)}
+                      </span>
+                    </td>
+                    <td className="num px-3 py-1.5 text-right text-fg-secondary">{fmtWan(row.buy_value)}</td>
+                    <td className="num px-3 py-1.5 text-right text-fg-secondary">{fmtWan(row.sell_value)}</td>
+                    <td className="max-w-[18rem] truncate px-3 py-1.5 text-fg-muted">{reasonOf(row) || '--'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </Card>
+
+        {/* 竞价风向标 */}
+        <Card className="p-0">
+          <SectionTitle
+            icon={<Ticket size={13} />}
+            title="盘前竞价短线风向标"
+            hint={auctionQuery.data?.date ? `日期 ${auctionQuery.data.date}` : '当日'}
+          />
+          {auctionQuery.isLoading ? (
+            <SkeletonRows rows={3} />
+          ) : auctionItems.length === 0 ? (
+            <EmptyState
+              icon={<Ticket size={20} />}
+              title="今日暂无风向标"
+              description="竞价风向标每个交易日盘前更新（每日约 5~6 只），当日非盘前时段可能为空，可选择历史日期查看。"
+            />
+          ) : (
+            <div className="grid grid-cols-1 gap-1.5 p-3 md:grid-cols-2 xl:grid-cols-3">
+              {auctionItems.map((item, index) => (
+                <div
+                  key={`${item.thscode}-${index}`}
+                  className="flex items-center justify-between rounded-card border border-line bg-elevated/40 px-3 py-2"
+                >
+                  <div>
+                    <div className="num text-xs">{item.thscode}</div>
+                    <div className="text-sm font-medium">{item.name ?? item.ticker ?? '--'}</div>
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {(item.tags ?? []).map((tag) => (
+                        <Badge key={tag} tone="accent">
+                          {tag}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <div className="text-2xs text-fg-muted">竞价涨幅</div>
+                    <Delta value={item.auction_pct} className="text-base font-semibold" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/DragonTigerPage.tsx
+++ b/frontend/src/pages/DragonTigerPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Flame, Ticket } from 'lucide-react'
 import { fetchAuctionBenchmark, fetchDragonTiger, type DragonTigerStock } from '../api/market'
+import { StockLink } from '../components/stock/StockLink'
 import { Badge, Card, Delta, EmptyState, PageHeader, SectionTitle, SkeletonRows } from '../components/ui'
 import { cn } from '../lib/cn'
 
@@ -138,8 +139,16 @@ export default function DragonTigerPage() {
               <tbody>
                 {stocks.map((row, index) => (
                   <tr key={`${row.thscode}-${index}`} className="border-t border-line/60 hover:bg-elevated/50">
-                    <td className="num px-3 py-1.5">{row.thscode || '--'}</td>
-                    <td className="px-3 py-1.5 text-fg-secondary">{row.name ?? '--'}</td>
+                    <td className="px-3 py-1.5">
+                      {row.thscode ? <StockLink code={row.thscode} name={row.name} /> : '--'}
+                    </td>
+                    <td className="px-3 py-1.5 text-fg-secondary">
+                      {row.thscode ? (
+                        <StockLink code={row.thscode} name={row.name} showCode={false} />
+                      ) : (
+                        row.name ?? '--'
+                      )}
+                    </td>
                     <td className="px-3 py-1.5 text-right">
                       <Delta value={typeof row.change === 'number' ? row.change * 100 : null} />
                     </td>
@@ -186,8 +195,14 @@ export default function DragonTigerPage() {
                   className="flex items-center justify-between rounded-card border border-line bg-elevated/40 px-3 py-2"
                 >
                   <div>
-                    <div className="num text-xs">{item.thscode}</div>
-                    <div className="text-sm font-medium">{item.name ?? item.ticker ?? '--'}</div>
+                    <div className="num text-xs text-fg-muted">{item.thscode}</div>
+                    <div className="text-sm font-medium">
+                      {item.thscode ? (
+                        <StockLink code={item.thscode} name={item.name ?? item.ticker} showCode={false} />
+                      ) : (
+                        item.name ?? '--'
+                      )}
+                    </div>
                     <div className="mt-1 flex flex-wrap gap-1">
                       {(item.tags ?? []).map((tag) => (
                         <Badge key={tag} tone="accent">

--- a/frontend/src/pages/HotStocksPage.tsx
+++ b/frontend/src/pages/HotStocksPage.tsx
@@ -1,0 +1,178 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { ArrowDown, ArrowUp, Flame, Minus, RefreshCw, TrendingUp } from 'lucide-react'
+import { fetchHotStocks, type HotPeriod, type HotStock } from '../api/market'
+import { StockLink } from '../components/stock/StockLink'
+import { Card, EmptyState, PageHeader, SectionTitle, SkeletonRows } from '../components/ui'
+import { cn } from '../lib/cn'
+
+const PERIODS = [
+  { key: 'day', label: '当日' },
+  { key: 'hour', label: '小时榜' },
+] as const
+
+function fmtHeat(heat: number | null | undefined): string {
+  if (heat === null || heat === undefined) return '--'
+  if (heat >= 1e8) return `${(heat / 1e8).toFixed(2)}亿`
+  if (heat >= 1e4) return `${(heat / 1e4).toFixed(1)}万`
+  return `${heat.toFixed(0)}`
+}
+
+function RankTrend({ row }: { row: HotStock }) {
+  const change = row.rank_change ?? 0
+  const trend = row.rank_trend
+  if (trend === 'up' || change > 0) {
+    return (
+      <span className="num inline-flex items-center gap-0.5 text-bull">
+        <ArrowUp size={11} />
+        {Math.abs(change)}
+      </span>
+    )
+  }
+  if (trend === 'down' || change < 0) {
+    return (
+      <span className="num inline-flex items-center gap-0.5 text-bear">
+        <ArrowDown size={11} />
+        {Math.abs(change)}
+      </span>
+    )
+  }
+  return (
+    <span className="inline-flex items-center gap-0.5 text-fg-muted">
+      <Minus size={11} /> 持平
+    </span>
+  )
+}
+
+function HotTable({ rows }: { rows: HotStock[] }) {
+  return (
+    <table className="w-full border-collapse text-xs">
+      <thead>
+        <tr className="border-b border-line text-left text-2xs text-fg-muted">
+          <th className="w-10 px-3 py-1.5 text-center font-medium">#</th>
+          <th className="px-3 py-1.5 font-medium">个股</th>
+          <th className="px-3 py-1.5 text-right font-medium">热度</th>
+          <th className="px-3 py-1.5 text-right font-medium">排名变化</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, index) => (
+          <tr key={`${row.ts_code}-${index}`} className="border-t border-line/60 hover:bg-elevated/50">
+            <td
+              className={cn(
+                'num px-3 py-1.5 text-center font-semibold',
+                (row.rank ?? index + 1) <= 3 ? 'text-warning' : 'text-fg-muted',
+              )}
+            >
+              {row.rank ?? index + 1}
+            </td>
+            <td className="px-3 py-1.5">
+              <StockLink code={row.ts_code} name={row.name} />
+            </td>
+            <td className="num px-3 py-1.5 text-right text-fg-secondary">{fmtHeat(row.heat)}</td>
+            <td className="px-3 py-1.5 text-right">
+              <RankTrend row={row} />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+export default function HotStocksPage() {
+  const [period, setPeriod] = useState<HotPeriod>('day')
+
+  const hotQuery = useQuery({
+    queryKey: ['market', 'hot-stocks', period],
+    queryFn: () => fetchHotStocks(period),
+    refetchInterval: 300_000,
+  })
+
+  const hot = hotQuery.data?.hot ?? []
+  const skyrocket = hotQuery.data?.skyrocket ?? []
+
+  return (
+    <div className="tsp-root min-h-full">
+      <PageHeader
+        title="热股榜单"
+        subtitle="同花顺热股榜与飙升榜（按市场关注度排序）· 5 分钟缓存"
+        right={
+          <div className="flex items-center gap-1.5">
+            <div className="flex items-center gap-1">
+              {PERIODS.map((item) => (
+                <button
+                  key={item.key}
+                  type="button"
+                  onClick={() => setPeriod(item.key)}
+                  className={cn(
+                    'rounded-btn px-2 py-0.5 text-xs transition-colors',
+                    period === item.key
+                      ? 'bg-accent/15 text-accent'
+                      : 'text-fg-muted hover:bg-elevated hover:text-fg-secondary',
+                  )}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
+            <button
+              type="button"
+              onClick={() => hotQuery.refetch()}
+              className="inline-flex items-center gap-1.5 rounded-btn border border-line px-2.5 py-1 text-xs text-fg-secondary transition-colors hover:bg-elevated hover:text-fg-primary"
+            >
+              <RefreshCw size={12} className={hotQuery.isFetching ? 'animate-spin' : ''} /> 刷新
+            </button>
+          </div>
+        }
+      />
+
+      {hotQuery.isError ? (
+        <div className="p-1.5">
+          <Card className="border-danger/30 bg-danger/5 px-4 py-3 text-xs text-danger">
+            热股榜加载失败：{(hotQuery.error as Error)?.message ?? '未知错误'}
+            <button type="button" className="ml-2 underline" onClick={() => hotQuery.refetch()}>
+              重试
+            </button>
+          </Card>
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-1 gap-1.5 p-1.5 lg:grid-cols-2">
+        <Card className="p-0">
+          <SectionTitle
+            icon={<Flame size={13} />}
+            title="热股榜"
+            hint={hot.length ? `Top ${hot.length}` : undefined}
+          />
+          {hotQuery.isLoading ? (
+            <SkeletonRows rows={10} />
+          ) : hot.length === 0 ? (
+            <EmptyState icon={<Flame size={22} />} title="暂无热股数据" description="热榜每小时更新，稍后再试。" />
+          ) : (
+            <div className="max-h-[calc(100vh-12rem)] overflow-y-auto">
+              <HotTable rows={hot} />
+            </div>
+          )}
+        </Card>
+
+        <Card className="p-0">
+          <SectionTitle
+            icon={<TrendingUp size={13} />}
+            title="飙升榜"
+            hint={skyrocket.length ? `Top ${skyrocket.length}` : undefined}
+          />
+          {hotQuery.isLoading ? (
+            <SkeletonRows rows={10} />
+          ) : skyrocket.length === 0 ? (
+            <EmptyState icon={<TrendingUp size={22} />} title="暂无飙升数据" description="热度飙升名单每小时更新。" />
+          ) : (
+            <div className="max-h-[calc(100vh-12rem)] overflow-y-auto">
+              <HotTable rows={skyrocket} />
+            </div>
+          )}
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/IndustryAnalysisPage.tsx
+++ b/frontend/src/pages/IndustryAnalysisPage.tsx
@@ -1,0 +1,11 @@
+import BoardAnalysisPage from './BoardAnalysisPage'
+
+export default function IndustryAnalysisPage() {
+  return (
+    <BoardAnalysisPage
+      tag="industry"
+      title="行业分析"
+      subtitle="同花顺行业指数实时涨跌排行 · 60s 自动刷新 · 点击板块查看成分股"
+    />
+  )
+}

--- a/frontend/src/pages/LimitUpLadderPage.tsx
+++ b/frontend/src/pages/LimitUpLadderPage.tsx
@@ -2,8 +2,12 @@ import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Flame, RefreshCw } from 'lucide-react'
 import {
+  fetchLimitBreakPool,
+  fetchLimitDownPool,
   fetchLimitUpLadder,
   fetchLimitUpPool,
+  type LimitBreakStock,
+  type LimitDownStock,
   type LimitUpStock,
 } from '../api/market'
 import { StockLink } from '../components/stock/StockLink'
@@ -30,6 +34,14 @@ function ladderBadgeTone(cnt: number | undefined): 'danger' | 'warning' | 'bull'
   if (cnt === 2) return 'warning'
   return 'bull'
 }
+
+const LADDER_TABS = [
+  { key: 'up', label: '涨停池' },
+  { key: 'down', label: '跌停池' },
+  { key: 'break', label: '炸板池' },
+] as const
+
+type LadderTabKey = (typeof LADDER_TABS)[number]['key']
 
 function LadderMatrix({ days }: { days: { date: string | null; counts: Record<string, number>; highest: number; total: number }[] }) {
   const boardCols = ['2', '3', '4', '5', '6', '7']
@@ -79,7 +91,7 @@ function LadderMatrix({ days }: { days: { date: string | null; counts: Record<st
   )
 }
 
-function PoolTable({ items }: { items: LimitUpStock[] }) {
+function UpPoolTable({ items }: { items: LimitUpStock[] }) {
   return (
     <table className="w-full border-collapse text-xs">
       <thead>
@@ -120,33 +132,124 @@ function PoolTable({ items }: { items: LimitUpStock[] }) {
   )
 }
 
+function DownPoolTable({ items }: { items: LimitDownStock[] }) {
+  return (
+    <table className="w-full border-collapse text-xs">
+      <thead>
+        <tr className="border-b border-line text-left text-2xs text-fg-muted">
+          <th className="px-3 py-1.5 font-medium">个股</th>
+          <th className="px-3 py-1.5 text-right font-medium">现价</th>
+          <th className="px-3 py-1.5 text-right font-medium">跌幅</th>
+          <th className="px-3 py-1.5 font-medium">首次跌停</th>
+          <th className="px-3 py-1.5 font-medium">最后封板</th>
+          <th className="px-3 py-1.5 text-right font-medium">换手率</th>
+        </tr>
+      </thead>
+      <tbody>
+        {items.map((row, index) => (
+          <tr key={`${row.ts_code}-${index}`} className="border-t border-line/60 hover:bg-elevated/50">
+            <td className="px-3 py-1.5">
+              <StockLink code={row.ts_code} name={row.name} />
+            </td>
+            <td className="num px-3 py-1.5 text-right">{row.last_price ?? '--'}</td>
+            <td className="px-3 py-1.5 text-right">
+              <Delta value={row.pct_chg} />
+            </td>
+            <td className="num px-3 py-1.5 text-fg-secondary">{row.first_limit_time ?? '--'}</td>
+            <td className="num px-3 py-1.5 text-fg-secondary">{row.last_limit_time ?? '--'}</td>
+            <td className="num px-3 py-1.5 text-right text-fg-secondary">
+              {row.turnover_ratio_pct != null ? `${row.turnover_ratio_pct.toFixed(2)}%` : '--'}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+function BreakPoolTable({ items }: { items: LimitBreakStock[] }) {
+  return (
+    <table className="w-full border-collapse text-xs">
+      <thead>
+        <tr className="border-b border-line text-left text-2xs text-fg-muted">
+          <th className="px-3 py-1.5 font-medium">个股</th>
+          <th className="px-3 py-1.5 text-right font-medium">现价</th>
+          <th className="px-3 py-1.5 text-right font-medium">涨幅</th>
+          <th className="px-3 py-1.5 text-right font-medium">炸板次数</th>
+          <th className="px-3 py-1.5 text-right font-medium">换手率</th>
+          <th className="px-3 py-1.5 text-right font-medium">成交额</th>
+        </tr>
+      </thead>
+      <tbody>
+        {items.map((row, index) => (
+          <tr key={`${row.ts_code}-${index}`} className="border-t border-line/60 hover:bg-elevated/50">
+            <td className="px-3 py-1.5">
+              <StockLink code={row.ts_code} name={row.name} />
+            </td>
+            <td className="num px-3 py-1.5 text-right">{row.last_price ?? '--'}</td>
+            <td className="px-3 py-1.5 text-right">
+              <Delta value={row.pct_chg} />
+            </td>
+            <td className="num px-3 py-1.5 text-right text-warning">{row.open_times ?? '--'}</td>
+            <td className="num px-3 py-1.5 text-right text-fg-secondary">
+              {row.turnover_ratio_pct != null ? `${row.turnover_ratio_pct.toFixed(2)}%` : '--'}
+            </td>
+            <td className="num px-3 py-1.5 text-right text-fg-secondary">{yi(row.turnover)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
 export default function LimitUpLadderPage() {
   const [date, setDate] = useState('')
+  const [tab, setTab] = useState<LadderTabKey>('up')
 
   const ladderQuery = useQuery({
     queryKey: ['market', 'limit-up-ladder'],
     queryFn: fetchLimitUpLadder,
     refetchInterval: 300_000,
   })
-  const poolQuery = useQuery({
+  // 三池全部预取：KPI 行需要跌停/炸板总数，切换 tab 无需等待
+  const upQuery = useQuery({
     queryKey: ['market', 'limit-up-pool', date],
     queryFn: () => fetchLimitUpPool(date || undefined),
     refetchInterval: date ? false : 60_000,
   })
+  const downQuery = useQuery({
+    queryKey: ['market', 'limit-down-pool', date],
+    queryFn: () => fetchLimitDownPool(date || undefined),
+    refetchInterval: date ? false : 60_000,
+  })
+  const breakQuery = useQuery({
+    queryKey: ['market', 'limit-break-pool', date],
+    queryFn: () => fetchLimitBreakPool(date || undefined),
+    refetchInterval: date ? false : 60_000,
+  })
 
-  const pool = poolQuery.data
-  const items = pool?.items ?? []
+  const up = upQuery.data
+  const down = downQuery.data
+  const broke = breakQuery.data
+  const items = up?.items ?? []
   const highest = Math.max(0, ...items.map((row) => row.continue_day_cnt ?? 0))
   const ladderCount = items.filter((row) => (row.continue_day_cnt ?? 0) >= 2).length
+  const breakTotal = broke?.total ?? 0
+  // 炸板率 = 炸板家数 / (涨停 + 炸板)，短线情绪核心指标
+  const breakRate = up?.total ? (breakTotal / (up.total + breakTotal)) * 100 : null
+
+  const tabQueries = { up: upQuery, down: downQuery, break: breakQuery }
+  const activeQuery = tabQueries[tab]
+  const activeDate = up?.date ?? down?.date ?? broke?.date
 
   return (
     <div className="tsp-root min-h-full">
       <PageHeader
         title="连板天梯"
         subtitle={
-          pool?.date
-            ? `涨停池日期 ${pool.date} · 扶摇特色数据${pool.stale ? '（降级缓存）' : ''}`
-            : '扶摇涨停池与连板天梯 · 60s 自动刷新'
+          activeDate
+            ? `数据日期 ${activeDate} · 扶摇特色数据${upQuery.data?.stale ? '（降级缓存）' : ''}`
+            : '扶摇涨停池/跌停池/炸板池 · 60s 自动刷新'
         }
         right={
           <div className="flex items-center gap-1.5">
@@ -160,12 +263,14 @@ export default function LimitUpLadderPage() {
             <button
               type="button"
               onClick={() => {
-                poolQuery.refetch()
+                upQuery.refetch()
+                downQuery.refetch()
+                breakQuery.refetch()
                 ladderQuery.refetch()
               }}
               className="inline-flex items-center gap-1.5 rounded-btn border border-line px-2.5 py-1 text-xs text-fg-secondary transition-colors hover:bg-elevated hover:text-fg-primary"
             >
-              <RefreshCw size={12} className={poolQuery.isFetching ? 'animate-spin' : ''} /> 刷新
+              <RefreshCw size={12} className={upQuery.isFetching ? 'animate-spin' : ''} /> 刷新
             </button>
           </div>
         }
@@ -173,11 +278,18 @@ export default function LimitUpLadderPage() {
 
       <div className="space-y-1.5 p-1.5">
         {/* KPI 行 */}
-        <div className="grid grid-cols-2 gap-1.5 md:grid-cols-4">
-          <KpiCell label="涨停家数" value={pool?.total ?? '—'} tone="bull" />
+        <div className="grid grid-cols-3 gap-1.5 md:grid-cols-6">
+          <KpiCell label="涨停家数" value={up?.total ?? '—'} tone="bull" />
           <KpiCell label="最高连板" value={highest ? `${highest}板` : '—'} tone={highest >= 4 ? 'bull' : 'neutral'} />
           <KpiCell label="连板家数" value={ladderCount || '—'} sub="≥2板" tone="accent" />
-          <KpiCell label="两板及以上占比" value={pool?.total ? `${((ladderCount / pool.total) * 100).toFixed(0)}%` : '—'} />
+          <KpiCell label="跌停家数" value={down?.total ?? '—'} tone="bear" />
+          <KpiCell label="炸板家数" value={breakTotal || '—'} tone="bear" />
+          <KpiCell
+            label="炸板率"
+            value={breakRate != null ? `${breakRate.toFixed(0)}%` : '—'}
+            sub="炸板/(涨停+炸板)"
+            tone={breakRate != null && breakRate >= 30 ? 'bear' : 'neutral'}
+          />
         </div>
 
         {/* 天梯矩阵 */}
@@ -208,33 +320,58 @@ export default function LimitUpLadderPage() {
           )}
         </Card>
 
-        {/* 涨停池 */}
+        {/* 三池表格（tab 切换） */}
         <Card className="p-0">
-          <SectionTitle title="涨停池" hint={pool?.total != null ? `${pool.total} 只 · 连板数降序` : undefined} />
-          {poolQuery.isLoading ? (
+          <SectionTitle
+            title="股票池"
+            right={
+              <div className="flex items-center gap-1">
+                {LADDER_TABS.map((item) => (
+                  <button
+                    key={item.key}
+                    type="button"
+                    onClick={() => setTab(item.key)}
+                    className={cn(
+                      'rounded-btn px-2 py-0.5 text-xs transition-colors',
+                      tab === item.key
+                        ? 'bg-accent/15 text-accent'
+                        : 'text-fg-muted hover:bg-elevated hover:text-fg-secondary',
+                    )}
+                  >
+                    {item.label}
+                  </button>
+                ))}
+              </div>
+            }
+          />
+          {activeQuery.isLoading ? (
             <SkeletonRows rows={8} />
-          ) : poolQuery.isError ? (
+          ) : activeQuery.isError ? (
             <EmptyState
-              title="涨停池加载失败"
-              description={(poolQuery.error as Error)?.message}
+              title="股票池加载失败"
+              description={(activeQuery.error as Error)?.message}
               action={
                 <button
                   type="button"
                   className="rounded-btn border border-line px-2.5 py-1 text-xs text-fg-secondary hover:bg-elevated"
-                  onClick={() => poolQuery.refetch()}
+                  onClick={() => activeQuery.refetch()}
                 >
                   重试
                 </button>
               }
             />
-          ) : items.length === 0 ? (
+          ) : (activeQuery.data?.items?.length ?? 0) === 0 ? (
             <EmptyState
               icon={<Flame size={22} />}
-              title="所选日期无涨停数据"
+              title="所选日期无数据"
               description="可能是非交易日，换一个日期试试。"
             />
+          ) : tab === 'up' ? (
+            <UpPoolTable items={(activeQuery.data?.items ?? []) as LimitUpStock[]} />
+          ) : tab === 'down' ? (
+            <DownPoolTable items={(activeQuery.data?.items ?? []) as LimitDownStock[]} />
           ) : (
-            <PoolTable items={items} />
+            <BreakPoolTable items={(activeQuery.data?.items ?? []) as LimitBreakStock[]} />
           )}
         </Card>
       </div>

--- a/frontend/src/pages/LimitUpLadderPage.tsx
+++ b/frontend/src/pages/LimitUpLadderPage.tsx
@@ -1,0 +1,243 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Flame, RefreshCw } from 'lucide-react'
+import {
+  fetchLimitUpLadder,
+  fetchLimitUpPool,
+  type LimitUpStock,
+} from '../api/market'
+import { StockLink } from '../components/stock/StockLink'
+import { Badge, Card, Delta, EmptyState, KpiCell, PageHeader, SectionTitle, SkeletonRows } from '../components/ui'
+import { cn } from '../lib/cn'
+
+function yi(amount: number | null | undefined): string {
+  if (amount === null || amount === undefined) return '--'
+  const value = amount / 1e8
+  return value >= 100 ? `${value.toFixed(1)}亿` : `${value.toFixed(2)}亿`
+}
+
+/** 连板数字 → 梯队色（越高越热） */
+function ladderTone(cnt: number | undefined): string {
+  if (!cnt) return 'text-fg-muted'
+  if (cnt >= 5) return 'text-danger font-semibold'
+  if (cnt >= 3) return 'text-warning font-medium'
+  return 'text-fg-primary'
+}
+
+function ladderBadgeTone(cnt: number | undefined): 'danger' | 'warning' | 'bull' | 'neutral' {
+  if (!cnt) return 'neutral'
+  if (cnt >= 3) return 'danger'
+  if (cnt === 2) return 'warning'
+  return 'bull'
+}
+
+function LadderMatrix({ days }: { days: { date: string | null; counts: Record<string, number>; highest: number; total: number }[] }) {
+  const boardCols = ['2', '3', '4', '5', '6', '7']
+  const visible = days.slice(0, 15) // 最近 15 个交易日，横向可读
+  const maxCell = Math.max(1, ...visible.flatMap((d) => boardCols.map((k) => d.counts[k] ?? 0)))
+  return (
+    <div className="overflow-x-auto px-3 pb-3">
+      <table className="w-full min-w-[34rem] border-collapse text-xs">
+        <thead>
+          <tr className="border-b border-line text-left text-2xs text-fg-muted">
+            <th className="px-2 py-1.5 font-medium">日期</th>
+            {boardCols.map((k) => (
+              <th key={k} className="px-2 py-1.5 text-center font-medium">
+                {k === '7' ? '7板+' : `${k}板`}
+              </th>
+            ))}
+            <th className="px-2 py-1.5 text-right font-medium">合计</th>
+          </tr>
+        </thead>
+        <tbody>
+          {visible.map((day) => (
+            <tr key={day.date ?? ''} className="border-t border-line/60">
+              <td className="num px-2 py-1 text-fg-secondary">{day.date ?? '--'}</td>
+              {boardCols.map((k) => {
+                const count = day.counts[k] ?? 0
+                return (
+                  <td key={k} className="px-1 py-1 text-center">
+                    {count > 0 ? (
+                      <span
+                        className={cn('num inline-block min-w-6 rounded-sm px-1 py-0.5', ladderTone(k === '7' ? 7 : Number(k)))}
+                        style={{ backgroundColor: `color-mix(in srgb, currentColor ${Math.round((count / maxCell) * 22 + 6)}%, transparent)` }}
+                      >
+                        {count}
+                      </span>
+                    ) : (
+                      <span className="text-fg-muted/40">·</span>
+                    )}
+                  </td>
+                )
+              })}
+              <td className="num px-2 py-1 text-right text-fg-secondary">{day.total}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function PoolTable({ items }: { items: LimitUpStock[] }) {
+  return (
+    <table className="w-full border-collapse text-xs">
+      <thead>
+        <tr className="border-b border-line text-left text-2xs text-fg-muted">
+          <th className="px-3 py-1.5 font-medium">梯队</th>
+          <th className="px-3 py-1.5 font-medium">个股</th>
+          <th className="px-3 py-1.5 text-right font-medium">现价</th>
+          <th className="px-3 py-1.5 text-right font-medium">涨幅</th>
+          <th className="px-3 py-1.5 font-medium">首次涨停</th>
+          <th className="px-3 py-1.5 text-right font-medium">封单额</th>
+          <th className="px-3 py-1.5 font-medium">涨停原因</th>
+        </tr>
+      </thead>
+      <tbody>
+        {items.map((row, index) => (
+          <tr key={`${row.ts_code}-${index}`} className="border-t border-line/60 hover:bg-elevated/50">
+            <td className="px-3 py-1.5">
+              <Badge tone={ladderBadgeTone(row.continue_day_cnt)}>{row.continue_day_text ?? '首板'}</Badge>
+            </td>
+            <td className="px-3 py-1.5">
+              <StockLink code={row.ts_code} name={row.name} />
+              {row.is_st ? <span className="ml-1 text-2xs text-danger">ST</span> : null}
+              {row.is_new ? <span className="ml-1 text-2xs text-accent">新</span> : null}
+            </td>
+            <td className="num px-3 py-1.5 text-right">{row.last_price ?? '--'}</td>
+            <td className="px-3 py-1.5 text-right">
+              <Delta value={row.pct_chg} />
+            </td>
+            <td className="num px-3 py-1.5 text-fg-secondary">{row.limit_up_time ?? '--'}</td>
+            <td className="num px-3 py-1.5 text-right text-fg-secondary">{yi(row.seal_money)}</td>
+            <td className="max-w-[16rem] truncate px-3 py-1.5 text-fg-muted" title={row.reason ?? ''}>
+              {row.reason ?? '--'}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+export default function LimitUpLadderPage() {
+  const [date, setDate] = useState('')
+
+  const ladderQuery = useQuery({
+    queryKey: ['market', 'limit-up-ladder'],
+    queryFn: fetchLimitUpLadder,
+    refetchInterval: 300_000,
+  })
+  const poolQuery = useQuery({
+    queryKey: ['market', 'limit-up-pool', date],
+    queryFn: () => fetchLimitUpPool(date || undefined),
+    refetchInterval: date ? false : 60_000,
+  })
+
+  const pool = poolQuery.data
+  const items = pool?.items ?? []
+  const highest = Math.max(0, ...items.map((row) => row.continue_day_cnt ?? 0))
+  const ladderCount = items.filter((row) => (row.continue_day_cnt ?? 0) >= 2).length
+
+  return (
+    <div className="tsp-root min-h-full">
+      <PageHeader
+        title="连板天梯"
+        subtitle={
+          pool?.date
+            ? `涨停池日期 ${pool.date} · 扶摇特色数据${pool.stale ? '（降级缓存）' : ''}`
+            : '扶摇涨停池与连板天梯 · 60s 自动刷新'
+        }
+        right={
+          <div className="flex items-center gap-1.5">
+            <input
+              type="date"
+              value={date}
+              max={new Date().toISOString().slice(0, 10)}
+              onChange={(event) => setDate(event.target.value)}
+              className="num rounded-input border border-line bg-elevated/50 px-2 py-1 text-xs outline-none focus:border-accent/60"
+            />
+            <button
+              type="button"
+              onClick={() => {
+                poolQuery.refetch()
+                ladderQuery.refetch()
+              }}
+              className="inline-flex items-center gap-1.5 rounded-btn border border-line px-2.5 py-1 text-xs text-fg-secondary transition-colors hover:bg-elevated hover:text-fg-primary"
+            >
+              <RefreshCw size={12} className={poolQuery.isFetching ? 'animate-spin' : ''} /> 刷新
+            </button>
+          </div>
+        }
+      />
+
+      <div className="space-y-1.5 p-1.5">
+        {/* KPI 行 */}
+        <div className="grid grid-cols-2 gap-1.5 md:grid-cols-4">
+          <KpiCell label="涨停家数" value={pool?.total ?? '—'} tone="bull" />
+          <KpiCell label="最高连板" value={highest ? `${highest}板` : '—'} tone={highest >= 4 ? 'bull' : 'neutral'} />
+          <KpiCell label="连板家数" value={ladderCount || '—'} sub="≥2板" tone="accent" />
+          <KpiCell label="两板及以上占比" value={pool?.total ? `${((ladderCount / pool.total) * 100).toFixed(0)}%` : '—'} />
+        </div>
+
+        {/* 天梯矩阵 */}
+        <Card>
+          <SectionTitle
+            icon={<Flame size={13} />}
+            title="连板天梯矩阵"
+            hint="近 15 个交易日 · 各梯队家数"
+          />
+          {ladderQuery.isLoading ? (
+            <SkeletonRows rows={6} />
+          ) : ladderQuery.isError ? (
+            <EmptyState
+              title="天梯加载失败"
+              description={(ladderQuery.error as Error)?.message}
+              action={
+                <button
+                  type="button"
+                  className="rounded-btn border border-line px-2.5 py-1 text-xs text-fg-secondary hover:bg-elevated"
+                  onClick={() => ladderQuery.refetch()}
+                >
+                  重试
+                </button>
+              }
+            />
+          ) : (
+            <LadderMatrix days={ladderQuery.data?.days ?? []} />
+          )}
+        </Card>
+
+        {/* 涨停池 */}
+        <Card className="p-0">
+          <SectionTitle title="涨停池" hint={pool?.total != null ? `${pool.total} 只 · 连板数降序` : undefined} />
+          {poolQuery.isLoading ? (
+            <SkeletonRows rows={8} />
+          ) : poolQuery.isError ? (
+            <EmptyState
+              title="涨停池加载失败"
+              description={(poolQuery.error as Error)?.message}
+              action={
+                <button
+                  type="button"
+                  className="rounded-btn border border-line px-2.5 py-1 text-xs text-fg-secondary hover:bg-elevated"
+                  onClick={() => poolQuery.refetch()}
+                >
+                  重试
+                </button>
+              }
+            />
+          ) : items.length === 0 ? (
+            <EmptyState
+              icon={<Flame size={22} />}
+              title="所选日期无涨停数据"
+              description="可能是非交易日，换一个日期试试。"
+            />
+          ) : (
+            <PoolTable items={items} />
+          )}
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/MarketDashboardPage.tsx
+++ b/frontend/src/pages/MarketDashboardPage.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { Activity, AlertTriangle, ArrowDownRight, ArrowUpRight, RefreshCw, TrendingUp } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { fetchDashboard, fetchIndices, type BoardRow } from '../api/market'
+import { StockLink } from '../components/stock/StockLink'
 import { Card, Delta, KpiCell, PageHeader, SectionTitle, SkeletonRows } from '../components/ui'
 import { cn } from '../lib/cn'
 
@@ -25,8 +26,7 @@ function BoardTable({ rows, metric }: { rows: BoardRow[]; metric: 'pct' | 'amoun
         {rows.map((row) => (
           <tr key={row.ts_code} className="border-t border-line/60 first:border-t-0 hover:bg-elevated/60">
             <td className="px-3 py-1.5">
-              <span className="num">{row.ts_code}</span>
-              {row.name ? <span className="ml-1.5 text-fg-secondary">{row.name}</span> : null}
+              <StockLink code={row.ts_code} name={row.name} />
             </td>
             <td className="num px-2 py-1.5 text-right text-fg-secondary">{row.price ?? '--'}</td>
             <td className="px-3 py-1.5 text-right">

--- a/frontend/src/pages/MarketDashboardPage.tsx
+++ b/frontend/src/pages/MarketDashboardPage.tsx
@@ -1,0 +1,218 @@
+import { useQuery } from '@tanstack/react-query'
+import { Activity, AlertTriangle, ArrowDownRight, ArrowUpRight, RefreshCw, TrendingUp } from 'lucide-react'
+import { Link } from 'react-router-dom'
+import { fetchDashboard, fetchIndices, type BoardRow } from '../api/market'
+import { Card, Delta, KpiCell, PageHeader, SectionTitle, SkeletonRows } from '../components/ui'
+import { cn } from '../lib/cn'
+
+function yi(amountYuan: number | null | undefined): string {
+  if (amountYuan === null || amountYuan === undefined) return '--'
+  const value = amountYuan / 1e8
+  return value >= 100 ? `${value.toFixed(0)}亿` : `${value.toFixed(2)}亿`
+}
+
+const INDEX_NAMES: Record<string, string> = {
+  '000001.SH': '上证指数',
+  '399001.SZ': '深证成指',
+  '399006.SZ': '创业板指',
+  '000300.SH': '沪深300',
+}
+
+function BoardTable({ rows, metric }: { rows: BoardRow[]; metric: 'pct' | 'amount' }) {
+  return (
+    <table className="w-full border-collapse text-xs">
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.ts_code} className="border-t border-line/60 first:border-t-0 hover:bg-elevated/60">
+            <td className="px-3 py-1.5">
+              <span className="num">{row.ts_code}</span>
+              {row.name ? <span className="ml-1.5 text-fg-secondary">{row.name}</span> : null}
+            </td>
+            <td className="num px-2 py-1.5 text-right text-fg-secondary">{row.price ?? '--'}</td>
+            <td className="px-3 py-1.5 text-right">
+              {metric === 'pct' ? (
+                <Delta value={row.pct_chg} />
+              ) : (
+                <span className="num text-fg-secondary">{yi(row.amount_yuan)}</span>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+export default function MarketDashboardPage() {
+  const dashboardQuery = useQuery({
+    queryKey: ['market', 'dashboard'],
+    queryFn: fetchDashboard,
+    refetchInterval: 30_000,
+  })
+  const indexQuery = useQuery({
+    queryKey: ['market', 'indices'],
+    queryFn: () => fetchIndices(),
+    refetchInterval: 30_000,
+  })
+
+  const data = dashboardQuery.data
+  const indices = indexQuery.data?.indices ?? []
+  const breadth = data?.breadth
+  const maxDist = Math.max(1, ...(data?.distribution ?? []).map((d) => d.count))
+
+  return (
+    <div className="tsp-root min-h-full">
+      <PageHeader
+        title="市场看板"
+        subtitle={
+          data?.source === 'local_parquet'
+            ? `实时源不可用 · 展示本地数据 ${data.as_of ?? ''}`
+            : data?.server_ts
+              ? `扶摇实时快照 · ${new Date(data.server_ts).toLocaleTimeString('zh-CN', { hour12: false })}`
+              : '扶摇实时快照 · 30s 自动刷新'
+        }
+        right={
+          <>
+            {data?.degraded ? (
+              <span className="inline-flex items-center gap-1 rounded-full border border-warning/25 bg-warning/12 px-2 py-0.5 text-2xs text-warning">
+                <AlertTriangle size={11} /> 降级模式
+              </span>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => dashboardQuery.refetch()}
+              className="inline-flex items-center gap-1.5 rounded-btn border border-line px-2.5 py-1 text-xs text-fg-secondary transition-colors hover:bg-elevated hover:text-fg-primary"
+            >
+              <RefreshCw size={12} className={dashboardQuery.isFetching ? 'animate-spin' : ''} /> 刷新
+            </button>
+          </>
+        }
+      />
+
+      <div className="space-y-1.5 p-1.5">
+        {/* 指数 ticker 行 */}
+        <div className="grid grid-cols-2 gap-1.5 md:grid-cols-4">
+          {(indices.length
+            ? indices
+            : [null, null, null, null]
+          ).map((quote, i) => (
+            <Card key={quote?.ts_code ?? `idx-${i}`} className="px-3 py-2">
+              {quote ? (
+                <>
+                  <div className="text-xs text-fg-muted">{INDEX_NAMES[quote.ts_code] ?? quote.ts_code}</div>
+                  <div className="mt-0.5 flex items-baseline justify-between">
+                    <span className="num text-base font-semibold">{quote.last_price?.toFixed(2) ?? '--'}</span>
+                    <Delta value={quote.pct_chg} />
+                  </div>
+                </>
+              ) : (
+                <div className="h-10 animate-pulse rounded-sm bg-elevated" />
+              )}
+            </Card>
+          ))}
+        </div>
+
+        {dashboardQuery.isError ? (
+          <Card className="border-danger/30 bg-danger/5 px-4 py-3 text-xs text-danger">
+            看板加载失败：{(dashboardQuery.error as Error)?.message ?? '未知错误'}
+            <button type="button" className="ml-2 underline" onClick={() => dashboardQuery.refetch()}>
+              重试
+            </button>
+          </Card>
+        ) : null}
+
+        {/* 市场宽度 KPI 行 */}
+        <div className="grid grid-cols-3 gap-1.5 md:grid-cols-6">
+          {breadth ? (
+            <>
+              <KpiCell label="上涨" value={breadth.up} tone="bull" sub={`${((breadth.up / (breadth.total || 1)) * 100).toFixed(1)}%`} />
+              <KpiCell label="下跌" value={breadth.down} tone="bear" sub={`${((breadth.down / (breadth.total || 1)) * 100).toFixed(1)}%`} />
+              <KpiCell label="平盘" value={breadth.flat} />
+              <KpiCell label="涨停(近)" value={breadth.limit_up} tone="bull" />
+              <KpiCell label="跌停(近)" value={breadth.limit_down} tone="bear" />
+              <KpiCell label="总成交" value={yi(data?.total_amount_yuan)} />
+            </>
+          ) : (
+            Array.from({ length: 6 }).map((_, i) => <KpiCell key={i} label="—" value="—" />)
+          )}
+        </div>
+
+        <div className="grid grid-cols-1 gap-1.5 xl:grid-cols-[1fr_20rem]">
+          {/* 左列：分布 + 榜单 */}
+          <div className="space-y-1.5">
+            <Card>
+              <SectionTitle icon={<Activity size={13} />} title="涨跌分布" hint="涨幅区间 · 家数" />
+              <div className="space-y-1 px-3 pb-3">
+                {(data?.distribution ?? []).map((bucket) => {
+                  const negative = bucket.bucket.startsWith('<') || bucket.bucket.startsWith('-')
+                  return (
+                    <div key={bucket.bucket} className="flex items-center gap-2">
+                      <span className="num w-20 shrink-0 text-2xs text-fg-muted">{bucket.bucket}</span>
+                      <div className="h-3 flex-1 overflow-hidden rounded-sm bg-elevated/60">
+                        <div
+                          className={cn('h-full rounded-sm', negative ? 'bg-bear/70' : 'bg-bull/70')}
+                          style={{ width: `${(bucket.count / maxDist) * 100}%` }}
+                        />
+                      </div>
+                      <span className="num w-10 shrink-0 text-right text-2xs">{bucket.count}</span>
+                    </div>
+                  )
+                })}
+                {dashboardQuery.isLoading ? <SkeletonRows rows={5} /> : null}
+              </div>
+            </Card>
+
+            <div className="grid grid-cols-1 gap-1.5 lg:grid-cols-3">
+              <Card>
+                <SectionTitle icon={<ArrowUpRight size={13} />} title="涨幅榜" />
+                {dashboardQuery.isLoading ? (
+                  <SkeletonRows rows={6} />
+                ) : (
+                  <BoardTable rows={data?.top_gainers ?? []} metric="pct" />
+                )}
+              </Card>
+              <Card>
+                <SectionTitle icon={<ArrowDownRight size={13} />} title="跌幅榜" />
+                {dashboardQuery.isLoading ? (
+                  <SkeletonRows rows={6} />
+                ) : (
+                  <BoardTable rows={data?.top_losers ?? []} metric="pct" />
+                )}
+              </Card>
+              <Card>
+                <SectionTitle icon={<TrendingUp size={13} />} title="成交额榜" />
+                {dashboardQuery.isLoading ? (
+                  <SkeletonRows rows={6} />
+                ) : (
+                  <BoardTable rows={data?.top_amount ?? []} metric="amount" />
+                )}
+              </Card>
+            </div>
+          </div>
+
+          {/* 右列 aside */}
+          <div className="space-y-1.5">
+            <Card>
+              <SectionTitle title="龙虎榜" hint="最近发布" />
+              <div className="px-3 pb-3 text-xs leading-6 text-fg-secondary">
+                <p>机构/游资席位龙虎榜与盘前竞价风向标。</p>
+                <Link to="/market/dragon-tiger" className="text-accent hover:underline">
+                  → 前往龙虎榜页查看
+                </Link>
+              </div>
+            </Card>
+            <Card>
+              <SectionTitle title="数据源状态" />
+              <div className="px-3 pb-3 text-xs leading-6 text-fg-secondary">
+                <p>tushare / 扶摇 / TickFlow 的配置与健康探测。</p>
+                <Link to="/datasources" className="text-accent hover:underline">
+                  → 数据源中心
+                </Link>
+              </div>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/WatchlistPage.tsx
+++ b/frontend/src/pages/WatchlistPage.tsx
@@ -1,0 +1,174 @@
+import { useState } from 'react'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { ListPlus, Trash2 } from 'lucide-react'
+import { fetchQuotes, type QuoteRow } from '../api/market'
+import { Card, Delta, EmptyState, PageHeader, SectionTitle, SkeletonRows } from '../components/ui'
+
+const STORAGE_KEY = 'qa-watchlist'
+const DEFAULT_WATCHLIST = ['600000.SH', '000001.SZ', '300750.SZ', '601318.SH', '600519.SH']
+
+function loadWatchlist(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return DEFAULT_WATCHLIST
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? (parsed as string[]) : DEFAULT_WATCHLIST
+  } catch {
+    return DEFAULT_WATCHLIST
+  }
+}
+
+function normalizeCode(input: string): string | null {
+  const text = input.trim().toUpperCase()
+  if (/^\d{6}\.(SH|SZ|BJ)$/.test(text)) return text
+  if (/^\d{6}$/.test(text)) {
+    // 按常见规则推断后缀：6 开头沪市，8/4 开头北交所，其余深市
+    if (text.startsWith('6')) return `${text}.SH`
+    if (text.startsWith('8') || text.startsWith('4')) return `${text}.BJ`
+    return `${text}.SZ`
+  }
+  return null
+}
+
+function Yi(amount: number | null | undefined): string {
+  if (amount === null || amount === undefined) return '--'
+  const value = amount / 1e8
+  return value >= 100 ? `${value.toFixed(1)}亿` : `${value.toFixed(2)}亿`
+}
+
+export default function WatchlistPage() {
+  const [codes, setCodes] = useState<string[]>(loadWatchlist)
+  const [input, setInput] = useState('')
+
+  const persist = (next: string[]) => {
+    setCodes(next)
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+    } catch {
+      // 忽略持久化失败
+    }
+  }
+
+  const quotesQuery = useQuery({
+    queryKey: ['market', 'watchlist', codes],
+    queryFn: () => fetchQuotes(codes),
+    refetchInterval: 5_000,
+    enabled: codes.length > 0,
+  })
+
+  const addMutation = useMutation({
+    mutationFn: async (raw: string) => {
+      const code = normalizeCode(raw)
+      if (!code) throw new Error('代码格式应为 6 位数字或 600000.SH 形式')
+      if (codes.includes(code)) throw new Error(`${code} 已在自选中`)
+      persist([...codes, code])
+      return code
+    },
+  })
+
+  const quotes = quotesQuery.data?.quotes ?? {}
+  const rows = codes.map((code) => quotes[code]).filter(Boolean) as QuoteRow[]
+
+  return (
+    <div className="tsp-root min-h-full">
+      <PageHeader
+        title="自选行情"
+        subtitle="扶摇实时快照 · 5s 自动刷新 · 分组保存在本地浏览器"
+        right={
+          <form
+            className="flex items-center gap-1.5"
+            onSubmit={(event) => {
+              event.preventDefault()
+              if (!input.trim()) return
+              addMutation.mutate(input, {
+                onSuccess: () => setInput(''),
+                onError: () => {},
+              })
+            }}
+          >
+            <input
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              placeholder="输入代码，如 600519"
+              className="num w-40 rounded-input border border-line bg-elevated/50 px-2 py-1 text-xs outline-none placeholder:text-fg-muted focus:border-accent/60"
+            />
+            <button
+              type="submit"
+              className="inline-flex items-center gap-1 rounded-btn border border-accent/30 bg-accent/12 px-2.5 py-1 text-xs text-accent transition-colors hover:bg-accent/20"
+            >
+              <ListPlus size={12} /> 添加
+            </button>
+          </form>
+        }
+      />
+
+      <div className="p-1.5">
+        <Card className="p-0">
+          <SectionTitle title="自选列表" hint={`${codes.length} 只`} />
+          {addMutation.isError ? (
+            <div className="mx-3 mb-2 rounded-input border border-danger/25 bg-danger/8 px-2 py-1 text-2xs text-danger">
+              {(addMutation.error as Error).message}
+            </div>
+          ) : null}
+
+          {codes.length === 0 ? (
+            <EmptyState
+              icon={<ListPlus size={22} />}
+              title="还没有自选股"
+              description="在右上角输入 6 位代码添加，例如 600519（贵州茅台）、300750（宁德时代）。"
+            />
+          ) : quotesQuery.isLoading ? (
+            <SkeletonRows rows={codes.length} />
+          ) : (
+            <table className="w-full border-collapse text-xs">
+              <thead>
+                <tr className="border-b border-line text-left text-2xs text-fg-muted">
+                  <th className="px-3 py-1.5 font-medium">代码</th>
+                  <th className="px-3 py-1.5 font-medium">名称</th>
+                  <th className="px-3 py-1.5 text-right font-medium">现价</th>
+                  <th className="px-3 py-1.5 text-right font-medium">涨跌幅</th>
+                  <th className="px-3 py-1.5 text-right font-medium">涨跌</th>
+                  <th className="px-3 py-1.5 text-right font-medium">成交额</th>
+                  <th className="w-10 px-2 py-1.5" aria-label="操作" />
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.ts_code} className="border-t border-line/60 hover:bg-elevated/50">
+                    <td className="num px-3 py-1.5">{row.ts_code}</td>
+                    <td className="px-3 py-1.5 text-fg-secondary">{row.name ?? '--'}</td>
+                    <td className="num px-3 py-1.5 text-right">{row.last_price ?? '--'}</td>
+                    <td className="px-3 py-1.5 text-right">
+                      <Delta value={row.pct_chg} />
+                    </td>
+                    <td className="px-3 py-1.5 text-right">
+                      <Delta value={row.change} suffix="" digits={2} />
+                    </td>
+                    <td className="num px-3 py-1.5 text-right text-fg-secondary">{Yi(row.turnover)}</td>
+                    <td className="px-2 py-1.5 text-right">
+                      <button
+                        type="button"
+                        aria-label={`移除 ${row.ts_code}`}
+                        onClick={() => persist(codes.filter((code) => code !== row.ts_code))}
+                        className="rounded-btn p-1 text-fg-muted transition-colors hover:bg-danger/12 hover:text-danger"
+                      >
+                        <Trash2 size={12} />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+                {rows.length < codes.length ? (
+                  <tr className="border-t border-line/60">
+                    <td colSpan={7} className="px-3 py-2 text-2xs text-fg-muted">
+                      有 {codes.length - rows.length} 只暂无行情（可能已退市或代码有误）
+                    </td>
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
+          )}
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/WatchlistPage.tsx
+++ b/frontend/src/pages/WatchlistPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { ListPlus, Trash2 } from 'lucide-react'
 import { fetchQuotes, type QuoteRow } from '../api/market'
+import { StockLink } from '../components/stock/StockLink'
 import { Card, Delta, EmptyState, PageHeader, SectionTitle, SkeletonRows } from '../components/ui'
 
 const STORAGE_KEY = 'qa-watchlist'
@@ -135,8 +136,12 @@ export default function WatchlistPage() {
               <tbody>
                 {rows.map((row) => (
                   <tr key={row.ts_code} className="border-t border-line/60 hover:bg-elevated/50">
-                    <td className="num px-3 py-1.5">{row.ts_code}</td>
-                    <td className="px-3 py-1.5 text-fg-secondary">{row.name ?? '--'}</td>
+                    <td className="px-3 py-1.5">
+                      <StockLink code={row.ts_code} name={row.name} />
+                    </td>
+                    <td className="px-3 py-1.5 text-fg-secondary">
+                      <StockLink code={row.ts_code} name={row.name} showCode={false} />
+                    </td>
                     <td className="num px-3 py-1.5 text-right">{row.last_price ?? '--'}</td>
                     <td className="px-3 py-1.5 text-right">
                       <Delta value={row.pct_chg} />

--- a/frontend/src/pages/WatchlistPage.tsx
+++ b/frontend/src/pages/WatchlistPage.tsx
@@ -1,7 +1,12 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { ListPlus, Trash2 } from 'lucide-react'
-import { fetchQuotes, type QuoteRow } from '../api/market'
+import { ListPlus, Search, Trash2 } from 'lucide-react'
+import {
+  fetchQuotes,
+  fetchTickerSearch,
+  type QuoteRow,
+  type TickerSearchItem,
+} from '../api/market'
 import { StockLink } from '../components/stock/StockLink'
 import { Card, Delta, EmptyState, PageHeader, SectionTitle, SkeletonRows } from '../components/ui'
 
@@ -31,6 +36,16 @@ function normalizeCode(input: string): string | null {
   return null
 }
 
+/** 输入防抖：搜索联想用，避免每个按键打一次接口 */
+function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delayMs)
+    return () => clearTimeout(timer)
+  }, [value, delayMs])
+  return debounced
+}
+
 function Yi(amount: number | null | undefined): string {
   if (amount === null || amount === undefined) return '--'
   const value = amount / 1e8
@@ -40,6 +55,12 @@ function Yi(amount: number | null | undefined): string {
 export default function WatchlistPage() {
   const [codes, setCodes] = useState<string[]>(loadWatchlist)
   const [input, setInput] = useState('')
+  const [showSuggestions, setShowSuggestions] = useState(false)
+  const searchBoxRef = useRef<HTMLFormElement>(null)
+
+  const debouncedInput = useDebouncedValue(input, 300)
+  const keyword = debouncedInput.trim()
+  const isDirectCode = Boolean(normalizeCode(keyword))
 
   const persist = (next: string[]) => {
     setCodes(next)
@@ -57,15 +78,52 @@ export default function WatchlistPage() {
     enabled: codes.length > 0,
   })
 
+  // 名称/代码模糊搜索联想（直接输入完整代码时不查，走 normalizeCode 直加）
+  const searchQuery = useQuery({
+    queryKey: ['market', 'ticker-search', keyword],
+    queryFn: () => fetchTickerSearch(keyword, 8),
+    enabled: keyword.length >= 2 && !isDirectCode,
+  })
+  const suggestions = (searchQuery.data?.items ?? []).filter(
+    (item: TickerSearchItem) => item.ts_code && !codes.includes(item.ts_code),
+  )
+
+  const addCode = (code: string): string | null => {
+    if (codes.includes(code)) return `${code} 已在自选中`
+    persist([...codes, code])
+    return null
+  }
+
   const addMutation = useMutation({
     mutationFn: async (raw: string) => {
       const code = normalizeCode(raw)
-      if (!code) throw new Error('代码格式应为 6 位数字或 600000.SH 形式')
-      if (codes.includes(code)) throw new Error(`${code} 已在自选中`)
-      persist([...codes, code])
+      if (!code) throw new Error('未识别代码：支持 6 位数字、600000.SH，或输入名称搜索')
+      const error = addCode(code)
+      if (error) throw new Error(error)
       return code
     },
   })
+
+  // 点击外部收起联想下拉
+  useEffect(() => {
+    const onClickOutside = (event: MouseEvent) => {
+      if (searchBoxRef.current && !searchBoxRef.current.contains(event.target as Node)) {
+        setShowSuggestions(false)
+      }
+    }
+    document.addEventListener('mousedown', onClickOutside)
+    return () => document.removeEventListener('mousedown', onClickOutside)
+  }, [])
+
+  const pickSuggestion = (item: TickerSearchItem) => {
+    const error = addCode(item.ts_code)
+    if (error) {
+      addMutation.mutate(item.ts_code, { onError: () => {} })
+      return
+    }
+    setInput('')
+    setShowSuggestions(false)
+  }
 
   const quotes = quotesQuery.data?.quotes ?? {}
   const rows = codes.map((code) => quotes[code]).filter(Boolean) as QuoteRow[]
@@ -77,10 +135,12 @@ export default function WatchlistPage() {
         subtitle="扶摇实时快照 · 5s 自动刷新 · 分组保存在本地浏览器"
         right={
           <form
-            className="flex items-center gap-1.5"
+            ref={searchBoxRef}
+            className="relative flex items-center gap-1.5"
             onSubmit={(event) => {
               event.preventDefault()
               if (!input.trim()) return
+              setShowSuggestions(false)
               addMutation.mutate(input, {
                 onSuccess: () => setInput(''),
                 onError: () => {},
@@ -89,9 +149,13 @@ export default function WatchlistPage() {
           >
             <input
               value={input}
-              onChange={(event) => setInput(event.target.value)}
-              placeholder="输入代码，如 600519"
-              className="num w-40 rounded-input border border-line bg-elevated/50 px-2 py-1 text-xs outline-none placeholder:text-fg-muted focus:border-accent/60"
+              onChange={(event) => {
+                setInput(event.target.value)
+                setShowSuggestions(true)
+              }}
+              onFocus={() => setShowSuggestions(true)}
+              placeholder="代码或名称，如 600519 / 茅台"
+              className="num w-48 rounded-input border border-line bg-elevated/50 px-2 py-1 text-xs outline-none placeholder:text-fg-muted focus:border-accent/60"
             />
             <button
               type="submit"
@@ -99,6 +163,35 @@ export default function WatchlistPage() {
             >
               <ListPlus size={12} /> 添加
             </button>
+            {showSuggestions && keyword.length >= 2 && !isDirectCode ? (
+              <div className="absolute right-0 top-full z-20 mt-1 w-72 overflow-hidden rounded-card border border-line bg-surface shadow-lg">
+                {searchQuery.isLoading ? (
+                  <div className="px-3 py-2 text-2xs text-fg-muted">搜索中…</div>
+                ) : suggestions.length === 0 ? (
+                  <div className="px-3 py-2 text-2xs text-fg-muted">
+                    {searchQuery.isError ? '搜索失败，稍后再试' : '没有匹配的 A 股标的'}
+                  </div>
+                ) : (
+                  <ul className="max-h-64 overflow-y-auto py-1">
+                    {suggestions.map((item) => (
+                      <li key={item.ts_code}>
+                        <button
+                          type="button"
+                          onClick={() => pickSuggestion(item)}
+                          className="flex w-full items-center justify-between px-3 py-1.5 text-left text-xs transition-colors hover:bg-elevated"
+                        >
+                          <span className="flex items-center gap-2">
+                            <Search size={11} className="text-fg-muted" />
+                            <span>{item.name ?? item.ts_code}</span>
+                          </span>
+                          <span className="num text-2xs text-fg-muted">{item.ts_code}</span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ) : null}
           </form>
         }
       />
@@ -116,7 +209,7 @@ export default function WatchlistPage() {
             <EmptyState
               icon={<ListPlus size={22} />}
               title="还没有自选股"
-              description="在右上角输入 6 位代码添加，例如 600519（贵州茅台）、300750（宁德时代）。"
+              description="在右上角输入 6 位代码或名称搜索添加，例如 600519（贵州茅台）、300750（宁德时代）。"
             />
           ) : quotesQuery.isLoading ? (
             <SkeletonRows rows={codes.length} />

--- a/frontend/src/styles/tsp.css
+++ b/frontend/src/styles/tsp.css
@@ -1,0 +1,71 @@
+/*
+ * 新版设计 token（tsp = tick-style panel）。
+ *
+ * 只服务于新页面（src/pages/market/* 等 tailwind 语义类页面），
+ * 与既有 Bootstrap 体系（theme.css）共存：
+ * - preflight 已关闭，不会重置旧页面样式
+ * - 变量挂在 :root（暗色默认）与 [data-theme="light"]，随 ThemeContext 自动切换
+ * - 品牌色沿用本项目靛蓝 #6366f1（hsl 239 84% 67%），而非参考项目的电光蓝
+ */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --ts-canvas: 240 5% 5%;
+  --ts-surface: 240 7% 10%;
+  --ts-elevated: 240 9% 14%;
+  --ts-border: 240 5% 22%;
+  --ts-fg-primary: 0 0% 98%;
+  --ts-fg-secondary: 240 5% 78%;
+  --ts-fg-muted: 240 5% 58%;
+  --ts-accent: 239 84% 67%;
+  --ts-bull: 4 87% 60%; /* A 股口径：红涨 */
+  --ts-bear: 152 67% 45%; /* 绿跌 */
+  --ts-warning: 32 95% 50%;
+  --ts-danger: 0 72% 51%;
+}
+
+[data-theme='light'] {
+  --ts-canvas: 240 10% 97%;
+  --ts-surface: 0 0% 100%;
+  --ts-elevated: 240 5% 94%;
+  --ts-border: 240 6% 86%;
+  --ts-fg-primary: 240 6% 10%;
+  --ts-fg-secondary: 240 4% 35%;
+  --ts-fg-muted: 240 5% 45%;
+  --ts-accent: 239 84% 60%;
+  --ts-bull: 4 74% 52%;
+  --ts-bear: 152 69% 38%;
+  --ts-warning: 32 95% 44%;
+  --ts-danger: 0 72% 48%;
+}
+
+@layer base {
+  /* 新页面挂 .tsp-root，内部细滚动条 + 边框分层；不污染旧页面 */
+  .tsp-root {
+    @apply bg-canvas text-fg-primary font-sans text-base;
+  }
+
+  .tsp-root * {
+    border-color: hsl(var(--ts-border));
+  }
+
+  .tsp-root ::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  .tsp-root ::-webkit-scrollbar-thumb {
+    @apply rounded-full bg-line;
+  }
+  .tsp-root ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+}
+
+@layer utilities {
+  /* 数字列：等宽 + 表格数字对齐 */
+  .num {
+    @apply font-mono tabular-nums;
+  }
+}

--- a/frontend/src/theme/ThemeContext.tsx
+++ b/frontend/src/theme/ThemeContext.tsx
@@ -65,13 +65,28 @@ interface ThemeCtx {
 
 const Ctx = createContext<ThemeCtx>({ mode: 'dark', toggle: () => {}, palette: DARK })
 
+const THEME_STORAGE_KEY = 'qa-theme'
+
+function initialTheme(): ThemeMode {
+  try {
+    return localStorage.getItem(THEME_STORAGE_KEY) === 'light' ? 'light' : 'dark'
+  } catch {
+    return 'dark'
+  }
+}
+
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [mode, setMode] = useState<ThemeMode>('dark')
+  const [mode, setMode] = useState<ThemeMode>(initialTheme)
 
   useEffect(() => {
     const root = document.documentElement
     root.setAttribute('data-theme', mode)
     root.setAttribute('data-bs-theme', mode)
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, mode)
+    } catch {
+      // 隐私模式等场景 localStorage 不可用时静默降级
+    }
   }, [mode])
 
   const value = useMemo<ThemeCtx>(

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,73 @@
+import type { Config } from 'tailwindcss'
+
+/**
+ * 新版设计体系（参考 tick-stock-panel 的语义 token 架构，品牌色沿用本项目靛蓝）。
+ *
+ * 约定：
+ * - preflight 关闭：与既有 Bootstrap 页面共存，旧页面不受影响
+ * - 语义色全部映射 HSL CSS 变量（见 src/styles/tsp.css），随 data-theme 自动切换
+ * - 暗色不使用阴影，靠 1px 边框分层
+ * - 数字一律 font-mono + tabular-nums（.num 工具类）
+ */
+const config: Config = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  darkMode: ['class', '[data-theme="dark"]'],
+  corePlugins: {
+    preflight: false,
+  },
+  theme: {
+    extend: {
+      colors: {
+        canvas: 'hsl(var(--ts-canvas) / <alpha-value>)',
+        surface: 'hsl(var(--ts-surface) / <alpha-value>)',
+        elevated: 'hsl(var(--ts-elevated) / <alpha-value>)',
+        line: 'hsl(var(--ts-border) / <alpha-value>)',
+        'fg-primary': 'hsl(var(--ts-fg-primary) / <alpha-value>)',
+        'fg-secondary': 'hsl(var(--ts-fg-secondary) / <alpha-value>)',
+        'fg-muted': 'hsl(var(--ts-fg-muted) / <alpha-value>)',
+        accent: 'hsl(var(--ts-accent) / <alpha-value>)',
+        bull: 'hsl(var(--ts-bull) / <alpha-value>)',
+        bear: 'hsl(var(--ts-bear) / <alpha-value>)',
+        warning: 'hsl(var(--ts-warning) / <alpha-value>)',
+        danger: 'hsl(var(--ts-danger) / <alpha-value>)',
+      },
+      borderRadius: {
+        card: '8px',
+        btn: '6px',
+        input: '4px',
+        dialog: '12px',
+      },
+      fontFamily: {
+        sans: [
+          'Inter',
+          '"HarmonyOS Sans SC"',
+          '"PingFang SC"',
+          '"Microsoft YaHei"',
+          'system-ui',
+          'sans-serif',
+        ],
+        mono: [
+          '"JetBrains Mono"',
+          'ui-monospace',
+          'SFMono-Regular',
+          'Menlo',
+          'Consolas',
+          'monospace',
+        ],
+      },
+      fontSize: {
+        '2xs': ['10px', '14px'],
+        xs: ['11px', '16px'],
+        sm: ['12px', '18px'],
+        base: ['13px', '20px'],
+        lg: ['15px', '22px'],
+      },
+      transitionTimingFunction: {
+        smooth: 'cubic-bezier(0.16, 1, 0.3, 1)',
+      },
+    },
+  },
+  plugins: [],
+}
+
+export default config

--- a/tests/api/test_market_api.py
+++ b/tests/api/test_market_api.py
@@ -57,10 +57,20 @@ class _FakeBoardService:
         self.ladder = {"days": []}
         self.boards = {"tag": "industry", "items": []}
         self.constituents = {"code": "881101.TI", "items": []}
+        self.hot = {"period": "day", "hot": [], "skyrocket": []}
+        self.search = {"query": "茅台", "items": []}
         self.kwargs = {}
 
     def get_limit_up_pool(self, date=None, page=1, size=100):
         self.kwargs["pool"] = (date, page, size)
+        return self.pool
+
+    def get_limit_down_pool(self, date=None, page=1, size=100):
+        self.kwargs["down_pool"] = (date, page, size)
+        return self.pool
+
+    def get_limit_break_pool(self, date=None, page=1, size=100):
+        self.kwargs["break_pool"] = (date, page, size)
         return self.pool
 
     def get_limit_up_ladder(self):
@@ -73,6 +83,14 @@ class _FakeBoardService:
     def get_board_constituents(self, code):
         self.kwargs["board_code"] = code
         return self.constituents
+
+    def get_hot_stocks(self, period="day"):
+        self.kwargs["period"] = period
+        return self.hot
+
+    def search_tickers(self, query, limit=10):
+        self.kwargs["search"] = (query, limit)
+        return self.search
 
 
 @pytest.fixture()
@@ -146,6 +164,29 @@ def test_limit_up_pool_validates_params(app, fake_service):
         app.test_client().get("/api/market/limit-up/pool?date=2026-09-04").status_code == 400
     )
     assert app.test_client().get("/api/market/limit-up/pool?page=x").status_code == 400
+
+
+def test_limit_down_and_break_pools(app, fake_service):
+    resp = app.test_client().get("/api/market/limit-down/pool?date=20260904")
+    assert resp.get_json()["code"] == 200
+    assert fake_service.board.kwargs["down_pool"] == ("20260904", 1, 100)
+    resp = app.test_client().get("/api/market/limit-break/pool?size=50")
+    assert resp.get_json()["code"] == 200
+    assert fake_service.board.kwargs["break_pool"] == (None, 1, 50)
+
+
+def test_hot_stocks_endpoint(app, fake_service):
+    assert app.test_client().get("/api/market/hot-stocks?period=week").status_code == 400
+    resp = app.test_client().get("/api/market/hot-stocks?period=hour")
+    assert resp.get_json()["code"] == 200
+    assert fake_service.board.kwargs["period"] == "hour"
+
+
+def test_ticker_search_endpoint(app, fake_service):
+    assert app.test_client().get("/api/market/ticker-search?q=m").status_code == 400
+    resp = app.test_client().get("/api/market/ticker-search?q=茅台")
+    assert resp.get_json()["code"] == 200
+    assert fake_service.board.kwargs["search"] == ("茅台", 10)
 
 
 def test_limit_up_ladder_endpoint(app, fake_service):

--- a/tests/api/test_market_api.py
+++ b/tests/api/test_market_api.py
@@ -1,0 +1,117 @@
+"""market_api / datasources_api 契约测试（fake 服务注入）。"""
+
+import pytest
+from flask import Flask
+
+from app.api.market_api import datasources_bp, market_bp
+
+pytestmark = pytest.mark.module_data_jobs
+
+
+@pytest.fixture()
+def app():
+    app = Flask(__name__)
+    app.config.update(TESTING=True)
+    app.register_blueprint(market_bp)
+    app.register_blueprint(datasources_bp)
+    return app
+
+
+class _FakeService:
+    def __init__(self):
+        self.quotes = {}
+        self.dashboard = {"breadth": {"up": 1}, "degraded": False}
+        self.indices = [{"ts_code": "000001.SH", "last_price": 3000.0, "pct_chg": 0.5}]
+        self.dragon = {"trade_date": "20260904"}
+        self.auction = {"item": []}
+        self.status = {"tushare": {"configured": True}}
+        self.kwargs = {}
+
+    def get_quotes(self, codes):
+        self.kwargs["codes"] = codes
+        return {c: {"ts_code": c} for c in codes}
+
+    def get_dashboard(self):
+        return self.dashboard
+
+    def get_indices(self, symbols=None):
+        self.kwargs["indices"] = symbols
+        return self.indices
+
+    def get_dragon_tiger(self, board_type="all", date=None):
+        self.kwargs["dragon"] = (board_type, date)
+        return self.dragon
+
+    def get_auction_benchmark(self, date=None):
+        self.kwargs["auction"] = date
+        return self.auction
+
+    def get_source_status(self, force=False):
+        self.kwargs["force"] = force
+        return self.status
+
+
+@pytest.fixture()
+def fake_service(monkeypatch):
+    service = _FakeService()
+    monkeypatch.setattr(
+        "app.api.market_api.get_market_snapshot_service", lambda: service
+    )
+    return service
+
+
+def test_snapshot_requires_codes(app):
+    resp = app.test_client().get("/api/market/snapshot")
+    assert resp.status_code == 400
+
+
+def test_snapshot_returns_envelope(app, fake_service):
+    resp = app.test_client().get("/api/market/snapshot?codes=600000.SH,000001.SZ")
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["code"] == 200
+    assert set(payload["data"]["quotes"]) == {"600000.SH", "000001.SZ"}
+    assert fake_service.kwargs["codes"] == ["600000.SH", "000001.SZ"]
+
+
+def test_dashboard_endpoint(app, fake_service):
+    resp = app.test_client().get("/api/market/dashboard")
+    assert resp.get_json()["data"]["breadth"]["up"] == 1
+
+
+def test_indices_endpoint_default_and_custom(app, fake_service):
+    app.test_client().get("/api/market/indices")
+    assert fake_service.kwargs["indices"] is None
+    app.test_client().get("/api/market/indices?codes=399001.SZ")
+    assert fake_service.kwargs["indices"] == ["399001.SZ"]
+
+
+def test_dragon_tiger_validates_board(app, fake_service):
+    resp = app.test_client().get("/api/market/dragon-tiger?board=wrong")
+    assert resp.status_code == 400
+    resp = app.test_client().get("/api/market/dragon-tiger?board=org&date=20260904")
+    assert resp.get_json()["code"] == 200
+    assert fake_service.kwargs["dragon"] == ("org", "20260904")
+
+
+def test_auction_benchmark_endpoint(app, fake_service):
+    resp = app.test_client().get("/api/market/auction-benchmark?date=20260903")
+    assert resp.get_json()["code"] == 200
+    assert fake_service.kwargs["auction"] == "20260903"
+
+
+def test_datasource_status_endpoint(app, fake_service):
+    resp = app.test_client().get("/api/datasources/status?force=1")
+    assert resp.get_json()["data"]["tushare"]["configured"] is True
+    assert fake_service.kwargs["force"] is True
+
+
+def test_api_error_envelope_on_service_exception(app, monkeypatch):
+    class _Boom:
+        def get_dashboard(self):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr("app.api.market_api.get_market_snapshot_service", lambda: _Boom())
+    resp = app.test_client().get("/api/market/dashboard")
+    assert resp.status_code == 500
+    assert resp.get_json()["code"] == 500

--- a/tests/api/test_market_api.py
+++ b/tests/api/test_market_api.py
@@ -51,12 +51,41 @@ class _FakeService:
         return self.status
 
 
+class _FakeBoardService:
+    def __init__(self):
+        self.pool = {"date": "20260904", "total": 1, "items": []}
+        self.ladder = {"days": []}
+        self.boards = {"tag": "industry", "items": []}
+        self.constituents = {"code": "881101.TI", "items": []}
+        self.kwargs = {}
+
+    def get_limit_up_pool(self, date=None, page=1, size=100):
+        self.kwargs["pool"] = (date, page, size)
+        return self.pool
+
+    def get_limit_up_ladder(self):
+        return self.ladder
+
+    def get_boards(self, tag):
+        self.kwargs["tag"] = tag
+        return self.boards
+
+    def get_board_constituents(self, code):
+        self.kwargs["board_code"] = code
+        return self.constituents
+
+
 @pytest.fixture()
 def fake_service(monkeypatch):
     service = _FakeService()
+    board = _FakeBoardService()
     monkeypatch.setattr(
         "app.api.market_api.get_market_snapshot_service", lambda: service
     )
+    monkeypatch.setattr(
+        "app.api.market_api.get_board_market_service", lambda: board
+    )
+    service.board = board
     return service
 
 
@@ -104,6 +133,40 @@ def test_datasource_status_endpoint(app, fake_service):
     resp = app.test_client().get("/api/datasources/status?force=1")
     assert resp.get_json()["data"]["tushare"]["configured"] is True
     assert fake_service.kwargs["force"] is True
+
+
+def test_limit_up_pool_endpoint(app, fake_service):
+    resp = app.test_client().get("/api/market/limit-up/pool?date=20260904&page=2&size=50")
+    assert resp.get_json()["code"] == 200
+    assert fake_service.board.kwargs["pool"] == ("20260904", 2, 50)
+
+
+def test_limit_up_pool_validates_params(app, fake_service):
+    assert (
+        app.test_client().get("/api/market/limit-up/pool?date=2026-09-04").status_code == 400
+    )
+    assert app.test_client().get("/api/market/limit-up/pool?page=x").status_code == 400
+
+
+def test_limit_up_ladder_endpoint(app, fake_service):
+    resp = app.test_client().get("/api/market/limit-up/ladder")
+    assert resp.get_json()["data"] == {"days": []}
+
+
+def test_boards_endpoint_validates_tag(app, fake_service):
+    assert app.test_client().get("/api/market/boards?tag=sector").status_code == 400
+    resp = app.test_client().get("/api/market/boards?tag=cn_concept")
+    assert resp.get_json()["code"] == 200
+    assert fake_service.board.kwargs["tag"] == "cn_concept"
+
+
+def test_board_constituents_endpoint(app, fake_service):
+    assert (
+        app.test_client().get("/api/market/boards/constituents").status_code == 400
+    )
+    resp = app.test_client().get("/api/market/boards/constituents?code=881101.TI")
+    assert resp.get_json()["code"] == 200
+    assert fake_service.board.kwargs["board_code"] == "881101.TI"
 
 
 def test_api_error_envelope_on_service_exception(app, monkeypatch):

--- a/tests/data_jobs/test_daily_history_fuyao_contract.py
+++ b/tests/data_jobs/test_daily_history_fuyao_contract.py
@@ -1,0 +1,100 @@
+"""daily_history_fuyao 合约测试：脚本主流程、schema 同构、注册表元数据。
+
+数据源契约：fuyao 是 daily_history/daily 表的可选生产者，产出必须与
+ParquetDataReader.STANDARD_COLUMNS["daily"] 完全兼容。
+"""
+
+import os
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from app.services.data_jobs.registry import JobRegistry
+from app.services.data_reader import ParquetDataReader
+from app.utils import daily_history_fuyao
+from app.utils.data_sources.fuyao_normalize import DAILY_COLUMNS
+
+pytestmark = pytest.mark.module_data_jobs
+
+
+def _fake_fetcher(monkeypatch, frames):
+    class _FakeFetcher:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def fetch_dates(self, trade_dates):
+            return {d: frames[d] for d in trade_dates if d in frames}
+
+    monkeypatch.setattr(daily_history_fuyao, "FuyaoDailyFetcher", _FakeFetcher)
+
+
+def _sample_frame(ts_code="000001.SZ", trade_date="20260904"):
+    return pd.DataFrame([
+        {
+            "ts_code": ts_code, "trade_date": trade_date, "open": 11.86, "high": 12.0,
+            "low": 11.85, "close": 11.89, "pre_close": 11.88, "change": 0.01,
+            "pct_chg": 0.0842, "vol": 814372.0, "amount": 969948.44,
+        }
+    ])
+
+
+@pytest.fixture
+def data_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("DATA_JOB_TRADE_DATE", "20260904")
+    for key in ("DATA_JOB_START_DATE", "DATA_JOB_END_DATE", "DATA_JOB_FULL_REFRESH"):
+        monkeypatch.delenv(key, raising=False)
+    return tmp_path
+
+
+def test_main_writes_partition_with_standard_schema(data_dir, monkeypatch):
+    _fake_fetcher(monkeypatch, {"20260904": _sample_frame()})
+
+    exit_code = daily_history_fuyao.main()
+
+    assert exit_code == 0
+    partition = data_dir / "daily_history" / "daily" / "year=2026" / "month=09" / "day=04"
+    assert (partition / "data.parquet").exists()
+
+
+def test_written_data_readable_via_parquet_reader(data_dir, monkeypatch):
+    """读取侧对数据源无感知：ParquetDataReader 按标准列读出 fuyao 产出。"""
+    _fake_fetcher(monkeypatch, {"20260904": _sample_frame()})
+    daily_history_fuyao.main()
+
+    reader = ParquetDataReader(data_dir=str(data_dir))
+    df = reader.get_daily(ts_codes=["000001.SZ"], start_date="20260904", end_date="20260904")
+    assert not df.empty
+    assert set(DAILY_COLUMNS).issubset(set(df.columns))
+    row = df[df["ts_code"] == "000001.SZ"].iloc[0]
+    assert row["close"] == pytest.approx(11.89)
+    assert row["vol"] == pytest.approx(814372.0)
+
+
+def test_main_fails_when_trade_date_missing(data_dir, monkeypatch, capsys):
+    _fake_fetcher(monkeypatch, {})  # 数据源没有返回任何日期
+
+    exit_code = daily_history_fuyao.main()
+
+    assert exit_code == 1
+    assert "20260904" in capsys.readouterr().out
+
+
+def test_main_noop_without_trade_dates(data_dir, monkeypatch):
+    monkeypatch.delenv("DATA_JOB_TRADE_DATE", raising=False)
+    _fake_fetcher(monkeypatch, {"20260904": _sample_frame()})
+
+    # 无交易日历、无显式参数 → 无可拉取日期，直接成功返回
+    assert daily_history_fuyao.main() == 0
+
+
+def test_registry_metadata_fuyao_source():
+    registry = JobRegistry()
+    job = registry.get_job("daily_history_fuyao")
+    assert job.source_name == "fuyao"
+    assert job.supports_incremental is True
+    assert "trade_calendar" in job.dependencies
+    assert "daily_history_fuyao" in registry._visible_job_types
+    # 与 tushare 版互为同表生产者，两者都在册
+    assert registry.get_job("daily_history_by_date").source_name == "tushare"

--- a/tests/data_jobs/test_financial_fuyao_contract.py
+++ b/tests/data_jobs/test_financial_fuyao_contract.py
@@ -166,3 +166,26 @@ def test_registry_metadata_financial_fuyao():
     registry = JobRegistry()
     assert registry.get_job("financial_fuyao").source_name == "fuyao"
     assert registry.get_job("stock_basic_fuyao").source_name == "fuyao"
+
+
+def test_read_existing_partition_falls_back_to_default_data_root(monkeypatch, tmp_path):
+    """回归：data_dir=None 时必须与 save_to_parquet 同源回退（DATA_DIR→项目 data/），
+    否则分块 flush 各自整分区覆盖，静默丢掉之前块的数据（PR #16 review #1）。"""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    end_date = "20260331"
+    table = "income_statement"
+
+    from app.utils.parquet_writer import save_to_parquet
+
+    existing = pd.DataFrame(
+        {"ts_code": ["600000.SH"], "end_date": [end_date], "ann_date": ["20260420"]}
+    )
+    save_to_parquet(existing, trade_date=end_date, table=table)
+
+    # save_to_parquet 写入的分区，_read_existing_partition 必须能读到
+    found = financial_fuyao._read_existing_partition(table, end_date, data_dir=None)
+    assert found is not None
+    assert list(found["ts_code"]) == ["600000.SH"]
+
+    # 显式 data_dir 仍然生效（指向别处时读不到该分区）
+    assert financial_fuyao._read_existing_partition(table, end_date, data_dir=str(tmp_path / "elsewhere")) is None

--- a/tests/data_jobs/test_financial_fuyao_contract.py
+++ b/tests/data_jobs/test_financial_fuyao_contract.py
@@ -1,0 +1,168 @@
+"""financial_fuyao / stock_basic_fuyao 合约测试：披露期推导、分区合并、主流程。"""
+
+from datetime import date
+
+import pandas as pd
+import pytest
+
+from app.services.data_jobs.registry import JobRegistry
+from app.utils import financial_fuyao, stock_basic_fuyao
+from app.utils.data_sources.fuyao_normalize import financial_items_to_frame
+
+pytestmark = pytest.mark.module_data_jobs
+
+
+# ---- 披露期推导 ----
+
+def test_expected_latest_period_follows_deadlines():
+    assert financial_fuyao.expected_latest_period(date(2026, 9, 5)) == "20260630"   # H1 截止 8/31 已过
+    assert financial_fuyao.expected_latest_period(date(2026, 8, 30)) == "20260331"  # H1 截止未到
+    assert financial_fuyao.expected_latest_period(date(2026, 5, 1)) == "20260331"   # Q1 截止 4/30 已过
+    assert financial_fuyao.expected_latest_period(date(2026, 1, 5)) == "20250930"   # FY 截止次年 4/30
+    assert financial_fuyao.expected_latest_period(date(2026, 4, 29)) == "20250930"  # Q1 截止前一天
+    assert financial_fuyao.expected_latest_period(date(2026, 4, 30)) == "20260331"  # 截止日当天即视为已披露
+
+
+def test_resolve_fetch_periods_includes_correction_window():
+    periods = financial_fuyao.resolve_fetch_periods("20260331", "20260630")
+    assert periods == ["20260331", "20260630"]
+    # 冷启动：5 年窗口
+    assert len(financial_fuyao.resolve_fetch_periods(None, "20260630")) >= 18
+
+
+# ---- 分区合并 ----
+
+def _income_frame(ts_code, end_date, ann_date, revenue):
+    return financial_items_to_frame(
+        [{"thscode": ts_code, "period_end_ms": _ms(end_date), "report_date_ms": _ms(ann_date),
+          "operating_income": revenue}],
+        "income", ts_code,
+    )
+
+
+def _ms(ymd):
+    from datetime import datetime
+
+    return int((datetime.strptime(ymd, "%Y%m%d") - datetime(1970, 1, 1)).total_seconds() * 1000) - 8 * 3600 * 1000
+
+
+def test_merge_partition_keeps_latest_announcement():
+    existing = _income_frame("600000.SH", "20260630", "20260820", 100.0)
+    # 更正公告（更晚的 ann_date）应覆盖旧值
+    restatement = _income_frame("600000.SH", "20260630", "20260901", 200.0)
+    merged = financial_fuyao._merge_partition(existing, restatement)
+    assert len(merged) == 1
+    assert merged.iloc[0]["revenue"] == 200.0
+
+    # 更旧的公告不应覆盖已有值
+    stale = _income_frame("600000.SH", "20260630", "20260701", 50.0)
+    merged = financial_fuyao._merge_partition(existing, stale)
+    assert merged.iloc[0]["revenue"] == 100.0
+
+    # 新标的追加
+    other = _income_frame("000001.SZ", "20260630", "20260825", 10.0)
+    merged = financial_fuyao._merge_partition(existing, other)
+    assert len(merged) == 2
+
+
+def test_merge_partition_with_empty_existing():
+    new = _income_frame("600000.SH", "20260630", "20260820", 100.0)
+    assert len(financial_fuyao._merge_partition(None, new)) == 1
+
+
+# ---- 脚本主流程 ----
+
+class _FakeFuyaoClient:
+    def __init__(self, statements):
+        self.statements = statements  # table -> {ts_code: items}
+
+    def financial_statement(self, table, ts_code, limit=20, period="quarterly"):
+        return self.statements.get(table, {}).get(ts_code, [])
+
+    def snapshot_all(self, max_pages=50):
+        return [], None
+
+
+def test_financial_main_writes_partitions(monkeypatch, tmp_path):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("DATA_JOB_FULL_REFRESH", raising=False)
+    items = [{"thscode": "600000.SH", "period_end_ms": _ms("20260630"),
+              "report_date_ms": _ms("20260820"), "operating_income": 100.0}]
+    client = _FakeFuyaoClient({
+        "income": {"600000.SH": items},
+        "balance_sheet": {"600000.SH": [dict(items[0], assets_total=50.0)]},
+        "cash_flow": {"600000.SH": [dict(items[0], act_cash_flow_net=5.0)]},
+    })
+    monkeypatch.setattr(financial_fuyao, "FuyaoClient", lambda: client)
+    monkeypatch.setattr(financial_fuyao, "all_stock_codes", lambda client=None: ["600000.SH"])
+
+    exit_code = financial_fuyao.main()
+
+    assert exit_code == 0
+    for table in ("income_statement", "balance_sheet", "cash_flow"):
+        path = tmp_path / table / "year=2026" / "month=06" / "day=30" / "data.parquet"
+        assert path.exists(), table
+        df = pd.read_parquet(path)
+        assert df.iloc[0]["ts_code"] == "600000.SH"
+        assert df.iloc[0]["end_date"] == "20260630"
+
+
+def test_financial_main_skips_when_local_covers_expected(monkeypatch, tmp_path, capsys):
+    (tmp_path / "income_statement" / "year=2026" / "month=06" / "day=30").mkdir(parents=True)
+    (tmp_path / "balance_sheet" / "year=2026" / "month=06" / "day=30").mkdir(parents=True)
+    (tmp_path / "cash_flow" / "year=2026" / "month=06" / "day=30").mkdir(parents=True)
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    client = _FakeFuyaoClient({})
+    monkeypatch.setattr(financial_fuyao, "FuyaoClient", lambda: client)
+    monkeypatch.setattr(financial_fuyao, "all_stock_codes", lambda client=None: ["600000.SH"])
+
+    exit_code = financial_fuyao.main()
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert out.count("跳过") == 3
+
+
+def test_financial_main_fails_when_no_symbols(monkeypatch, tmp_path):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("DATA_JOB_FULL_REFRESH", raising=False)
+    client = _FakeFuyaoClient({})
+    monkeypatch.setattr(financial_fuyao, "FuyaoClient", lambda: client)
+    monkeypatch.setattr(financial_fuyao, "all_stock_codes", lambda client=None: [])
+
+    assert financial_fuyao.main() == 1
+
+
+# ---- stock_basic_fuyao ----
+
+def test_stock_basic_main_merges_and_saves(monkeypatch, tmp_path):
+    import os
+
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    existing = pd.DataFrame([
+        {"ts_code": "000001.SZ", "symbol": "000001", "name": "旧名称", "industry": "银行", "list_status": "L"},
+    ])
+    existing.to_parquet(tmp_path / "stock_basic.parquet")
+
+    rows = [{"thscode": "000001.SZ", "name": "平安银行"},
+            {"thscode": "301999.SZ", "name": "新股"}]
+    client = _FakeFuyaoClient({})
+    client.snapshot_all = lambda max_pages=50: (rows, 123)
+    monkeypatch.setattr(stock_basic_fuyao, "FuyaoClient", lambda: client)
+
+    exit_code = stock_basic_fuyao.main()
+
+    assert exit_code == 0
+    df = pd.read_parquet(tmp_path / "stock_basic.parquet")
+    assert len(df) == 2
+    by_code = df.set_index("ts_code")
+    assert by_code.loc["000001.SZ", "name"] == "平安银行"
+    assert by_code.loc["000001.SZ", "industry"] == "银行"
+    assert by_code.loc["301999.SZ", "list_status"] == "L"
+    assert os.environ.get("DATA_DIR") == str(tmp_path)
+
+
+def test_registry_metadata_financial_fuyao():
+    registry = JobRegistry()
+    assert registry.get_job("financial_fuyao").source_name == "fuyao"
+    assert registry.get_job("stock_basic_fuyao").source_name == "fuyao"

--- a/tests/data_jobs/test_registry.py
+++ b/tests/data_jobs/test_registry.py
@@ -27,12 +27,14 @@ def test_registry_visible_jobs_follow_whitelist():
     jobs = registry.list_visible_jobs()
     job_types = [job.job_type for job in jobs]
 
-    assert len(job_types) == 10
+    assert len(job_types) == 12
     assert job_types == [
         "trade_calendar",
         "stock_basic",
+        "stock_basic_fuyao",
         "stock_company",
         "daily_history_by_date",
+        "daily_history_fuyao",
         "daily_basic",
         "moneyflow",
         "stk_factor",

--- a/tests/services/test_board_market_service.py
+++ b/tests/services/test_board_market_service.py
@@ -1,0 +1,176 @@
+"""board_market_service 契约测试（fake 客户端注入，不发真实请求）。"""
+
+import time
+
+import pytest
+
+from app.services import board_market_service as bms
+from app.utils.data_sources.fuyao_client import FuyaoError
+
+pytestmark = pytest.mark.module_data_jobs
+
+
+def _pool_row(thscode="605577.SH", cnt=5):
+    return {
+        "thscode": thscode,
+        "ticker": thscode.split(".")[0],
+        "name": "龙版传媒",
+        "is_st": False,
+        "is_new": False,
+        "last_price": 15.55,
+        "price_change_ratio_pct": 9.9717,
+        "limit_up_time": "09:31",
+        "limit_up_reason": "AI漫剧+出版发行",
+        "continue_day_text": f"{cnt}连板",
+        "continue_day_cnt": cnt,
+        "seal_money": 83333989,
+        "max_seal_money": 167993942.95,
+    }
+
+
+class _FakeClient:
+    def __init__(self):
+        self.trading_days_value = [{"date_ms": 0, "date": "20260904"}]
+        self.pool_data = {
+            "pagination": {"total": 1, "pages": 1, "size": 100, "page": 1},
+            "item": [_pool_row()],
+        }
+        self.ladder_data = {
+            "item": [
+                {
+                    "date": "2026-09-04",
+                    "boards": {
+                        "two_board": [{"thscode": "600108.SH"}] * 6,
+                        "five_board": [{"thscode": "605577.SH"}],
+                    },
+                }
+            ]
+        }
+        self.catalog_data = [
+            {"thscode": "881101.TI", "name": "种植业与林业"},
+            {"thscode": "884001.TI", "name": "种子生产"},
+        ]
+        self.snapshot_rows = [
+            {
+                "thscode": "881101.TI",
+                "last_price": 4890.6,
+                "price_change_ratio_pct": 2.476,
+                "turnover": 17778347000,
+                "volume": 2296708100,
+            }
+        ]
+        self.constituents = [
+            {"thscode": "000998.SZ", "ticker": "000998", "name": "隆平高科"}
+        ]
+        self.calls = []
+
+    def trading_days(self):
+        self.calls.append("trading_days")
+        return self.trading_days_value
+
+    def limit_up_pool(self, date_ms=None, page=1, size=100, **_):
+        self.calls.append(("pool", date_ms, page, size))
+        return self.pool_data
+
+    def limit_up_ladder(self):
+        self.calls.append("ladder")
+        return self.ladder_data
+
+    def ths_index_catalog(self, tag=None):
+        self.calls.append(("catalog", tag))
+        return self.catalog_data
+
+    def index_snapshot(self, thscodes):
+        self.calls.append(("snapshot", list(thscodes)))
+        return [r for r in self.snapshot_rows if r["thscode"] in thscodes], None
+
+    def ths_index_constituents(self, thscode):
+        self.calls.append(("constituents", thscode))
+        return self.constituents
+
+
+@pytest.fixture()
+def service(monkeypatch):
+    svc = bms.BoardMarketService(client=_FakeClient())
+    monkeypatch.setattr(bms, "get_board_market_service", lambda: svc)
+    return svc
+
+
+def test_pool_normalizes_fields_and_resolves_latest_date(service):
+    payload = service.get_limit_up_pool()
+    row = payload["items"][0]
+    assert payload["date"] == "20260904"
+    assert row["ts_code"] == "605577.SH"
+    assert row["pct_chg"] == pytest.approx(9.9717)
+    assert row["continue_day_text"] == "5连板"
+    assert row["seal_money"] == 83333989
+    # date_ms 为北京时间零点
+    (_, date_ms, _, _), = [c for c in service.client.calls if isinstance(c, tuple) and c[0] == "pool"]
+    assert date_ms == 1788451200000
+
+
+def test_pool_rejects_bad_date(service):
+    with pytest.raises(ValueError):
+        service.get_limit_up_pool(date="2026/09/04")
+
+
+def test_pool_serves_stale_on_error(service, monkeypatch):
+    service.get_limit_up_pool(date="20260901")
+
+    def _boom(**_):
+        raise FuyaoError("network", "down")
+
+    service.client.limit_up_pool = _boom
+    # 历史日新鲜期 24h，跳到 24h+30min：新鲜判定失效但仍在 1h 回供窗口内
+    real_monotonic = time.monotonic()
+    monkeypatch.setattr(bms.time, "monotonic", lambda: real_monotonic + 24 * 3600 + 1800)
+    payload = service.get_limit_up_pool(date="20260901")
+    assert payload["stale"] is True
+    assert payload["items"][0]["ts_code"] == "605577.SH"
+
+
+def test_ladder_counts_and_highest(service):
+    payload = service.get_limit_up_ladder()
+    day = payload["days"][0]
+    assert day["counts"] == {"2": 6, "3": 0, "4": 0, "5": 1, "6": 0, "7": 0}
+    assert day["highest"] == 5
+    assert day["total"] == 7
+
+
+def test_boards_joins_catalog_and_snapshot_sorted_desc(service):
+    payload = service.get_boards("industry")
+    assert payload["tag"] == "industry"
+    assert payload["items"][0]["thscode"] == "881101.TI"
+    assert payload["items"][0]["name"] == "种植业与林业"
+    assert payload["items"][0]["pct_chg"] == pytest.approx(2.476)
+    assert payload["unavailable"] == ["884001.TI"]
+
+
+def test_boards_rejects_bad_tag(service):
+    with pytest.raises(ValueError):
+        service.get_boards("sector")
+
+
+def test_constituents_enriched_from_quote_frame(service, monkeypatch):
+    def _fake_quote_index():
+        return {
+            "000998.SZ": {
+                "name": "隆平高科",
+                "last_price": 13.5,
+                "pct_chg": 1.23,
+                "amount_yuan": 8.6e8,
+            }
+        }
+
+    monkeypatch.setattr(service, "_quote_frame_index", _fake_quote_index, raising=False)
+    payload = service.get_board_constituents("884001.TI")
+    row = payload["items"][0]
+    assert payload["code"] == "884001.TI"
+    assert row["name"] == "隆平高科"
+    assert row["last_price"] == 13.5
+    assert row["pct_chg"] == pytest.approx(1.23)
+
+
+def test_fallback_trade_date_skips_weekend():
+    # 纯函数：周末向前回退到周五
+    assert len(bms.BoardMarketService._fallback_trade_date()) == 8

--- a/tests/services/test_board_market_service.py
+++ b/tests/services/test_board_market_service.py
@@ -35,6 +35,47 @@ class _FakeClient:
             "pagination": {"total": 1, "pages": 1, "size": 100, "page": 1},
             "item": [_pool_row()],
         }
+        self.down_pool_data = {
+            "pagination": {"total": 1},
+            "item": [
+                {
+                    "thscode": "002909.SZ",
+                    "name": "集泰股份",
+                    "last_price": 7.21,
+                    "price_change_ratio_pct": -9.9875,
+                    "first_limit_time": "14:33",
+                    "last_limit_time": "14:54",
+                    "turnover_ratio_pct": 37.8386,
+                }
+            ],
+        }
+        self.break_pool_data = {
+            "pagination": {"total": 1},
+            "item": [
+                {
+                    "thscode": "688170.SH",
+                    "name": "德龙激光",
+                    "last_price": 61.9,
+                    "price_change_ratio_pct": 17.5019,
+                    "open_times": 4,
+                    "turnover_ratio_pct": 16.9039,
+                    "turnover": 1068862770.0,
+                }
+            ],
+        }
+        self.hot_data = [
+            {
+                "thscode": "601086.SH",
+                "name": "国芳集团",
+                "rank": 1,
+                "heat": "4741356",
+                "rank_change": 0,
+                "rank_trend": "flat",
+            }
+        ]
+        self.search_data = [
+            {"thscode": "600519.SH", "ticker": "600519", "name": "贵州茅台", "exchange": "SH"}
+        ]
         self.ladder_data = {
             "item": [
                 {
@@ -71,6 +112,26 @@ class _FakeClient:
     def limit_up_pool(self, date_ms=None, page=1, size=100, **_):
         self.calls.append(("pool", date_ms, page, size))
         return self.pool_data
+
+    def limit_down_pool(self, date_ms=None, page=1, size=100, **_):
+        self.calls.append(("down", date_ms, page, size))
+        return self.down_pool_data
+
+    def limit_break_pool(self, date_ms=None, page=1, size=100, **_):
+        self.calls.append(("break", date_ms, page, size))
+        return self.break_pool_data
+
+    def hot_stock_list(self, period="day"):
+        self.calls.append(("hot", period))
+        return self.hot_data
+
+    def skyrocket_list(self, period="day"):
+        self.calls.append(("skyrocket", period))
+        return self.hot_data
+
+    def ticker_search(self, query, asset_type="a-share", limit=10):
+        self.calls.append(("search", query, limit))
+        return self.search_data
 
     def limit_up_ladder(self):
         self.calls.append("ladder")
@@ -174,3 +235,40 @@ def test_constituents_enriched_from_quote_frame(service, monkeypatch):
 def test_fallback_trade_date_skips_weekend():
     # 纯函数：周末向前回退到周五
     assert len(bms.BoardMarketService._fallback_trade_date()) == 8
+
+
+def test_down_and_break_pool_normalization(service):
+    down = service.get_limit_down_pool(date="20260904")
+    assert down["items"][0]["pct_chg"] == pytest.approx(-9.9875)
+    assert down["items"][0]["first_limit_time"] == "14:33"
+
+    broke = service.get_limit_break_pool(date="20260904")
+    assert broke["items"][0]["open_times"] == 4
+    assert broke["items"][0]["turnover"] == 1068862770.0
+    # 同一日期不同池的缓存互不串
+    assert down["items"][0]["ts_code"] == "002909.SZ"
+    assert broke["items"][0]["ts_code"] == "688170.SH"
+
+
+def test_hot_stocks_merges_lists_and_types_heat(service):
+    payload = service.get_hot_stocks("day")
+    assert payload["period"] == "day"
+    assert len(payload["hot"]) == 1
+    assert payload["skyrocket"][0]["heat"] == 4741356.0
+    assert isinstance(payload["hot"][0]["heat"], float)
+    # period 是独立缓存键
+    service.get_hot_stocks("hour")
+    assert ("hot", "hour") in service.client.calls
+
+
+def test_hot_stocks_rejects_bad_period(service):
+    with pytest.raises(ValueError):
+        service.get_hot_stocks("week")
+
+
+def test_ticker_search_passthrough_and_validation(service):
+    payload = service.search_tickers("茅台", limit=5)
+    assert payload["items"][0]["ts_code"] == "600519.SH"
+    assert service.client.calls[-1] == ("search", "茅台", 5)
+    with pytest.raises(ValueError):
+        service.search_tickers("m")

--- a/tests/services/test_market_snapshot_service.py
+++ b/tests/services/test_market_snapshot_service.py
@@ -1,0 +1,188 @@
+"""市场看板聚合与服务层合约测试（fake client，不发网络请求）。"""
+
+import pandas as pd
+import pytest
+
+from app.services import market_snapshot_service as svc_mod
+from app.services.market_dashboard import build_dashboard_payload, limit_ratio_for
+from app.services.market_snapshot_service import MarketSnapshotService
+
+pytestmark = pytest.mark.module_data_jobs
+
+
+def _row(ts_code, price, pct, prev, amount_yuan, name=None):
+    return {"ts_code": ts_code, "name": name, "price": price, "pct_chg": pct,
+            "prev_close": prev, "amount_yuan": amount_yuan}
+
+
+def _frame(rows):
+    return pd.DataFrame(rows)
+
+
+# ---- 聚合 ----
+
+def test_dashboard_breadth_distribution_and_boards():
+    rows = [
+        _row("000001.SZ", 11.0, 3.0, 10.677, 2e9, "甲"),
+        _row("000002.SZ", 5.0, -3.0, 5.1, 1e9, "乙"),
+        _row("300001.SZ", 10.0, 20.05, 8.33, 5e8, "丙"),   # 创业板 20% 涨停近似
+        _row("600000.SH", 9.0, 0.0, 9.0, 3e8, "丁"),
+        _row("600001.SH", 8.0, -10.5, 8.94, 2e8, "戊"),    # 主板跌停近似
+    ]
+    payload = build_dashboard_payload(_frame(rows))
+
+    breadth = payload["breadth"]
+    assert breadth["up"] == 2 and breadth["down"] == 2 and breadth["flat"] == 1
+    assert breadth["limit_up"] == 1 and breadth["limit_down"] == 1
+    assert payload["total_amount_yuan"] == pytest.approx(4.0e9)
+
+    dist = {item["bucket"]: item["count"] for item in payload["distribution"]}
+    assert dist["0 ~ 2%"] == 1
+    assert dist["2% ~ 5%"] == 1
+    assert dist["-5% ~ -2%"] == 1
+    assert dist["< -5%"] == 1
+    assert dist[">= 5%"] == 1
+
+    assert payload["top_gainers"][0]["ts_code"] == "300001.SZ"
+    assert payload["top_losers"][0]["ts_code"] == "600001.SH"
+    assert payload["top_amount"][0]["ts_code"] == "000001.SZ"
+
+
+def test_dashboard_empty_frame():
+    payload = build_dashboard_payload(pd.DataFrame())
+    assert payload["breadth"] == {}
+    assert payload["top_gainers"] == []
+
+
+def test_limit_ratio_by_board():
+    assert limit_ratio_for("830001.BJ") == 0.30
+    assert limit_ratio_for("300001.SZ") == 0.20
+    assert limit_ratio_for("688001.SH") == 0.20
+    assert limit_ratio_for("600000.SH") == 0.10
+
+
+# ---- 服务：快照缓存与降级 ----
+
+class _FakeFuyaoClient:
+    def __init__(self, snapshot_items=None, fail=False, empty=False):
+        self.snapshot_items = snapshot_items or []
+        self.fail = fail
+        self.empty = empty
+        self.snapshot_calls = 0
+
+    def snapshot_page(self, limit=None, offset=0, thscodes=None):
+        self.snapshot_calls += 1
+        if self.fail:
+            raise svc_mod.FuyaoError(4001, "限频")
+        if thscodes:
+            wanted = set(thscodes)
+            items = [item for item in self.snapshot_items if item["thscode"] in wanted]
+            return {"item": items}
+        if self.empty:
+            return {"item": []}
+        return {"item": self.snapshot_items}
+
+    def snapshot_all(self, max_pages=50):
+        self.snapshot_calls += 1
+        if self.fail:
+            raise svc_mod.FuyaoError("network", "挂了")
+        if self.empty:
+            return [], None
+        return self.snapshot_items, 123
+
+
+def _snapshot_item(ts_code, price, pct):
+    return {"thscode": ts_code, "last_price": price, "price_change_ratio_pct": pct,
+            "open_price": price, "high_price": price, "low_price": price,
+            "prev_price": price / (1 + pct / 100), "price_change": price * pct / 100,
+            "volume": 1000, "turnover": price * 1000}
+
+
+def test_get_quotes_fetches_and_caches(monkeypatch):
+    client = _FakeFuyaoClient([_snapshot_item("600000.SH", 9.28, 1.2)])
+    service = MarketSnapshotService(client=client)
+
+    quotes = service.get_quotes(["600000.SH", "000001.SZ"])
+    assert "600000.SH" in quotes
+    assert quotes["600000.SH"]["pct_chg"] == pytest.approx(1.2)
+
+    # 第二次命中缓存，不再发请求
+    service.get_quotes(["600000.SH"])
+    assert client.snapshot_calls == 1
+
+
+def test_get_quotes_falls_back_to_stale_cache_on_failure(monkeypatch):
+    client = _FakeFuyaoClient([_snapshot_item("600000.SH", 9.28, 1.2)])
+    service = MarketSnapshotService(client=client)
+    service.get_quotes(["600000.SH"])
+
+    client.fail = True
+    quotes = service.get_quotes(["600000.SH"])
+    assert quotes["600000.SH"]["last_price"] == pytest.approx(9.28)
+
+
+def test_dashboard_degrades_to_local_parquet(monkeypatch, tmp_path):
+    """扶摇失败时回退本地日线最近分区，并标记 degraded。"""
+    client = _FakeFuyaoClient(fail=True)
+    service = MarketSnapshotService(client=client)
+
+    local = pd.DataFrame([
+        {"ts_code": "000001.SZ", "close": 11.0, "pct_chg": 2.0, "pre_close": 10.78, "amount": 1e6},
+        {"ts_code": "600000.SH", "close": 9.0, "pct_chg": -1.0, "pre_close": 9.09, "amount": 2e6},
+    ])
+    import app.utils.parquet_job_helpers as helpers_mod
+    monkeypatch.setattr(helpers_mod, "latest_partition_date", lambda *a, **k: "20260904")
+
+    class _FakeReader:
+        def get_daily(self, **kwargs):
+            return local
+
+    import app.services.data_reader as reader_mod
+    monkeypatch.setattr(reader_mod, "ParquetDataReader", _FakeReader)
+
+    payload = service.get_dashboard()
+
+    assert payload["degraded"] is True
+    assert payload["source"] == "local_parquet"
+    assert payload["as_of"] == "20260904"
+    assert payload["breadth"]["up"] == 1
+    assert "degraded_reason" in payload
+
+
+# ---- 数据源状态 ----
+
+def test_source_status_reports_configuration(monkeypatch):
+    monkeypatch.setenv("TUSHARE_TOKEN", "tok")
+    monkeypatch.setenv("FUYAO_API_KEY", "sk-ok")
+    monkeypatch.setenv("TICKFLOW_API_KEY", "")
+
+    client = _FakeFuyaoClient([_snapshot_item("600000.SH", 9.28, 1.2)])
+    service = MarketSnapshotService(client=client)
+
+    class _FakeTickflow:
+        def __init__(self, api_key=None):
+            pass
+
+        def detect_tier(self):
+            return "none"
+
+    import app.utils.data_sources.tickflow_client as tf_mod
+    monkeypatch.setattr(tf_mod, "TickflowClient", _FakeTickflow)
+
+    status = service.get_source_status(force=True)
+    assert status["tushare"]["configured"] is True
+    assert status["fuyao"]["configured"] is True and status["fuyao"]["ok"] is True
+    assert status["tickflow"]["configured"] is False
+    assert status["tickflow"]["tier"] == "none"
+
+
+def test_source_status_cached(monkeypatch):
+    monkeypatch.setenv("TUSHARE_TOKEN", "tok")
+    monkeypatch.setenv("FUYAO_API_KEY", "sk-ok")
+    monkeypatch.delenv("TICKFLOW_API_KEY", raising=False)
+
+    client = _FakeFuyaoClient([_snapshot_item("600000.SH", 9.28, 1.2)])
+    service = MarketSnapshotService(client=client)
+    service.get_source_status(force=True)
+    service.get_source_status()
+    assert client.snapshot_calls == 1

--- a/tests/services/test_market_snapshot_service.py
+++ b/tests/services/test_market_snapshot_service.py
@@ -186,3 +186,74 @@ def test_source_status_cached(monkeypatch):
     service.get_source_status(force=True)
     service.get_source_status()
     assert client.snapshot_calls == 1
+
+
+# ---- 龙虎榜/竞价缓存（PR #16 review #2/#3 修复的行为锁定）----
+
+import time as _time
+
+from app.utils.data_sources.fuyao_client import FuyaoError
+
+
+class _FakeDayClient:
+    """按调用计数的最小 client：dragon/boom 可切换。"""
+
+    def __init__(self, payload=None, boom=False):
+        self.calls = 0
+        self.payload = payload if payload is not None else {"trade_date": "20260904"}
+        self.boom = boom
+
+    def dragon_tiger_list(self, board_type="all", date=None):
+        self.calls += 1
+        if self.boom:
+            raise FuyaoError("network", "down")
+        return dict(self.payload)
+
+
+def test_dragon_tiger_none_date_cache_expires_and_refetches(monkeypatch):
+    client = _FakeDayClient()
+    service = MarketSnapshotService(client=client)
+    service.get_dragon_tiger()
+    service.get_dragon_tiger()
+    assert client.calls == 1  # 命中短缓存
+
+    real = _time.monotonic()
+    monkeypatch.setattr(svc_mod.time, "monotonic", lambda: real + 301)
+    service.get_dragon_tiger()
+    assert client.calls == 2  # date=None 的"最近发布日"缓存 300s 后过期重取
+
+
+def test_dragon_tiger_serves_stale_on_error(monkeypatch):
+    client = _FakeDayClient()
+    service = MarketSnapshotService(client=client)
+    service.get_dragon_tiger()
+
+    client.boom = True
+    real = _time.monotonic()
+    # 过了新鲜期(300s)但仍在 10 分钟回供窗口内
+    monkeypatch.setattr(svc_mod.time, "monotonic", lambda: real + 600)
+    payload = service.get_dragon_tiger()
+    assert payload["stale"] is True
+    assert payload["trade_date"] == "20260904"  # 回供的是旧值
+    assert client.calls == 2  # 1 次成功 + 恰好 1 次失败尝试，无重试风暴
+
+
+def test_day_cache_capacity_eviction(monkeypatch):
+    client = _FakeDayClient()
+    service = MarketSnapshotService(client=client)
+    monkeypatch.setattr(svc_mod, "DAY_CACHE_MAX_ENTRIES", 2)
+    for d in ("20260901", "20260902", "20260903"):
+        service.get_dragon_tiger(date=d)
+    with service._lock:
+        remaining = set(service._dragon_cache.keys())
+    assert ("all", "20260901") not in remaining  # 最旧被淘汰
+    assert len(remaining) == 2
+
+
+def test_dragon_tiger_cached_payload_is_deep_copied():
+    payload = {"trade_date": "20260904", "stock_items": [{"ts_code": "600000.SH"}]}
+    service = MarketSnapshotService(client=_FakeDayClient(payload=payload))
+    first = service.get_dragon_tiger()
+    first["stock_items"][0]["ts_code"] = "MUTATED"
+    second = service.get_dragon_tiger()
+    assert second["stock_items"][0]["ts_code"] == "600000.SH"

--- a/tests/services/test_stock_name_registry.py
+++ b/tests/services/test_stock_name_registry.py
@@ -1,0 +1,98 @@
+"""StockNameRegistry 契约测试（临时缓存目录 + fake tickflow 客户端）。"""
+
+import pytest
+
+from app.services.stock_name_registry import StockNameRegistry
+
+pytestmark = pytest.mark.module_data_jobs
+
+
+class _FakeTickflow:
+    def __init__(self, per_exchange):
+        self.per_exchange = per_exchange
+        self.exchanges_called = []
+
+    def instruments(self, exchange="SH", instrument_type="stock", limit=5000):
+        self.exchanges_called.append(exchange)
+        return self.per_exchange.get(exchange, [])
+
+
+@pytest.fixture()
+def registry(tmp_path):
+    return StockNameRegistry(cache_path=tmp_path / "instruments.parquet")
+
+
+def test_fetch_names_merges_three_exchanges(monkeypatch):
+    fake = _FakeTickflow(
+        {
+            "SH": [{"symbol": "600000.SH", "name": "浦发银行"}],
+            "SZ": [{"symbol": "000001.SZ", "name": "平安银行"}],
+            "BJ": [{"symbol": "430047.BJ", "name": "诺思兰德"}],
+        }
+    )
+    monkeypatch.setattr(
+        "app.utils.data_sources.tickflow_client.TickflowClient", lambda: fake
+    )
+    from app.services.stock_name_registry import fetch_tickflow_names
+
+    names = fetch_tickflow_names()
+    assert names["600000.SH"] == "浦发银行"
+    assert names["430047.BJ"] == "诺思兰德"
+    assert set(fake.exchanges_called) == {"SH", "SZ", "BJ"}
+
+
+def test_name_map_merges_tickflow_and_stock_basic(registry, monkeypatch):
+    fake = _FakeTickflow(
+        {
+            "SH": [{"symbol": "600000.SH", "name": "浦发银行"},
+                   {"symbol": "603999.SH", "name": "新股示例"}],
+        }
+    )
+    monkeypatch.setattr(
+        "app.services.stock_name_registry.fetch_tickflow_names", lambda client=None: {"600000.SH": "浦发银行", "603999.SH": "新股示例"}
+    )
+    monkeypatch.setattr(
+        "app.services.data_reader.ParquetDataReader.get_stock_basic",
+        lambda self: __import__("pandas").DataFrame(
+            {"ts_code": ["600000.SH"], "name": ["浦发银行(本地)"]}
+        ),
+    )
+    name_map = registry.name_map()
+    # stock_basic 优先，TickFlow 补缺
+    assert name_map["600000.SH"] == "浦发银行(本地)"
+    assert name_map["603999.SH"] == "新股示例"
+
+
+def test_merge_names_fills_missing_only(registry, monkeypatch):
+    monkeypatch.setattr(
+        registry, "name_map", lambda max_age_seconds=None: {"600000.SH": "浦发银行"}
+    )
+    rows = [
+        {"ts_code": "600000.SH", "name": None},
+        {"ts_code": "000001.SZ", "name": "已有名称"},
+    ]
+    merged = registry.merge_names(rows)
+    assert merged[0]["name"] == "浦发银行"
+    assert merged[1]["name"] == "已有名称"
+
+
+def test_cache_roundtrip(registry, monkeypatch):
+    calls = {"n": 0}
+
+    def _fetch(client=None):
+        calls["n"] += 1
+        return {"600000.SH": "浦发银行"}
+
+    monkeypatch.setattr(
+        "app.services.stock_name_registry.fetch_tickflow_names", _fetch
+    )
+    monkeypatch.setattr(
+        "app.services.data_reader.ParquetDataReader.get_stock_basic",
+        lambda self: __import__("pandas").DataFrame(),
+    )
+    registry.name_map()
+    registry.invalidate()
+    registry.name_map()
+    # 第二次走 parquet 落盘缓存，不再触发网络
+    assert calls["n"] == 1
+    assert registry._cache_path.exists()

--- a/tests/utils/test_data_sources_fuyao_client.py
+++ b/tests/utils/test_data_sources_fuyao_client.py
@@ -181,3 +181,45 @@ def test_download_dump_missing_url_raises(client, tmp_path):
     ])
     with pytest.raises(FuyaoError):
         client.download_dump("daily-k", tmp_path / "x.parquet")
+
+
+# ---- 涨跌停特色数据 / 同花顺指数 ----
+
+def test_limit_up_pool_passes_date_ms_and_paging(client):
+    client._session = FakeSession([
+        FakeResponse(payload={"code": 0, "message": "ok", "data": {
+            "pagination": {"total": 1, "page": 2, "size": 50},
+            "item": [{"thscode": "605577.SH", "continue_day_cnt": 5}],
+        }}),
+    ])
+    data = client.limit_up_pool(date_ms=1788451200000, page=2, size=50)
+    call = client._session.calls[0]
+    assert call["url"].endswith("/api/a-share/special-data/limit-up-pool")
+    assert call["params"]["date_ms"] == 1788451200000
+    assert call["params"]["sort_field"] == "continue_day_cnt"
+    assert data["item"][0]["continue_day_cnt"] == 5
+
+
+def test_limit_up_ladder_returns_matrix(client):
+    boards = {"two_board": [{"thscode": "600108.SH"}], "seven_over": []}
+    client._session = FakeSession([
+        FakeResponse(payload={"code": 0, "message": "ok",
+                              "data": {"item": [{"date": "2026-09-04", "boards": boards}]}}),
+    ])
+    data = client.limit_up_ladder()
+    assert data["item"][0]["boards"]["two_board"][0]["thscode"] == "600108.SH"
+
+
+def test_ths_index_catalog_and_constituents(client):
+    client._session = FakeSession([
+        FakeResponse(payload={"code": 0, "message": "ok",
+                              "data": {"item": [{"thscode": "881101.TI", "name": "种植业与林业"}]}}),
+        FakeResponse(payload={"code": 0, "message": "ok",
+                              "data": {"item": [{"thscode": "000998.SZ", "name": "隆平高科"}]}}),
+    ])
+    catalog = client.ths_index_catalog(tag="industry")
+    constituents = client.ths_index_constituents("881101.TI")
+    assert client._session.calls[0]["params"] == {"tag": "industry"}
+    assert client._session.calls[1]["params"] == {"thscode": "881101.TI"}
+    assert catalog[0]["name"] == "种植业与林业"
+    assert constituents[0]["thscode"] == "000998.SZ"

--- a/tests/utils/test_data_sources_fuyao_client.py
+++ b/tests/utils/test_data_sources_fuyao_client.py
@@ -223,3 +223,42 @@ def test_ths_index_catalog_and_constituents(client):
     assert client._session.calls[1]["params"] == {"thscode": "881101.TI"}
     assert catalog[0]["name"] == "种植业与林业"
     assert constituents[0]["thscode"] == "000998.SZ"
+
+
+def test_limit_down_and_break_pools(client):
+    client._session = FakeSession([
+        FakeResponse(payload={"code": 0, "message": "ok", "data": {"pagination": {"total": 9}, "item": [{"thscode": "002909.SZ"}]}}),
+        FakeResponse(payload={"code": 0, "message": "ok", "data": {"pagination": {"total": 48}, "item": [{"thscode": "688170.SH", "open_times": 4}]}}),
+    ])
+    down = client.limit_down_pool(date_ms=1788451200000)
+    broke = client.limit_break_pool(date_ms=1788451200000)
+    assert "/limit-down-pool" in client._session.calls[0]["url"]
+    assert "/limit-break-pool" in client._session.calls[1]["url"]
+    assert down["item"][0]["thscode"] == "002909.SZ"
+    assert broke["item"][0]["open_times"] == 4
+
+
+def test_hot_and_skyrocket_lists(client):
+    client._session = FakeSession([
+        FakeResponse(payload={"code": 0, "message": "ok", "data": {"item": [{"thscode": "601086.SH", "heat": "4741356"}]}}),
+        FakeResponse(payload={"code": 0, "message": "ok", "data": {"item": []}}),
+    ])
+    hot = client.hot_stock_list(period="hour")
+    sky = client.skyrocket_list(period="hour")
+    assert client._session.calls[0]["params"] == {"period": "hour"}
+    assert hot[0]["heat"] == "4741356"
+    assert sky == []
+
+
+def test_ticker_search(client):
+    client._session = FakeSession([
+        FakeResponse(payload={"code": 0, "message": "ok", "data": {
+            "item": [{"thscode": "600519.SH", "name": "贵州茅台", "asset_type": "a-share"}]
+        }}),
+    ])
+    rows = client.ticker_search("茅台", limit=5)
+    call = client._session.calls[0]
+    assert "/api/meta/tickers/search" in call["url"]
+    assert call["params"]["q"] == "茅台"
+    assert call["params"]["limit"] == 5
+    assert rows[0]["name"] == "贵州茅台"

--- a/tests/utils/test_data_sources_fuyao_client.py
+++ b/tests/utils/test_data_sources_fuyao_client.py
@@ -1,0 +1,183 @@
+"""扶摇 REST 客户端合约测试：信封解包、错误码、节流、分页、dump 下载。"""
+
+import time
+
+import pytest
+
+from app.utils.data_sources.fuyao_client import (
+    FuyaoClient,
+    FuyaoError,
+    beijing_ms_to_ymd,
+    release_of,
+)
+
+
+class FakeResponse:
+    def __init__(self, payload=None, status_code=200, text="", chunks=()):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text
+        self._chunks = list(chunks)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("not json")
+        return self._payload
+
+    def iter_content(self, chunk_size=None):
+        return iter(self._chunks)
+
+
+class FakeSession:
+    """按序回放响应，并记录每次调用的 url/headers/params。"""
+
+    def __init__(self, responses=None):
+        self.responses = list(responses or [])
+        self.calls = []
+
+    def get(self, url, headers=None, params=None, timeout=None, stream=False, **kwargs):
+        self.calls.append({"url": url, "headers": headers or {}, "params": params or {}, "stream": stream})
+        if self.responses:
+            return self.responses.pop(0)
+        return FakeResponse(payload={"code": 0, "message": "ok", "data": {}})
+
+    def stream(self, method, url, timeout=None):
+        self.calls.append({"url": url, "headers": {}, "params": {}, "stream": True})
+        return self.responses.pop(0)
+
+
+@pytest.fixture
+def client():
+    return FuyaoClient(api_key="sk-test", throttle_seconds=0)
+
+
+# ---- 时间口径 ----
+
+def test_beijing_ms_to_ymd_uses_beijing_midnight():
+    # 1751385600000 = 2025-07-01 16:00 UTC = 北京时间 2025-07-02 零点
+    assert beijing_ms_to_ymd(1751385600000) == "20250702"
+
+
+def test_beijing_ms_to_ymd_handles_none_and_nan():
+    assert beijing_ms_to_ymd(None) is None
+    assert beijing_ms_to_ymd(float("nan")) is None
+
+
+def test_release_of_extracts_date_from_url():
+    url = "https://o.thsi.cn/x/releases/20260904/a.parquet?sig=abc"
+    assert release_of(url) == "20260904"
+    assert release_of("https://no-release-path/x.parquet") is None
+
+
+# ---- 信封与错误 ----
+
+def test_missing_key_raises_no_key(monkeypatch):
+    monkeypatch.delenv("FUYAO_API_KEY", raising=False)
+    client = FuyaoClient(api_key="", throttle_seconds=0)
+    with pytest.raises(FuyaoError) as exc:
+        client.trading_days()
+    assert "FUYAO_API_KEY" in str(exc.value)
+
+
+def test_error_code_raises_fuyao_error(client):
+    client._session = FakeSession([FakeResponse(payload={"code": 1002, "message": "invalid"})])
+    with pytest.raises(FuyaoError) as exc:
+        client.trading_days()
+    assert exc.value.code == 1002
+    assert not exc.value.is_rate_limited
+
+
+def test_rate_limit_code_flagged(client):
+    client._session = FakeSession([FakeResponse(payload={"code": 4001, "message": "rate"})])
+    with pytest.raises(FuyaoError) as exc:
+        client.trading_days()
+    assert exc.value.is_rate_limited
+
+
+def test_http_error_raises(client):
+    client._session = FakeSession([FakeResponse(status_code=500, text="boom")])
+    with pytest.raises(FuyaoError):
+        client.trading_days()
+
+
+def test_none_params_are_dropped(client):
+    client._session = FakeSession()
+    client.historical_kline("600000.SH", start_ms=123, end_ms=None)
+    params = client._session.calls[0]["params"]
+    assert params["thscode"] == "600000.SH"
+    assert params["start"] == 123
+    assert "end" not in params
+
+
+# ---- 节流 ----
+
+def test_throttle_enforces_min_interval():
+    client = FuyaoClient(api_key="sk-test", throttle_seconds=0.05)
+    client._session = FakeSession()
+    start = time.monotonic()
+    client.trading_days()
+    client.trading_days()
+    elapsed = time.monotonic() - start
+    assert elapsed >= 0.05
+
+
+# ---- 快照分页 ----
+
+def test_snapshot_all_paginates_until_total_reached(client):
+    page1 = {"timestamp": 123, "total": 3, "item": [{"thscode": f"00000{i}.SZ"} for i in (1, 2)]}
+    page2 = {"timestamp": 123, "total": 3, "item": [{"thscode": "000003.SZ"}]}
+    client._session = FakeSession([FakeResponse(payload={"code": 0, "message": "ok", "data": page1}),
+                                   FakeResponse(payload={"code": 0, "message": "ok", "data": page2})])
+    rows, ts = client.snapshot_all()
+    assert len(rows) == 3
+    assert ts == 123
+    assert client._session.calls[0]["params"] == {"limit": 6000, "offset": 0}
+    assert client._session.calls[1]["params"] == {"limit": 6000, "offset": 2}
+
+
+def test_price_snapshot_batch_limits_to_100(client):
+    client._session = FakeSession()
+    client.price_snapshot_batch([f"{i:06d}.SZ" for i in range(150)])
+    thscodes = client._session.calls[0]["params"]["thscodes"].split(",")
+    assert len(thscodes) == 100
+    assert "limit" not in client._session.calls[0]["params"]
+
+
+def test_index_snapshot_joins_codes(client):
+    client._session = FakeSession()
+    client.index_snapshot(["000001.SH", "399001.SZ"])
+    assert client._session.calls[0]["params"] == {"thscodes": "000001.SH,399001.SZ"}
+
+
+# ---- dump 下载 ----
+
+def test_download_dump_uses_presigned_url_without_api_key(client, tmp_path):
+    presigned = "https://oss.example.com/x/releases/20260904/k.parquet?sig=1"
+    client._session = FakeSession([
+        FakeResponse(payload={"code": 0, "message": "ok",
+                              "data": {"presigned_url": presigned}}),
+        FakeResponse(chunks=[b"parquet", b"-bytes"]),
+    ])
+    dest = tmp_path / "cache" / "k__20260904.parquet"
+    result = client.download_dump("daily-k-10d", dest)
+
+    assert result == dest
+    assert dest.read_bytes() == b"parquet-bytes"
+    download_call = client._session.calls[1]
+    assert download_call["url"] == presigned
+    assert "X-api-key" not in download_call["headers"]
+    assert not list(tmp_path.rglob("*.part.*"))  # 临时文件已清理
+
+
+def test_download_dump_missing_url_raises(client, tmp_path):
+    client._session = FakeSession([
+        FakeResponse(payload={"code": 0, "message": "ok", "data": {}}),
+    ])
+    with pytest.raises(FuyaoError):
+        client.download_dump("daily-k", tmp_path / "x.parquet")

--- a/tests/utils/test_data_sources_fuyao_dump.py
+++ b/tests/utils/test_data_sources_fuyao_dump.py
@@ -1,0 +1,137 @@
+"""dump 缓存与三档取数策略合约测试（fake client，不访问网络）。"""
+
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from app.utils.data_sources.fuyao_client import FuyaoError
+from app.utils.data_sources.fuyao_dump import DumpStore, FuyaoDailyFetcher
+from app.utils.data_sources.fuyao_normalize import DAILY_COLUMNS
+
+
+def _beijing_midnight_ms(ymd: str) -> int:
+    dt = datetime.strptime(ymd, "%Y%m%d")
+    return int((dt - datetime(1970, 1, 1)).total_seconds() * 1000) - 8 * 3600 * 1000
+
+
+def _dump_row(ts_code, ymd, close, volume=100_000, turnover=1_000_000):
+    return {
+        "thscode": ts_code, "currency": "CNY", "interval": "1d", "adjusted": "none",
+        "date_ms": _beijing_midnight_ms(ymd),
+        "open_price": close, "high_price": close, "low_price": close, "close_price": close,
+        "volume": volume, "turnover": turnover,
+    }
+
+
+def _dump_frame(ts_codes, ymds):
+    rows = [
+        _dump_row(code, ymd, close=10.0 + i * 0.1)
+        for i, ymd in enumerate(ymds)
+        for code in ts_codes
+    ]
+    return pd.DataFrame(rows)
+
+
+class FakeDumpClient:
+    """dump_download_url/download_dump 的进程内替身。"""
+
+    def __init__(self, dumps):
+        self.dumps = dumps  # kind -> DataFrame
+        self.downloads = []
+
+    def dump_download_url(self, kind):
+        return {"presigned_url": f"https://oss.example.com/releases/20260904/{kind.replace('-', '_')}.parquet"}
+
+    def download_dump(self, kind, dest_path):
+        self.downloads.append(kind)
+        self.dumps[kind].to_parquet(dest_path)
+
+
+def _fetcher(tmp_path, recent_dump=None, full_dump=None):
+    dumps = {}
+    if recent_dump is not None:
+        dumps["daily-k-10d"] = recent_dump
+    if full_dump is not None:
+        dumps["daily-k"] = full_dump
+    client = FakeDumpClient(dumps)
+    store = DumpStore(client, cache_dir=tmp_path)
+    return FuyaoDailyFetcher(client=client, store=store), client
+
+
+# ---- DumpStore ----
+
+def test_dump_store_downloads_once_and_caches_by_release(tmp_path):
+    dumps = {"daily-k-10d": _dump_frame(["000001.SZ"], ["20260904"])}
+    fake = FakeDumpClient(dumps)
+    store = DumpStore(fake, cache_dir=tmp_path)
+
+    path1 = store.ensure_path("daily-k-10d", "daily_k_10d")
+    path2 = store.ensure_path("daily-k-10d", "daily_k_10d")
+    assert path1 == path2
+    assert fake.downloads == ["daily-k-10d"]  # 第二次命中缓存
+
+
+def test_dump_store_reuses_old_full_dump_when_covering_start(tmp_path):
+    """已有 10 年 dump 覆盖请求起点时复用旧 release，不重下 172MB。"""
+    full = _dump_frame(["000001.SZ"], ["20260601", "20260904"])
+    fake = FakeDumpClient({})
+    store = DumpStore(fake, cache_dir=tmp_path)
+    # 预置旧 release 缓存（模拟早前下载）
+    old_path = tmp_path / "daily_k__20260601.parquet"
+    full.to_parquet(old_path)
+
+    path = store.ensure_path("daily-k", "daily_k", reuse_old_if_covers="20260701")
+    assert path == old_path
+    assert fake.downloads == []
+
+
+# ---- FuyaoDailyFetcher 三档策略 ----
+
+def test_fetch_dates_uses_recent_dump_for_near_window(tmp_path):
+    ymds = [f"202609{d:02d}" for d in range(1, 5)]
+    recent = _dump_frame(["000001.SZ", "600000.SH"], ymds)
+    fetcher, fake = _fetcher(tmp_path, recent_dump=recent)
+
+    result = fetcher.fetch_dates(["20260903", "20260904"])
+    assert set(result) == {"20260903", "20260904"}
+    assert set(fake.downloads) == {"daily-k-10d"}  # 未触发 10 年 dump
+    for frame in result.values():
+        assert list(frame.columns) == DAILY_COLUMNS
+    # pre_close 由前一日推导
+    day4 = result["20260904"]
+    assert (day4["pre_close"] == 10.2).all()
+
+
+def test_fetch_dates_falls_back_to_full_dump_for_old_window(tmp_path):
+    recent = _dump_frame(["000001.SZ"], ["20260901", "20260904"])
+    full = _dump_frame(["000001.SZ"], ["20250601", "20250602", "20250603"])
+    fetcher, fake = _fetcher(tmp_path, recent_dump=recent, full_dump=full)
+
+    result = fetcher.fetch_dates(["20250602", "20250603"])
+    assert set(result) == {"20250602", "20250603"}
+    assert "daily-k" in fake.downloads
+    assert "daily-k-10d" in fake.downloads  # 补尾不触发（日期都在大 dump 内）→ 实际是覆盖判断
+    # pre_close 在深窗口内正确推导
+    day3 = result["20250603"]
+    assert day3["pre_close"].notna().all()
+
+
+def test_fetch_dates_rejects_window_beyond_ten_years(tmp_path):
+    full = _dump_frame(["000001.SZ"], ["20250601"])
+    fetcher, _ = _fetcher(tmp_path, recent_dump=_dump_frame(["000001.SZ"], ["20260904"]), full_dump=full)
+    with pytest.raises(FuyaoError) as exc:
+        fetcher.fetch_dates(["20100101", "20260904"])
+    assert exc.value.code == "window_too_long"
+
+
+def test_fetch_dates_rejects_too_many_uncovered_dates(tmp_path):
+    """dump 覆盖不了且缺口超过兜底上限时明确失败，而不是烧数小时单标的接口。"""
+    recent = _dump_frame(["000001.SZ"], ["20260901", "20260904"])
+    # 大 dump 只覆盖 6 月初，缺口 [20250610..20250831] 远超 5 天
+    full = _dump_frame(["000001.SZ"], ["20250601", "20250602"])
+    fetcher, _ = _fetcher(tmp_path, recent_dump=recent, full_dump=full)
+    with pytest.raises(FuyaoError) as exc:
+        fetcher.fetch_dates(["20250610", "20250611", "20250612", "20250613", "20250614", "20250615"])
+    assert exc.value.code == "dates_not_covered"

--- a/tests/utils/test_data_sources_fuyao_normalize.py
+++ b/tests/utils/test_data_sources_fuyao_normalize.py
@@ -1,0 +1,187 @@
+"""归一化层合约测试：单位换算、时区解析、字段映射、schema 同构。"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from app.utils.data_sources.fuyao_normalize import (
+    DAILY_COLUMNS,
+    daily_frame_from_dump,
+    daily_frame_from_kline_rows,
+    financial_items_to_frame,
+    snapshot_rows_to_quote_frame,
+    snapshot_rows_to_stock_basic,
+)
+
+
+def _beijing_midnight_ms(ymd: str) -> int:
+    from datetime import datetime
+
+    dt = datetime.strptime(ymd, "%Y%m%d")
+    epoch = datetime(1970, 1, 1)
+    return int((dt - epoch).total_seconds() * 1000) - 8 * 3600 * 1000
+
+
+def _dump_row(ts_code, ymd, o, h, l, c, volume, turnover, adjusted="none"):
+    return {
+        "thscode": ts_code, "currency": "CNY", "interval": "1d", "adjusted": adjusted,
+        "date_ms": _beijing_midnight_ms(ymd),
+        "open_price": o, "high_price": h, "low_price": l, "close_price": c,
+        "volume": volume, "turnover": turnover,
+    }
+
+
+def _dump_frame(rows):
+    return pd.DataFrame(rows)
+
+
+# ---- daily：dump → tushare 口径 ----
+
+def test_daily_units_and_pre_close_derivation():
+    rows = [
+        _dump_row("000001.SZ", "20260601", 10.0, 11.0, 9.9, 10.5, 1_000_000, 105_000_000),
+        _dump_row("000001.SZ", "20260602", 10.5, 11.5, 10.4, 11.0, 1_234_567, 130_000_000),
+        _dump_row("600000.SH", "20260601", 9.0, 9.5, 8.9, 9.2, 2_000_000, 180_000_000),
+    ]
+    df = daily_frame_from_dump(_dump_frame(rows), ["20260601", "20260602"])
+
+    assert list(df.columns) == DAILY_COLUMNS
+    # vol: 股 → 手（向下取整）
+    row = df[(df.ts_code == "000001.SZ") & (df.trade_date == "20260602")].iloc[0]
+    assert row["vol"] == np.floor(1_234_567 / 100)
+    # amount: 元 → 千元
+    assert row["amount"] == pytest.approx(130_000.0)
+    # pre_close 来自前一交易日 close
+    assert row["pre_close"] == pytest.approx(10.5)
+    assert row["change"] == pytest.approx(0.5)
+    assert row["pct_chg"] == pytest.approx(round((11.0 / 10.5 - 1) * 100, 4))
+    # 首个交易日无前收盘 → change/pct_chg 为 NaN
+    first = df[(df.ts_code == "000001.SZ") & (df.trade_date == "20260601")].iloc[0]
+    assert np.isnan(first["pre_close"]) and np.isnan(first["pct_chg"])
+
+
+def test_daily_single_date_keeps_pre_close_from_dump_context():
+    """只取一天时 pre_close 仍由 dump 内前一交易日推导（先推导后过滤）。"""
+    rows = [
+        _dump_row("000001.SZ", "20260601", 10.0, 11.0, 9.9, 10.5, 1_000_000, 105_000_000),
+        _dump_row("000001.SZ", "20260602", 10.5, 11.5, 10.4, 11.0, 1_200_000, 130_000_000),
+    ]
+    df = daily_frame_from_dump(_dump_frame(rows), ["20260602"])
+    assert len(df) == 1
+    assert df.iloc[0]["pre_close"] == pytest.approx(10.5)
+
+
+def test_daily_filters_date_range_and_non_raw_adjusted():
+    rows = [
+        _dump_row("000001.SZ", "20260601", 10.0, 11.0, 9.9, 10.5, 1_000_000, 105_000_000),
+        _dump_row("000001.SZ", "20260603", 10.5, 11.5, 10.4, 11.0, 1_200_000, 130_000_000),
+        # 复权口径行必须被拒绝（防御 dump 混源）
+        _dump_row("000001.SZ", "20260604", 11.0, 12.0, 10.9, 11.5, 1_200_000, 130_000_000, adjusted="forward"),
+    ]
+    df = daily_frame_from_dump(_dump_frame(rows), ["20260603", "20260604"])
+    assert sorted(df["trade_date"].unique()) == ["20260603"]
+    assert len(df) == 1
+
+
+def test_daily_drops_halted_rows():
+    rows = [
+        _dump_row("000001.SZ", "20260601", 10.0, 11.0, 9.9, 10.5, 1_000_000, 105_000_000),
+        _dump_row("000001.SZ", "20260602", None, None, None, None, 0, 0),  # 停牌日
+    ]
+    df = daily_frame_from_dump(_dump_frame(rows), ["20260601", "20260602"])
+    assert "20260602" not in set(df["trade_date"])
+
+
+def test_daily_from_kline_rows_maps_metadata():
+    rows = [
+        {"date_ms": _beijing_midnight_ms("20260601"), "open_price": 1, "high_price": 2,
+         "low_price": 0.5, "close_price": 1.5, "volume": 500, "turnover": 750},
+        {"date_ms": _beijing_midnight_ms("20260602"), "open_price": 1.5, "high_price": 2.5,
+         "low_price": 1.4, "close_price": 2.0, "volume": 600, "turnover": 1200},
+    ]
+    df = daily_frame_from_kline_rows(rows, "600000.SH")
+    assert list(df.columns) == DAILY_COLUMNS
+    assert set(df["ts_code"]) == {"600000.SH"}
+    assert df.iloc[1]["pre_close"] == pytest.approx(1.5)
+    assert df.iloc[0]["vol"] == 5.0
+
+
+# ---- 财务三表 ----
+
+def test_financial_items_map_to_tushare_columns_with_passthrough():
+    items = [{
+        "thscode": "600000.SH", "period": "quarterly", "fiscal_year": 2026, "fiscal_period": "Q2",
+        "report_date_ms": _beijing_midnight_ms("20260824"), "period_end_ms": _beijing_midnight_ms("20260630"),
+        "currency": "CNY", "operating_income": 100, "net_profit": 10, "parent_holder_net_profit": 8,
+        "basic_eps": 0.5, "extra_fuyao_field": 42,
+    }]
+    df = financial_items_to_frame(items, "income", "600000.SH")
+
+    assert df.iloc[0]["ts_code"] == "600000.SH"
+    assert df.iloc[0]["end_date"] == "20260630"
+    assert df.iloc[0]["ann_date"] == "20260824"
+    assert df.iloc[0]["revenue"] == 100        # operating_income → revenue
+    assert df.iloc[0]["n_income"] == 10        # net_profit → n_income
+    assert df.iloc[0]["n_income_attr_p"] == 8  # parent_holder_net_profit → n_income_attr_p
+    assert df.iloc[0]["extra_fuyao_field"] == 42  # 独有字段原名透传
+    assert "operating_income" not in df.columns
+
+
+def test_financial_null_stays_nan_not_zero():
+    items = [{
+        "thscode": "600000.SH", "report_date_ms": None, "period_end_ms": _beijing_midnight_ms("20260630"),
+        "operating_income": 100, "operating_costs": None,
+    }]
+    df = financial_items_to_frame(items, "income", "600000.SH")
+    assert pd.isna(df.iloc[0]["oper_cost"])
+
+
+def test_financial_unknown_table_raises():
+    with pytest.raises(ValueError):
+        financial_items_to_frame([], "shares", "600000.SH")
+
+
+# ---- 快照 ----
+
+def test_quote_frame_handles_dual_field_naming():
+    rows = [
+        {"thscode": "000001.SZ", "name": "平安银行", "last_price": 11.89, "open_price": 11.86,
+         "high_price": 12.0, "low_price": 11.85, "prev_price": 11.88,
+         "price_change": 0.01, "price_change_ratio_pct": 0.084, "volume": 100, "turnover": 200},
+        {"thscode": "600000.SH", "name": "浦发银行", "last_price": 9.2, "open_price": 9.1,
+         "highest_price": 9.4, "lowest_price": 9.0, "prev_close_price": 9.1,
+         "price_change": 0.1, "price_change_ratio_pct": 1.1, "volume": None, "turnover": None},
+    ]
+    df = snapshot_rows_to_quote_frame(rows)
+    assert df.iloc[0]["high"] == 12.0 and df.iloc[0]["prev_close"] == 11.88
+    assert df.iloc[1]["high"] == 9.4 and df.iloc[1]["prev_close"] == 9.1
+    assert np.isnan(df.iloc[1]["volume"])
+
+
+def test_quote_frame_drops_rows_without_code():
+    df = snapshot_rows_to_quote_frame([{"name": "no code"}, {"thscode": "000001.SZ", "last_price": 1}])
+    assert len(df) == 1
+
+
+def test_stock_basic_refresh_names_and_appends_new_codes():
+    existing = pd.DataFrame([
+        {"ts_code": "000001.SZ", "symbol": "000001", "name": "旧名称", "industry": "银行", "list_status": "L"},
+        {"ts_code": "000002.SZ", "symbol": "000002", "name": "万科A", "industry": "地产", "list_status": "L"},
+    ])
+    rows = [
+        {"thscode": "000001.SZ", "name": "平安银行"},
+        {"thscode": "300001.SZ", "name": "特锐德"},  # 新增代码
+    ]
+    df = snapshot_rows_to_stock_basic(rows, existing)
+    by_code = df.set_index("ts_code")
+    assert by_code.loc["000001.SZ", "name"] == "平安银行"
+    assert by_code.loc["000001.SZ", "industry"] == "银行"  # 元数据保留
+    assert by_code.loc["000002.SZ", "name"] == "万科A"     # 缺席快照的记录保留
+    assert by_code.loc["300001.SZ", "list_status"] == "L"  # 新增记录标记在市
+    assert pd.isna(by_code.loc["300001.SZ", "industry"])
+
+
+def test_stock_basic_from_empty_existing():
+    df = snapshot_rows_to_stock_basic([{"thscode": "000001.SZ", "name": "平安银行"}], None)
+    assert df.iloc[0]["symbol"] == "000001"
+    assert df.iloc[0]["list_status"] == "L"

--- a/tests/utils/test_data_sources_tickflow_client.py
+++ b/tests/utils/test_data_sources_tickflow_client.py
@@ -104,3 +104,21 @@ def test_detect_tier_paid_when_ex_factors_ok():
 def test_detect_tier_none_without_key(monkeypatch):
     monkeypatch.delenv("TICKFLOW_API_KEY", raising=False)
     assert TickflowClient(api_key="").detect_tier() == "none"
+
+
+def test_instruments_returns_list():
+    client = TickflowClient(api_key="tk-test")
+    client._session = FakeSession([
+        FakeResponse(payload={"code": 0, "message": "ok", "data": {
+            "exchange": "SH", "count": 2,
+            "data": [
+                {"symbol": "600000.SH", "name": "浦发银行", "ext": {"listing_date": "1999-11-10"}},
+                {"symbol": "600519.SH", "name": "贵州茅台"},
+            ],
+        }}),
+    ])
+    rows = client.instruments(exchange="SH")
+    call = client._session.calls[0]
+    assert "/v1/exchanges/SH/instruments" in call["url"]
+    assert call["headers"]["x-api-key"] == "tk-test"
+    assert [r["symbol"] for r in rows] == ["600000.SH", "600519.SH"]

--- a/tests/utils/test_data_sources_tickflow_client.py
+++ b/tests/utils/test_data_sources_tickflow_client.py
@@ -1,0 +1,106 @@
+"""TickFlow 轻量客户端合约测试：认证头、权限错误、档位探测。"""
+
+import pytest
+
+from app.utils.data_sources.tickflow_client import TickflowClient, TickflowError
+
+
+class FakeResponse:
+    def __init__(self, payload=None, status_code=200, text=""):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("not json")
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self, responses=None):
+        self.responses = list(responses or [])
+        self.calls = []
+
+    def get(self, url, headers=None, params=None, timeout=None, **kwargs):
+        self.calls.append({"url": url, "headers": headers or {}, "params": params or {}})
+        if self.responses:
+            return self.responses.pop(0)
+        return FakeResponse(payload={"data": {}})
+
+
+def _ok(payload):
+    return FakeResponse(payload={"data": payload})
+
+
+def test_missing_key_raises_no_key(monkeypatch):
+    monkeypatch.delenv("TICKFLOW_API_KEY", raising=False)
+    client = TickflowClient(api_key="")
+    with pytest.raises(TickflowError) as exc:
+        client.klines("600000.SH")
+    assert "TICKFLOW_API_KEY" in str(exc.value)
+
+
+def test_klines_uses_x_api_key_header_and_drops_none():
+    client = TickflowClient(api_key="tk-test")
+    client._session = FakeSession([_ok({"close": [9.2]})])
+    data = client.klines("600000.SH", count=1)
+    assert data == {"close": [9.2]}
+    call = client._session.calls[0]
+    assert call["headers"] == {"x-api-key": "tk-test"}
+    assert call["params"] == {"symbol": "600000.SH", "period": "1d", "count": 1, "adjust": "none"}
+
+
+def test_permission_denied_error_flagged():
+    client = TickflowClient(api_key="tk-test")
+    client._session = FakeSession([
+        FakeResponse(payload={"code": "NO_KLINE_PERMISSION", "message": "无分钟K线查询权限"},
+                     status_code=403),
+    ])
+    with pytest.raises(TickflowError) as exc:
+        client.klines("600000.SH", period="1m")
+    assert exc.value.is_permission_denied
+
+
+def test_quotes_accepts_list_payload():
+    client = TickflowClient(api_key="tk-test")
+    client._session = FakeSession([_ok([{"symbol": "600000.SH", "last_price": 9.28}])])
+    assert client.quotes(["600000.SH"])[0]["last_price"] == 9.28
+
+
+def test_quotes_accepts_wrapped_payload():
+    client = TickflowClient(api_key="tk-test")
+    client._session = FakeSession([_ok({"quotes": [{"symbol": "600000.SH"}]})])
+    assert client.quotes(["600000.SH"]) == [{"symbol": "600000.SH"}]
+
+
+def test_detect_tier_none_when_klines_denied():
+    client = TickflowClient(api_key="tk-bad")
+    client._session = FakeSession([
+        FakeResponse(payload={"code": "NO_KLINE_PERMISSION", "message": "denied"}, status_code=403),
+    ])
+    assert client.detect_tier() == "none"
+
+
+def test_detect_tier_free_when_ex_factors_denied():
+    client = TickflowClient(api_key="tk-free")
+    client._session = FakeSession([
+        _ok({"close": [9.2]}),
+        FakeResponse(payload={"code": "NO_EX_FACTORS_PERMISSION", "message": "denied"},
+                     status_code=403),
+    ])
+    assert client.detect_tier() == "free"
+
+
+def test_detect_tier_paid_when_ex_factors_ok():
+    client = TickflowClient(api_key="tk-paid")
+    client._session = FakeSession([
+        _ok({"close": [9.2]}),
+        _ok({"600000.SH": [{"ex_factor": 1.0, "timestamp": 1}]}),
+    ])
+    assert client.detect_tier() == "paid"
+
+
+def test_detect_tier_none_without_key(monkeypatch):
+    monkeypatch.delenv("TICKFLOW_API_KEY", raising=False)
+    assert TickflowClient(api_key="").detect_tier() == "none"


### PR DESCRIPTION
## 概述

按设计方案（f903d148）完成两期开发：**扶摇/TickFlow 数据源整合**（独立于 tushare，互不污染）与**市场类前端页面焕新**，共 5 个提交、548+ 新测试断言全部通过。

## 后端：数据源整合（0a9e19ee）

- **FuyaoClient**（扶摇·同花顺官方 API）：实时快照/历史K线/财务三表/估值/交易日历/龙虎榜/竞价风向标/dump 下载，统一节流 + 信封解包；北京时区零点 ms 解析、字段双命名兼容
- **TickflowClient**：free 档日K/实时行情/标的维表，`detect_tier` 判档；定位为校验与名称兜底源，不做批量任务
- **数据任务**：`daily_history_fuyao`（10d dump→10年 dump→单标的兜底三级策略，tushare 同 schema 落 parquet）、`financial_fuyao`（披露日历推报告期）、`stock_basic_fuyao`，注册进数据任务中心
- **单元换算**：股→手、元→千元、pre_close 推导等全部对拍验证过

## 后端：市场服务与 API（本分支后续提交）

- `MarketSnapshotService`：看板/快照/龙虎榜/风向标聚合，TTL 缓存 + 扶摇异常降级本地 parquet（标 degraded）
- `StockNameRegistry`：stock_basic + TickFlow 维表合并名称兜底（parquet 缓存 7 天），解决快照无名称问题
- `BoardMarketService`：涨停/跌停/炸板三池（通用获取器，历史日永久缓存）、连板天梯、同花顺行业/概念板块排行与成分股、热股榜/飙升榜、标的检索；全部带 TTL 缓存 + 1 小时过期回供
- `/api/market` 新增 13 个端点（dashboard/indices/dragon-tiger/limit-up·down·break/boards/hot-stocks/ticker-search 等）+ `/api/datasources/status` 三源健康探测

## 前端：新设计体系 + 7 个市场页面（b10da6c7 → 38eae0a8）

- Tailwind token 体系（暗色优先、A 股红涨绿跌、等宽数字）与旧 Bootstrap 共存，不污染旧页面
- 新页面：**市场看板**（指数 ticker/宽度/分布/三榜单）、**自选行情**（5s 刷新、名称搜索添加）、**龙虎榜**（三榜 tab + 竞价风向标）、**连板天梯**（六格 KPI 含炸板率 + 15 日天梯热力矩阵 + 三池 tab）、**热股榜单**（热股/飙升双榜）、**概念分析 / 行业分析**（390/320 板块排行 + 成分股联动）、**数据源中心**
- 全部个股可点击跳转既有 `/stock/:tsCode` 详情页

## 测试与验证

- 新增 100+ 契约测试（client/service/API 三层）；全量回归 551 通过，仅剩 master 既有 5 个失败（factor_ic_ir/portfolio/deployment 基线内），零新增回归
- `npm run build` 通过；浏览器逐页实测：真实数据渲染、tab 切换、搜索联想添加自选、个股跳详情、降级提示均验证通过

## 风险与说明

- `.env` 已含 FUYAO/TICKFLOW key（不入库，仅本地）；dump 缓存与名称缓存写入 `data/cache/`（gitignore 内）
- TickFlow 为免费档（约 5rpm），仅用于名称维表（7 天缓存）与档位探测，无批量调用